### PR TITLE
Enable all warnings as errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,7 +74,8 @@ let package = Package(
                 ),
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error),
             ]
         ),
         .target(
@@ -83,7 +84,8 @@ let package = Package(
                 .init(stringLiteral: parserTargetName)
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error),
             ]
         ),
         .executableTarget(
@@ -97,7 +99,8 @@ let package = Package(
                 ),
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error),
             ]
         ),
         .target(
@@ -106,7 +109,8 @@ let package = Package(
                 .init(stringLiteral: parserTargetName)
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error),
             ]
         ),
         .testTarget(
@@ -119,7 +123,8 @@ let package = Package(
                 .copy("Resources/DBXCResultParser.xcresult")
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error),
             ]
         ),
         .testTarget(
@@ -129,7 +134,8 @@ let package = Package(
                 .init(stringLiteral: testHelpersTargetName),
             ],
             swiftSettings: [
-                .swiftLanguageMode(.v6)
+                .swiftLanguageMode(.v6),
+                .treatAllWarnings(as: .error),
             ]
         ),
     ]

--- a/Sources/DBXCResultParser-TextFormatterExec/DBXCTextFormatterExecutable.swift
+++ b/Sources/DBXCResultParser-TextFormatterExec/DBXCTextFormatterExecutable.swift
@@ -116,7 +116,7 @@ extension NumberFormatter {
     }
 }
 
-extension Locale: ExpressibleByArgument {
+extension Locale: @retroactive ExpressibleByArgument {
     public init?(argument: String) {
         self.init(identifier: argument)
     }


### PR DESCRIPTION
## Summary

Enable all Swift compiler warnings as errors to enforce stricter code quality standards and catch potential issues at compile time.

Fixes #60

## Key Changes

- Added `.treatAllWarnings(as: .error)` to all targets in `Package.swift` via `swiftSettings` using Swift 6.2 API
- Added `@retroactive` attribute to `Locale` extension to fix warning about conformance

## Additional Changes

None