### PR TITLE
Fix flaky tests for Xcode 15.0 xcresult files

### DIFF
--- a/Tests/DBXCResultParserTests/Constants+Helpers.swift
+++ b/Tests/DBXCResultParserTests/Constants+Helpers.swift
@@ -50,6 +50,51 @@ struct Constants {
         ((try? testsReportPaths) ?? []).map { $0.lastPathComponent }
     }
 
+    /// Copies xcresult bundle to a temporary directory to avoid SQLite access conflicts
+    /// when multiple tests access the same xcresult file concurrently.
+    ///
+    /// Problem: xcresult bundles contain SQLite databases internally. When multiple tests
+    /// run in parallel and access the same xcresult file via `xcrun xcresulttool` and
+    /// `xcrun xccov`, they all read from the same SQLite database, which causes errors like:
+    ///
+    /// ```
+    /// processFailed(exitCode: exited(64), error: "Error: "database.sqlite3" couldn't be moved
+    /// to "DBXCResultParser-15.0.xcresult" because an item with the same name already exists.")
+    /// ```
+    ///
+    /// Note: This issue appears to be specific to Xcode 15.0 xcresult files. The exact reason
+    /// is unknown, but it's likely related to how SQLite database files are structured or
+    /// accessed in Xcode 15.0's xcresult format. Newer versions (e.g., 26.1.1) don't exhibit
+    /// this behavior, but we apply the fix to all xcresult files for consistency and safety.
+    ///
+    /// This happens because SQLite tries to move/access database files concurrently, leading to:
+    /// - Database file access conflicts
+    /// - Race conditions
+    /// - Flaky test failures in CI environments
+    ///
+    /// Solution: Each test gets its own copy of the xcresult bundle in a temporary directory,
+    /// ensuring complete isolation and preventing concurrent SQLite access conflicts.
+    ///
+    /// - Parameter xcresultPath: The original xcresult bundle path
+    /// - Returns: URL to the temporary copy
+    /// - Throws: An error if copying fails
+    static func copyXcresultToTemporaryDirectory(_ xcresultPath: URL) throws -> URL {
+        let fileManager = FileManager.default
+        let tempDir = fileManager.temporaryDirectory
+        let uniqueName = UUID().uuidString + ".xcresult"
+        let tempXcresultPath = tempDir.appendingPathComponent(uniqueName)
+
+        // Remove destination if it exists (shouldn't happen with UUID, but just in case)
+        if fileManager.fileExists(atPath: tempXcresultPath.path) {
+            try fileManager.removeItem(at: tempXcresultPath)
+        }
+
+        // Copy the entire bundle (directory) recursively
+        try fileManager.copyItem(at: xcresultPath, to: tempXcresultPath)
+
+        return tempXcresultPath
+    }
+
     /// Returns URL for a given xcresult file name
     static func url(for fileName: String) throws -> URL {
         let paths = try testsReportPaths

--- a/Tests/DBXCResultParserTests/DBXCReportModelValuesTests.swift
+++ b/Tests/DBXCResultParserTests/DBXCReportModelValuesTests.swift
@@ -7,7 +7,11 @@ import Testing
 struct DBXCReportModelValuesTests {
     @Test(arguments: Constants.testsReportFileNames)
     func test_coverageValues(fileName: String) async throws {
-        let reportPath = try Constants.url(for: fileName)
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+        }
         let report = try await DBXCReportModel(xcresultPath: reportPath)
         let expected = try Constants.expectedReportValues(for: fileName)
 
@@ -41,7 +45,11 @@ struct DBXCReportModelValuesTests {
 
     @Test(arguments: Constants.testsReportFileNames)
     func test_warningsValues(fileName: String) async throws {
-        let reportPath = try Constants.url(for: fileName)
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+        }
         let report = try await DBXCReportModel(xcresultPath: reportPath)
         let expected = try Constants.expectedWarningsValues(for: fileName)
 

--- a/Tests/DBXCResultParserTests/DBXCTextFormatterSnapshotTests.swift
+++ b/Tests/DBXCResultParserTests/DBXCTextFormatterSnapshotTests.swift
@@ -11,7 +11,11 @@ struct DBXCTextFormatterSnapshotTests {
 
     @Test(arguments: Constants.testsReportFileNames)
     func test_listFormat_allStatuses(fileName: String) async throws {
-        let reportPath = try Constants.url(for: fileName)
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+        }
         let report = try await DBXCReportModel(xcresultPath: reportPath)
         let formatted = formatter.format(report, format: .list, locale: locale)
 
@@ -24,7 +28,11 @@ struct DBXCTextFormatterSnapshotTests {
 
     @Test(arguments: Constants.testsReportFileNames)
     func test_listFormat_successOnly(fileName: String) async throws {
-        let reportPath = try Constants.url(for: fileName)
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+        }
         let report = try await DBXCReportModel(xcresultPath: reportPath)
         let formatted = formatter.format(
             report,
@@ -42,7 +50,11 @@ struct DBXCTextFormatterSnapshotTests {
 
     @Test(arguments: Constants.testsReportFileNames)
     func test_listFormat_failureOnly(fileName: String) async throws {
-        let reportPath = try Constants.url(for: fileName)
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+        }
         let report = try await DBXCReportModel(xcresultPath: reportPath)
         let formatted = formatter.format(
             report,
@@ -60,7 +72,11 @@ struct DBXCTextFormatterSnapshotTests {
 
     @Test(arguments: Constants.testsReportFileNames)
     func test_listFormat_skippedOnly(fileName: String) async throws {
-        let reportPath = try Constants.url(for: fileName)
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+        }
         let report = try await DBXCReportModel(xcresultPath: reportPath)
         let formatted = formatter.format(
             report,
@@ -78,7 +94,11 @@ struct DBXCTextFormatterSnapshotTests {
 
     @Test(arguments: Constants.testsReportFileNames)
     func test_countFormat_allStatuses(fileName: String) async throws {
-        let reportPath = try Constants.url(for: fileName)
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+        }
         let report = try await DBXCReportModel(xcresultPath: reportPath)
         let formatted = formatter.format(report, format: .count, locale: locale)
 
@@ -91,7 +111,11 @@ struct DBXCTextFormatterSnapshotTests {
 
     @Test(arguments: Constants.testsReportFileNames)
     func test_countFormat_failureOnly(fileName: String) async throws {
-        let reportPath = try Constants.url(for: fileName)
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+        }
         let report = try await DBXCReportModel(xcresultPath: reportPath)
         let formatted = formatter.format(
             report,


### PR DESCRIPTION
## Summary

Fixes flaky tests for Xcode 15.0 xcresult files by copying xcresult bundles to temporary directories in tests. This prevents SQLite access conflicts when multiple tests run in parallel and access the same xcresult file concurrently.

## Key Changes

- Added `copyXcresultToTemporaryDirectory` helper function in `Constants+Helpers.swift` that copies xcresult bundles to temporary directories with unique names
- Updated all parameterized tests in `DBXCTextFormatterSnapshotTests` and `DBXCReportModelValuesTests` to use temporary copies of xcresult files
- Each test now gets its own isolated copy, preventing concurrent SQLite database access conflicts
- Added comprehensive documentation explaining the problem and solution

## Additional Changes

- The fix is applied to all xcresult files for consistency and safety, even though the issue is specific to Xcode 15.0 xcresult files
- Temporary copies are automatically cleaned up using `defer` blocks in each test

Fixes #87