### PR TITLE
Build and publish release binary in GitHub Releases

### DIFF
--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -27,17 +27,20 @@ jobs:
         xcode-version: ${{ steps.xcode-version.outputs.version }}
 
     - name: Build release binary
-      run: swift build -c release --product "$PRODUCT_NAME"
+      id: build
+      run: |
+        swift build -c release --product "$PRODUCT_NAME"
+        echo "bin-path=$(swift build -c release --product "$PRODUCT_NAME" --show-bin-path)" >> $GITHUB_OUTPUT
 
     - name: Package binary
+      id: package
       run: |
-        BINARY_PATH=$(swift build -c release --product "$PRODUCT_NAME" --show-bin-path)/$PRODUCT_NAME
         ARCHIVE_NAME="${PRODUCT_NAME}_${GITHUB_REF_NAME}_darwin_arm64.tar.gz"
-        tar -czf "${ARCHIVE_NAME}" -C "$(dirname "${BINARY_PATH}")" "$PRODUCT_NAME"
-        echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
+        tar -czf "${ARCHIVE_NAME}" -C "${{ steps.build.outputs.bin-path }}" "$PRODUCT_NAME"
+        echo "archive-name=${ARCHIVE_NAME}" >> $GITHUB_OUTPUT
 
     - name: Release
       uses: softprops/action-gh-release@v2
       with:
         generate_release_notes: true
-        files: ${{ env.ARCHIVE_NAME }}
+        files: ${{ steps.package.outputs.archive-name }}


### PR DESCRIPTION
## Summary

Update the release workflow to build a macOS arm64 binary and upload it as a `.tar.gz` archive asset to GitHub Releases. This enables distribution through package managers like Aqua.

## Key Changes

- Switch runner from `ubuntu-latest` to `macos-latest` (arm64)
- Build release binary with `swift build -c release --product peekie`
- Package binary into `peekie_{version}_darwin_arm64.tar.gz` and upload as a release asset
- Extract product name into a workflow-level `env.PRODUCT_NAME` variable
- Use `GITHUB_REF_NAME` for tag name and step outputs for passing data between steps

## Additional Changes

- Add Xcode version selection (consistent with `unittest.yml`)
- Increase timeout from 5 to 15 minutes to account for Swift compilation