### PR TITLE
Improve repository metadata and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Peekie
 
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdodobrands%2FDBXCResultParser%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/dodobrands/DBXCResultParser)
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdodobrands%2FDBXCResultParser%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/dodobrands/DBXCResultParser)
-[![](https://github.com/dodobrands/DBXCResultParser/actions/workflows/unittest.yml/badge.svg)](https://github.com/dodobrands/DBXCResultParser/actions/workflows/unittest.yml)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdodobrands%2FPeekie%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/dodobrands/Peekie)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdodobrands%2FPeekie%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/dodobrands/Peekie)
+[![](https://github.com/dodobrands/Peekie/actions/workflows/unittest.yml/badge.svg)](https://github.com/dodobrands/Peekie/actions/workflows/unittest.yml)
 [![](https://img.shields.io/badge/XCTest-Supported-success)](https://developer.apple.com/documentation/xctest)
 [![](https://img.shields.io/badge/Swift%20Testing-Supported-success)](https://www.swift.org/documentation/package-manager/)
 


### PR DESCRIPTION
## Summary

Updates repository metadata visible on GitHub public page to better reflect the current state of the project after migration from DBXCResultParser to Peekie.

## Key Changes

- **Updated repository description**: Changed from brief "xcresult parser" to more descriptive "Swift package for parsing Xcode .xcresult files with support for XCTest and Swift Testing frameworks"
- **Added repository topics**: Added relevant tags for better discoverability:
  - swift, xcresult, xcode, testing, xctest, swift-testing
  - code-coverage, sonarqube, ci-cd, swift-package
- **Added homepage URL**: Set to Swift Package Index page
- **Fixed badges in README**: Updated all badge URLs from `DBXCResultParser` to `Peekie`:
  - Swift Package Index badges (swift-versions and platforms)
  - GitHub Actions workflow badge

## Additional Changes

- All changes are metadata-only and don't affect code functionality
- Improves repository discoverability and SEO on GitHub