### PR TITLE
Parse all known issueType values from xcresult build-results

### DIFF
--- a/Sources/PeekieSDK/Models/Report+Warnings.swift
+++ b/Sources/PeekieSDK/Models/Report+Warnings.swift
@@ -15,17 +15,17 @@ extension Report {
     ) async -> [String: [Module.File.Issue]] {
         let parsed = await buildResultsDTO.warnings.concurrentCompactMap {
             warning -> (String, Module.File.Issue)? in
-            guard
-                let issueType = Module.File.Issue.IssueType(rawValue: warning.issueType),
-                let fileName = warning.fileName
-            else { return nil }
+            guard let fileName = warning.fileName else { return nil }
 
             let normalized = normalizeWarningMessage(warning.message)
             guard !normalized.isEmpty else { return nil }
 
             return (
                 fileName,
-                Module.File.Issue(type: issueType, message: normalized)
+                Module.File.Issue(
+                    type: Module.File.Issue.IssueType(rawValue: warning.issueType),
+                    message: normalized
+                )
             )
         }
 

--- a/Sources/PeekieSDK/Models/Report.swift
+++ b/Sources/PeekieSDK/Models/Report.swift
@@ -123,10 +123,52 @@ extension Report.Module.File {
         /// Human-readable message describing the issue
         public let message: String
 
-        /// Types of build issues that can be reported
-        public enum IssueType: String, Equatable, Sendable {
-            case buildWarning = "Swift Compiler Warning"
+        /// Types of build issues that can be reported.
+        ///
+        /// The set of `issueType` values emitted by `xcresulttool` is open — Apple
+        /// adds new typed diagnostics in newer Xcode releases. Use `.unknown(_)`
+        /// for forward compatibility; the raw string is preserved verbatim.
+        public enum IssueType: Equatable, Sendable {
+            case swiftCompilerWarning
+            case swiftCompilerError
+            case deprecatedDeclaration
+            case noUsage
+            case unknown(String)
         }
+    }
+}
+
+extension Report.Module.File.Issue.IssueType {
+    public init(rawValue: String) {
+        switch rawValue {
+        case "Swift Compiler Warning": self = .swiftCompilerWarning
+        case "Swift Compiler Error": self = .swiftCompilerError
+        case "DeprecatedDeclaration": self = .deprecatedDeclaration
+        case "No-usage": self = .noUsage
+        default: self = .unknown(rawValue)
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .swiftCompilerWarning: return "Swift Compiler Warning"
+        case .swiftCompilerError: return "Swift Compiler Error"
+        case .deprecatedDeclaration: return "DeprecatedDeclaration"
+        case .noUsage: return "No-usage"
+        case .unknown(let raw): return raw
+        }
+    }
+}
+
+extension Report.Module.File.Issue.IssueType: Codable {
+    public init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self.init(rawValue: raw)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
     }
 }
 

--- a/Tests/PeekieTests/IssueTypeTests.swift
+++ b/Tests/PeekieTests/IssueTypeTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+@testable import PeekieSDK
+
+private typealias IssueType = Report.Module.File.Issue.IssueType
+
+@Suite
+struct IssueTypeTests {
+    @Test
+    func knownRawValuesMapToTypedCases() {
+        #expect(IssueType(rawValue: "Swift Compiler Warning") == .swiftCompilerWarning)
+        #expect(IssueType(rawValue: "Swift Compiler Error") == .swiftCompilerError)
+        #expect(IssueType(rawValue: "DeprecatedDeclaration") == .deprecatedDeclaration)
+        #expect(IssueType(rawValue: "No-usage") == .noUsage)
+    }
+
+    @Test
+    func unknownRawValueFallsBackToUnknown() {
+        #expect(IssueType(rawValue: "FooNewType") == .unknown("FooNewType"))
+    }
+
+    @Test
+    func rawValueRoundTrips() {
+        #expect(IssueType.swiftCompilerWarning.rawValue == "Swift Compiler Warning")
+        #expect(IssueType.swiftCompilerError.rawValue == "Swift Compiler Error")
+        #expect(IssueType.deprecatedDeclaration.rawValue == "DeprecatedDeclaration")
+        #expect(IssueType.noUsage.rawValue == "No-usage")
+        #expect(IssueType.unknown("Something").rawValue == "Something")
+    }
+
+    @Test
+    func codableRoundTripsThroughRawValue() throws {
+        let cases: [IssueType] = [
+            .swiftCompilerWarning,
+            .swiftCompilerError,
+            .deprecatedDeclaration,
+            .noUsage,
+            .unknown("FutureType"),
+        ]
+
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for value in cases {
+            let data = try encoder.encode(value)
+            let json = String(data: data, encoding: .utf8)
+            #expect(json == "\"\(value.rawValue)\"")
+
+            let decoded = try decoder.decode(IssueType.self, from: data)
+            #expect(decoded == value)
+        }
+    }
+}

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -56,7 +56,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -56,7 +56,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -56,7 +56,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -56,7 +56,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -56,7 +56,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -67,7 +67,7 @@
           "warnings" : [
             {
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }
@@ -100,7 +100,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -264,7 +264,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -286,7 +286,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -67,7 +67,7 @@
           "warnings" : [
             {
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }
@@ -100,7 +100,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -264,7 +264,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -286,7 +286,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -67,7 +67,7 @@
           "warnings" : [
             {
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }
@@ -100,7 +100,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -264,7 +264,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -286,7 +286,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -56,7 +56,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -56,7 +56,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -56,7 +56,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -56,7 +56,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -56,7 +56,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -87,7 +87,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -101,7 +101,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -67,7 +67,7 @@
           "warnings" : [
             {
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }
@@ -100,7 +100,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -172,7 +172,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -194,7 +194,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -67,7 +67,7 @@
           "warnings" : [
             {
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }
@@ -100,7 +100,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -172,7 +172,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -194,7 +194,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
@@ -18,7 +18,7 @@
           "warnings" : [
             {
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         },
@@ -67,7 +67,7 @@
           "warnings" : [
             {
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             }
           ]
         }
@@ -100,7 +100,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -172,7 +172,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
@@ -194,7 +194,7 @@
           "warnings" : [
             {
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
+              "type" : "Swift Compiler Error"
             },
             {
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
@@ -32,7 +32,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "Calculator"
       - suites: 0 members
     ▿ Module
@@ -64,7 +64,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -75,7 +75,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -86,7 +86,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "ExamplesTests"
       ▿ suites: 2 members
         ▿ Suite

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
@@ -32,7 +32,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "Calculator"
       - suites: 0 members
     ▿ Module
@@ -64,7 +64,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -75,7 +75,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -86,7 +86,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "ExamplesTests"
       ▿ suites: 2 members
         ▿ Suite

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
@@ -32,7 +32,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "Calculator"
       - suites: 0 members
     ▿ Module
@@ -64,7 +64,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -75,7 +75,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -86,7 +86,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "ExamplesTests"
       ▿ suites: 2 members
         ▿ Suite

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
@@ -32,7 +32,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "Calculator"
       - suites: 0 members
     ▿ Module
@@ -64,7 +64,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -75,7 +75,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -86,7 +86,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "ExamplesTests"
       ▿ suites: 2 members
         ▿ Suite

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
@@ -32,7 +32,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "Calculator"
       - suites: 0 members
     ▿ Module
@@ -64,7 +64,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -75,7 +75,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -86,7 +86,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "ExamplesTests"
       ▿ suites: 2 members
         ▿ Suite

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
@@ -19,7 +19,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from StringUtils"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "XcodeprojExampleFramework.framework"
       - suites: 0 members
     ▿ Module
@@ -47,7 +47,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -79,16 +79,16 @@
           ▿ warnings: 4 elements
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
             ▿ Issue
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests"
       ▿ suites: 2 members
         ▿ Suite
@@ -1058,13 +1058,13 @@
           ▿ warnings: 3 elements
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
             ▿ Issue
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -1075,15 +1075,15 @@
           ▿ warnings: 4 elements
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
             ▿ Issue
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"
       - suites: 0 members

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
@@ -19,7 +19,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from StringUtils"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "XcodeprojExampleFramework.framework"
       - suites: 0 members
     ▿ Module
@@ -47,7 +47,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -79,16 +79,16 @@
           ▿ warnings: 4 elements
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
             ▿ Issue
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests"
       ▿ suites: 2 members
         ▿ Suite
@@ -1058,13 +1058,13 @@
           ▿ warnings: 3 elements
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
             ▿ Issue
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -1075,15 +1075,15 @@
           ▿ warnings: 4 elements
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
             ▿ Issue
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"
       - suites: 0 members

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
@@ -19,7 +19,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from StringUtils"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
       - name: "XcodeprojExampleFramework.framework"
       - suites: 0 members
     ▿ Module
@@ -47,7 +47,7 @@
           ▿ warnings: 1 element
             ▿ Issue
               - message: "Some warning from Calculator"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -79,16 +79,16 @@
           ▿ warnings: 4 elements
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
             ▿ Issue
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests"
       ▿ suites: 2 members
         ▿ Suite
@@ -1058,13 +1058,13 @@
           ▿ warnings: 3 elements
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
             ▿ Issue
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -1075,15 +1075,15 @@
           ▿ warnings: 4 elements
             ▿ Issue
               - message: "Some warning from ExampleSUITests"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerError
             ▿ Issue
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.buildWarning
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"
       - suites: 0 members


### PR DESCRIPTION
## Summary

Resolves #159. `Report.Module.File.Issue.IssueType` used to be a closed `String` enum with a single case `.buildWarning = "Swift Compiler Warning"`. The guard in `parseWarnings(from:)` dropped every diagnostic whose `issueType` did not match exactly — on Xcode 26 that's most typed compiler warnings (`DeprecatedDeclaration`, `No-usage`, `Swift Compiler Error`, and anything new Apple ships next year). Now we parse all of them and keep unknown ones around verbatim via `.unknown(String)`.

## Key Changes

- `IssueType` becomes a multi-case enum: `.swiftCompilerWarning`, `.swiftCompilerError`, `.deprecatedDeclaration`, `.noUsage`, `.unknown(String)`. `rawValue` and `init(rawValue:)` round-trip; `init(rawValue:)` is no longer Optional — unrecognized strings become `.unknown(raw)`.
- `IssueType` conforms to `Codable` — encodes as the raw Apple string (no `"unknown:"` prefix for the fallback case).
- `parseWarnings(from:)` drops the `IssueType(rawValue:)` guard; every warning that has a `fileName` and non-empty normalized message gets through.
- Unit tests on `IssueType` covering known values, unknown fallback, and Codable round-trip.
- Snapshots re-recorded: existing fixtures use `#warning("…")` directives, which xcresult emits as two records each — the `Swift Compiler Error` half now appears in the snapshot output for the first time.

## Breaking change

`5.0.0`. `issue.type == .buildWarning` → must be replaced with `.swiftCompilerWarning`. `IssueType(rawValue:)` is no longer Optional.

## Additional Changes

_None._