### PR TITLE
Remove xcresulttool from CI workflow

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -42,10 +42,3 @@ jobs:
 
     - name: Test
       run: swift test
-
-    - name: Report
-      uses: kishikawakatsumi/xcresulttool@v1
-      continue-on-error: true
-      with:
-        path: ${{ env.SCHEME }}.xcresult
-      if: success() || failure()


### PR DESCRIPTION
## Summary

Remove kishikawakatsumi/xcresulttool@v1 action from CI workflow.

## Key Changes

- Removed the Report step that used xcresulttool action

## Additional Changes

None

---

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)