### PR TITLE
Replace --xcresult-path option with positional argument

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -50,10 +50,10 @@ jobs:
 
     # Verify CLI tool functionality by parsing test xcresult file
     - name: Parse xcresult (text format)
-      run: swift run peekie text --xcresult-path Tests/PeekieTests/Resources/SPM-26.1.1-iOS.xcresult
+      run: swift run peekie text Tests/PeekieTests/Resources/SPM-26.1.1-iOS.xcresult
 
     - name: Parse xcresult (sonar format)
-      run: swift run peekie sonar --xcresult-path Tests/PeekieTests/Resources/SPM-26.1.1-iOS.xcresult --tests-path swift-tests-example/SPM/Tests/ExamplesTests
+      run: swift run peekie sonar Tests/PeekieTests/Resources/SPM-26.1.1-iOS.xcresult --tests-path swift-tests-example/SPM/Tests/ExamplesTests
 
     - name: Install mise
       uses: jdx/mise-action@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,11 +44,11 @@ periphery scan
 
 ### Running the Command-Line Tool
 ```bash
-swift run peekie --xcresult-path path/to/tests.xcresult
+swift run peekie text path/to/tests.xcresult
 ```
 
 Options:
-- `--xcresult-path`: Path to the `.xcresult` file
+- `<xcresult-path>`: Path to the `.xcresult` file (positional argument)
 - `--format`: Output format (`list` or `count`)
 - `--locale`: Locale for number formatting (e.g., "en-GB")
 - `--include`: Filter test results by status (e.g., `failure,skipped`)

--- a/README.md
+++ b/README.md
@@ -286,33 +286,33 @@ The package includes a command-line tool that can be executed to generate test r
 #### Text Format Subcommand
 
 ```bash
-swift run peekie text --xcresult-path path/to/tests.xcresult
+swift run peekie text path/to/tests.xcresult
 ```
 
 **Examples:**
 
 ```bash
 # Default: list format with all test statuses
-swift run peekie text --xcresult-path path/to/tests.xcresult
+swift run peekie text path/to/tests.xcresult
 
 # Count format (summary)
-swift run peekie text --xcresult-path path/to/tests.xcresult --format count
+swift run peekie text path/to/tests.xcresult --format count
 
 # Show only failures
-swift run peekie text --xcresult-path path/to/tests.xcresult --include failure
+swift run peekie text path/to/tests.xcresult --include failure
 
 # Show failures and skipped tests
-swift run peekie text --xcresult-path path/to/tests.xcresult --include failure,skipped
+swift run peekie text path/to/tests.xcresult --include failure,skipped
 
 # Use specific locale for formatting
-swift run peekie text --xcresult-path path/to/tests.xcresult --locale ru-RU
+swift run peekie text path/to/tests.xcresult --locale ru-RU
 
 # Combine options: count format with only failures, using French locale
-swift run peekie text --xcresult-path path/to/tests.xcresult --format count --include failure --locale fr-FR
+swift run peekie text path/to/tests.xcresult --format count --include failure --locale fr-FR
 ```
 
 **Available options for `text` subcommand:**
-- `--xcresult-path`: Specifies the path to the `.xcresult` file (required).
+- `<xcresult-path>`: Path to the `.xcresult` file (required, positional argument).
 - `--format`: Determines the output format (`list` or `count`). Default: `list`.
 - `--locale`: Sets the locale for number and measurement formatting (e.g., "en-GB", "ru-RU", "fr-FR"). Default: system locale.
 - `--include`: Filters the test results to include only certain statuses. Comma-separated list of: `success`, `failure`, `skipped`, `expectedFailure`, `mixed`, `unknown`. Default: all statuses.
@@ -320,7 +320,7 @@ swift run peekie text --xcresult-path path/to/tests.xcresult --format count --in
 #### SonarQube Format Subcommand
 
 ```bash
-swift run peekie sonar --xcresult-path path/to/tests.xcresult --tests-path path/to/tests
+swift run peekie sonar path/to/tests.xcresult --tests-path path/to/tests
 ```
 
 **Examples:**
@@ -328,14 +328,14 @@ swift run peekie sonar --xcresult-path path/to/tests.xcresult --tests-path path/
 ```bash
 # Generate SonarQube XML report
 # Note: --tests-path must point to a directory containing test source files, not the .xcresult file
-swift run peekie sonar --xcresult-path path/to/tests.xcresult --tests-path path/to/tests
+swift run peekie sonar path/to/tests.xcresult --tests-path path/to/tests
 
 # Save output to file
-swift run peekie sonar --xcresult-path path/to/tests.xcresult --tests-path Tests/PeekieTests > sonar-report.xml
+swift run peekie sonar path/to/tests.xcresult --tests-path Tests/PeekieTests > sonar-report.xml
 ```
 
 **Available options for `sonar` subcommand:**
-- `--xcresult-path`: Specifies the path to the `.xcresult` file (required).
+- `<xcresult-path>`: Path to the `.xcresult` file (required, positional argument).
 - `--tests-path`: Specifies the path to the directory containing test source files (required). This must be a directory path (not a `.xcresult` file) containing your test source code (`.swift` files). This is used to map test suite names to file paths.
 
 ## Updating Test Resources

--- a/Sources/Peekie/Sonar.swift
+++ b/Sources/Peekie/Sonar.swift
@@ -10,7 +10,7 @@ public struct Sonar: AsyncParsableCommand {
 
     public init() {}
 
-    @Option(help: "Path to .xcresult")
+    @Argument(help: "Path to .xcresult")
     public var xcresultPath: String
 
     @Option(help: "Path to folder with tests")

--- a/Sources/Peekie/Text.swift
+++ b/Sources/Peekie/Text.swift
@@ -10,7 +10,7 @@ public struct Text: AsyncParsableCommand {
 
     public init() {}
 
-    @Option(help: "Path to .xcresult")
+    @Argument(help: "Path to .xcresult")
     public var xcresultPath: String
 
     @Option(help: "Result format")


### PR DESCRIPTION
## Summary

This PR replaces the `--xcresult-path` option with a positional argument for the xcresult file path in both `text` and `sonar` commands. This simplifies the command-line interface by allowing users to pass the path directly without a flag.

## Key Changes

- Changed `@Option` to `@Argument` for `xcresultPath` in `Text.swift` and `Sonar.swift` commands
- Updated all documentation (README.md, AGENTS.md) with new command syntax examples
- Updated GitHub workflow to use the new positional argument syntax

## Additional Changes

- Updated command examples throughout the documentation to reflect the new syntax: `peekie text path/to/file.xcresult` instead of `peekie text --xcresult-path path/to/file.xcresult`

Closes #111