### PR TITLE
Fix Swift Testing badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fdodobrands%2FPeekie%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/dodobrands/Peekie)
 [![](https://github.com/dodobrands/Peekie/actions/workflows/unittest.yml/badge.svg)](https://github.com/dodobrands/Peekie/actions/workflows/unittest.yml)
 [![](https://img.shields.io/badge/XCTest-Supported-success)](https://developer.apple.com/documentation/xctest)
-[![](https://img.shields.io/badge/Swift%20Testing-Supported-success)](https://www.swift.org/documentation/package-manager/)
+[![](https://img.shields.io/badge/Swift%20Testing-Supported-success)](https://developer.apple.com/xcode/swift-testing/)
 
 <p align="center">
   <img width="128" height="128" alt="Peekie Logo" src="https://github.com/user-attachments/assets/df9d5117-ba56-465d-8607-96302e638f4e" />


### PR DESCRIPTION
## Summary

Fixed the Swift Testing badge link in README to point to the official Apple documentation.

## Key Changes

- Updated the Swift Testing badge URL from broken link to official Apple documentation

## Additional Changes

None