### PR TITLE
Remove unused environment variables from CI workflow

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -12,10 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  SCHEME: "DBXCResultParser-Package"
-  DESTINATION: "platform=OS X"
-
 jobs:
   tests:
 


### PR DESCRIPTION
## Summary

Remove unused SCHEME and DESTINATION environment variables from unittest workflow.

## Key Changes

- Removed `env` section with `SCHEME` and `DESTINATION` variables
- These were only used with xcodebuild commands, no longer needed with Swift CLI

## Additional Changes

None

---

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)