### PR TITLE
docs: recommend mise installation for CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ The `PeekieSDK` package provides a Swift module for parsing `.xcresult` files ge
 
 ## Installation
 
+### Command-Line Tool (Recommended)
+
+The recommended way to install the `peekie` command-line tool is via [mise](https://mise.jdx.dev/getting-started.html):
+
+```bash
+mise use github:dodobrands/peekie
+```
+
+### Swift Package
+
 To use `PeekieSDK` in your Swift package, add it to the dependencies for your `Package.swift` file:
 
 ```swift


### PR DESCRIPTION
## Summary

Updated README to recommend mise as the primary installation method for the `peekie` command-line tool.

## Key Changes

- Added "Command-Line Tool (Recommended)" section with mise installation instructions
- Included link to mise getting started guide
- Reorganized installation section to separate CLI tool and Swift package installation

## Additional Changes

None