### PR TITLE
Drop TotalCoverageDTO; reuse CoverageReportDTO for total

### DIFF
--- a/Sources/PeekieSDK/Models/DTO/DTO+Helpers.swift
+++ b/Sources/PeekieSDK/Models/DTO/DTO+Helpers.swift
@@ -66,27 +66,6 @@ extension CoverageReportDTO {
     }
 }
 
-extension TotalCoverageDTO {
-    init(from xcresultPath: URL) async throws {
-        let output = try await Shell.execute(
-            "xcrun",
-            arguments: [
-                "xccov", "view", "--report", "--json",
-                xcresultPath.path,
-            ]
-        )
-        guard let data = output.data(using: .utf8) else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
-                    codingPath: [],
-                    debugDescription: "Failed to convert output to Data"
-                )
-            )
-        }
-        self = try JSONDecoder().decode(TotalCoverageDTO.self, from: data)
-    }
-}
-
 extension BuildResultsDTO {
     private static let logger = Logger(label: "com.peekie.dto")
 

--- a/Sources/PeekieSDK/Models/DTO/FileCoverageDTO.swift
+++ b/Sources/PeekieSDK/Models/DTO/FileCoverageDTO.swift
@@ -17,5 +17,6 @@ struct TargetCoverageDTO: Decodable {
 }
 
 struct CoverageReportDTO: Decodable {
+    var lineCoverage: Double
     var targets: [TargetCoverageDTO]
 }

--- a/Sources/PeekieSDK/Models/DTO/TotalCoverageDTO.swift
+++ b/Sources/PeekieSDK/Models/DTO/TotalCoverageDTO.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-struct TotalCoverageDTO: Decodable {
-    let lineCoverage: Double
-}

--- a/Sources/PeekieSDK/Models/Report+Convenience.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience.swift
@@ -62,10 +62,6 @@ extension Report {
             warningsByFileName = [:]
         }
 
-        // Try to get total coverage from xcresult file
-        let totalCoverageDTO: TotalCoverageDTO? =
-            includeCoverage ? try? await TotalCoverageDTO(from: xcresultPath) : nil
-
         var modules = Set<Module>()
 
         // Process test nodes: Test Plan -> Unit test bundle -> Test Suite -> Test Case -> Repetition
@@ -534,12 +530,8 @@ extension Report {
         let totalCoverage: Double? =
             includeCoverage
             ? {
-                if let totalCoverageDTO = totalCoverageDTO {
-                    let lineCoverage = totalCoverageDTO.lineCoverage
-                    // totalCoverageDTO is available; still allow fallback in case of zeroed data
-                    if lineCoverage > 0 {
-                        return lineCoverage
-                    }
+                if let lineCoverage = coverageReportDTO?.lineCoverage, lineCoverage > 0 {
+                    return lineCoverage
                 }
 
                 let fileCoverages = modules.flatMap { $0.files }.compactMap { $0.coverage }


### PR DESCRIPTION
## Summary

Resolves #166. Halves `xccov` work on every `Report.init(xcresultPath:)`: the second `xcrun xccov view --report --json` call that populated `TotalCoverageDTO` is gone — the top-level `lineCoverage` now comes from the already-loaded `CoverageReportDTO`. ~1–3s saved per large xcresult bundle, output of `Report.coverage` bit-identical.

## Key Changes

- `CoverageReportDTO` gains a top-level `lineCoverage` field (sibling of `targets`, present in the same JSON payload).
- `Report+Convenience.swift` reads `coverageReportDTO?.lineCoverage` instead of issuing a second `xccov` call. Existing `> 0` fallback-to-summed-files behavior preserved verbatim.
- `TotalCoverageDTO` and its `init(from:)` deleted — internal, no public surface affected.

## Additional Changes

_None._