### PR TITLE
Merge DBXCResultParser and TextFormatter into single target

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -44,4 +44,4 @@ jobs:
 
     # Verify CLI tool functionality by parsing test xcresult file
     - name: Parse xcresult
-      run: swift run DBXCResultParser-TextFormatterExec --xcresult-path Tests/DBXCResultParserTests/Resources/DBXCResultParser-26.1.1.xcresult
+      run: swift run DBXCResultParserExec --xcresult-path Tests/DBXCResultParserTests/Resources/DBXCResultParser-26.1.1.xcresult

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ swift test --filter <TestClassName>.<testMethodName>
 
 ### Running the Command-Line Tool
 ```bash
-swift run DBXCResultParser-TextFormatterExec --xcresult-path path/to/tests.xcresult
+swift run DBXCResultParserExec --xcresult-path path/to/tests.xcresult
 ```
 
 Options:
@@ -51,7 +51,7 @@ Options:
 - `CoverageDTO`: Code coverage data from `xccov`
 - DTOs are initialized by executing `xcresulttool` commands via `DBShell` and parsing JSON output
 
-**DBXCTextFormatter** (`Sources/DBXCResultParser-TextFormatter/DBXCTextFormatter.swift`)
+**DBXCTextFormatter** (`Sources/DBXCResultParser/DBXCTextFormatter.swift`)
 - Formats `DBXCReportModel` into human-readable text
 - Two output formats:
   - `list`: Detailed test results with file names and statuses
@@ -61,9 +61,8 @@ Options:
 ### Package Structure
 
 The package exports:
-- **DBXCResultParser**: Core parsing library
-- **DBXCResultParser-TextFormatter**: Text formatting utilities
-- **DBXCResultParser-TextFormatterExec**: Executable command-line tool
+- **DBXCResultParser**: Core parsing library (includes parsing and formatting)
+- **DBXCResultParserExec**: Executable command-line tool
 - **DBXCResultParserTestHelpers**: Test helper utilities
 
 ## Testing

--- a/Package.swift
+++ b/Package.swift
@@ -6,17 +6,14 @@ import PackageDescription
 let packageName = "DBXCResultParser"
 
 let parserLibraryName = packageName
-let formatterLibraryName = parserLibraryName + "-TextFormatter"
-let executableFormatterLibraryName = formatterLibraryName + "Exec"
+let executableLibraryName = parserLibraryName + "Exec"
 let testHelpersLibraryName = parserLibraryName + "TestHelpers"
 
 let parserTargetName = parserLibraryName
-let formatterTargetName = formatterLibraryName
-let executableFormatterTargetName = formatterTargetName + "Exec"
+let executableTargetName = executableLibraryName
 let testHelpersTargetName = testHelpersLibraryName
 
 let parserTestsTargetName = parserTargetName + "Tests"
-let formatterTestsTargetName = formatterTargetName + "Tests"
 
 let package = Package(
     name: packageName,
@@ -31,22 +28,15 @@ let package = Package(
             ]
         ),
         .library(
-            name: formatterLibraryName,
-            targets: [
-                parserTargetName,
-                formatterTargetName,
-            ]
-        ),
-        .library(
             name: testHelpersLibraryName,
             targets: [
-                testHelpersLibraryName
+                testHelpersTargetName
             ]
         ),
         .executable(
-            name: executableFormatterLibraryName,
+            name: executableLibraryName,
             targets: [
-                executableFormatterTargetName
+                executableTargetName
             ]
         ),
     ],
@@ -82,21 +72,10 @@ let package = Package(
                 .treatAllWarnings(as: .error),
             ]
         ),
-        .target(
-            name: formatterTargetName,
-            dependencies: [
-                .init(stringLiteral: parserTargetName)
-            ],
-            swiftSettings: [
-                .swiftLanguageMode(.v6),
-                .treatAllWarnings(as: .error),
-            ]
-        ),
         .executableTarget(
-            name: executableFormatterTargetName,
+            name: executableTargetName,
             dependencies: [
                 .init(stringLiteral: parserTargetName),
-                .init(stringLiteral: formatterTargetName),
                 .product(
                     name: "ArgumentParser",
                     package: "swift-argument-parser"
@@ -121,7 +100,6 @@ let package = Package(
             name: parserTestsTargetName,
             dependencies: [
                 .init(stringLiteral: parserTargetName),
-                .init(stringLiteral: formatterTargetName),
                 .init(stringLiteral: testHelpersTargetName),
                 .product(
                     name: "SnapshotTesting",
@@ -133,17 +111,6 @@ let package = Package(
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
-            ]
-        ),
-        .testTarget(
-            name: formatterTestsTargetName,
-            dependencies: [
-                .init(stringLiteral: formatterTargetName),
-                .init(stringLiteral: testHelpersTargetName),
-            ],
-            swiftSettings: [
-                .swiftLanguageMode(.v6),
-                .treatAllWarnings(as: .error),
             ]
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -212,29 +212,29 @@ print(output) // Will output numbers and durations formatted in French
 The package includes a command-line tool that can be executed to generate test reports. Here is an example of how to run it:
 
 ```bash
-swift run DBXCResultParser-TextFormatterExec --xcresult-path path/to/tests.xcresult
+swift run DBXCResultParserExec --xcresult-path path/to/tests.xcresult
 ```
 
 **Examples:**
 
 ```bash
 # Default: list format with all test statuses
-swift run DBXCResultParser-TextFormatterExec --xcresult-path path/to/tests.xcresult
+swift run DBXCResultParserExec --xcresult-path path/to/tests.xcresult
 
 # Count format (summary)
-swift run DBXCResultParser-TextFormatterExec --xcresult-path path/to/tests.xcresult --format count
+swift run DBXCResultParserExec --xcresult-path path/to/tests.xcresult --format count
 
 # Show only failures
-swift run DBXCResultParser-TextFormatterExec --xcresult-path path/to/tests.xcresult --include failure
+swift run DBXCResultParserExec --xcresult-path path/to/tests.xcresult --include failure
 
 # Show failures and skipped tests
-swift run DBXCResultParser-TextFormatterExec --xcresult-path path/to/tests.xcresult --include failure,skipped
+swift run DBXCResultParserExec --xcresult-path path/to/tests.xcresult --include failure,skipped
 
 # Use specific locale for formatting
-swift run DBXCResultParser-TextFormatterExec --xcresult-path path/to/tests.xcresult --locale ru-RU
+swift run DBXCResultParserExec --xcresult-path path/to/tests.xcresult --locale ru-RU
 
 # Combine options: count format with only failures, using French locale
-swift run DBXCResultParser-TextFormatterExec --xcresult-path path/to/tests.xcresult --format count --include failure --locale fr-FR
+swift run DBXCResultParserExec --xcresult-path path/to/tests.xcresult --format count --include failure --locale fr-FR
 ```
 
 **Available options:**

--- a/Sources/DBXCResultParser/DBXCTextFormatter.swift
+++ b/Sources/DBXCResultParser/DBXCTextFormatter.swift
@@ -1,4 +1,3 @@
-import DBXCResultParser
 import Foundation
 
 extension DBXCTextFormatter {

--- a/Sources/DBXCResultParserExec/DBXCTextFormatterExecutable.swift
+++ b/Sources/DBXCResultParserExec/DBXCTextFormatterExecutable.swift
@@ -1,6 +1,5 @@
 import ArgumentParser
 import DBXCResultParser
-import DBXCResultParser_TextFormatter
 import Foundation
 
 @main

--- a/Tests/DBXCResultParserTests/DBXCTextFormatterSnapshotTests.swift
+++ b/Tests/DBXCResultParserTests/DBXCTextFormatterSnapshotTests.swift
@@ -1,4 +1,3 @@
-import DBXCResultParser_TextFormatter
 import Foundation
 import SnapshotTesting
 import Testing

--- a/Tests/DBXCResultParserTests/DBXCTextFormatterTests.swift
+++ b/Tests/DBXCResultParserTests/DBXCTextFormatterTests.swift
@@ -1,5 +1,4 @@
 import DBXCResultParserTestHelpers
-import DBXCResultParser_TextFormatter
 import Foundation
 import Testing
 


### PR DESCRIPTION
## Summary
Merge DBXCResultParser and DBXCResultParser-TextFormatter into a single target and library. Rename executable to DBXCResultParserExec.

## Key Changes
- Moved DBXCTextFormatter.swift to DBXCResultParser target
- Removed DBXCResultParser-TextFormatter target and library
- Renamed DBXCResultParser-TextFormatterExec to DBXCResultParserExec
- Updated all imports to use only DBXCResultParser
- Merged formatter tests into DBXCResultParserTests
- Updated documentation and CI workflow

## Additional Changes
- Updated AGENTS.md and README.md with new executable name
- Updated CI workflow to use new executable name