### PR TITLE
Exclude __Snapshots__ directory from test target in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -106,6 +106,9 @@ let package = Package(
                     package: "swift-snapshot-testing"
                 ),
             ],
+            exclude: [
+                "__Snapshots__"
+            ],
             resources: [
                 .copy("Resources")
             ],


### PR DESCRIPTION
## Summary

Excludes `__Snapshots__` directory from the test target in Package.swift to eliminate SPM warnings about unhandled snapshot test files.

## Key Changes

- Added `exclude: ["__Snapshots__"]` to the test target configuration
- This tells SPM to ignore snapshot files, eliminating the 12 warnings about unhandled files
- Snapshot files are generated automatically by snapshot testing framework and don't need to be included as resources

## Additional Changes

- No additional changes required

Fixes #95