### PR TITLE
Add --skip-build flag to swift test command in CI workflow

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -40,7 +40,7 @@ jobs:
       run: swift build --build-tests
 
     - name: Test
-      run: swift test
+      run: swift test --skip-build
 
     # Verify CLI tool functionality by parsing test xcresult file
     - name: Parse xcresult


### PR DESCRIPTION
## Summary

Adds `--skip-build` flag to the `swift test` command in the CI workflow to avoid rebuilding the project since the build step already runs before tests.

## Key Changes

- Added `--skip-build` flag to `swift test` command in `.github/workflows/unittest.yml`
- This skips rebuilding the project during test execution, reducing CI execution time

## Additional Changes

- No additional changes required

Fixes #97