### PR TITLE
Update remaining references from DBXCResultParser to generic examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ The package exports:
 
 ## Testing
 
-Test resources are stored in `Tests/PeekieTests/Resources/DBXCResultParser.xcresult` - this is a sample `.xcresult` file used for testing.
+Test resources are stored in `Tests/PeekieTests/Resources/` - sample `.xcresult` files used for testing (e.g., `SPM-26.1.1-iOS.xcresult`, `Xcworkspace-26.1.1-iOS.xcresult`).
 
 ## Code Style Guidelines
 

--- a/Sources/PeekieSDK/Models/Report+Convenience.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience.swift
@@ -95,7 +95,7 @@ extension Report {
                 if let coverageReportDTO = coverageReportDTO {
                     for target in coverageReportDTO.targets {
                         // Try to match target name with module name
-                        // Module name is like "DBXCResultParserTests", target might be "DBXCResultParser"
+                        // Module name is like "MyPackageTests", target might be "MyPackage"
                         let targetBaseName = target.name.replacingOccurrences(of: "Tests", with: "")
                         let moduleBaseName = moduleName.replacingOccurrences(of: "Tests", with: "")
 
@@ -468,7 +468,7 @@ extension Report {
                 }()
 
                 // Try to find existing module by target name or create a new one
-                // Target name might be like "DBXCResultParser", module might be "DBXCResultParserTests"
+                // Target name might be like "MyPackage", module might be "MyPackageTests"
                 var moduleName = target.name
                 var existingModule = modules[moduleName]
 


### PR DESCRIPTION
## Summary

Replace leftover DBXCResultParser references with generic examples to align with the project rename to Peekie.

## Key Changes

- Replace `DBXCResultParser`/`DBXCResultParserTests` examples in code comments with generic `MyPackage`/`MyPackageTests`
- Update `AGENTS.md` testing section to reflect actual test resource files structure (`SPM-26.1.1-iOS.xcresult`, `Xcworkspace-26.1.1-iOS.xcresult`)

## Additional Changes

None