### PR TITLE
Migrate CI to Swift Package Manager CLI commands

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -29,26 +29,13 @@ jobs:
       uses: ./.github/actions/prepare_env_app_build    
 
     - name: Resolve Dependencies
-      run: >
-        xcodebuild -resolvePackageDependencies
-        -scheme ${{ env.SCHEME }}
-        -destination '${{ env.DESTINATION }}'
-        -quiet
+      run: swift package resolve
 
     - name: Build
-      run: >
-        xcodebuild build-for-testing
-        -scheme ${{ env.SCHEME }}
-        -destination '${{ env.DESTINATION }}'
-        -quiet
+      run: swift build
 
     - name: Test
-      run: >
-        xcodebuild test-without-building
-        -scheme ${{ env.SCHEME }}
-        -destination '${{ env.DESTINATION }}'
-        -resultBundlePath ${{ env.SCHEME }}
-        -quiet
+      run: swift test
 
     - name: Report
       uses: kishikawakatsumi/xcresulttool@v1


### PR DESCRIPTION
## Summary

Replace xcodebuild commands with Swift Package Manager CLI commands for simpler and more standard workflow.

## Key Changes

- Use `swift package resolve` instead of `xcodebuild -resolvePackageDependencies`
- Use `swift build` instead of `xcodebuild build-for-testing`
- Use `swift test` instead of `xcodebuild test-without-building`

## Additional Changes

None

---

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)