### PR TITLE
Expose source location (line/column) on build warnings

### DIFF
--- a/Sources/PeekieSDK/Formatters/JsonFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/JsonFormatter.swift
@@ -117,10 +117,12 @@ private struct JsonFile: Encodable {
 private struct JsonWarning: Encodable {
     let message: String
     let type: String
+    let location: Report.Module.File.Issue.Location?
 
     init(from issue: Report.Module.File.Issue) {
         self.type = issue.type.rawValue
         self.message = issue.message
+        self.location = issue.location
     }
 }
 

--- a/Sources/PeekieSDK/Models/DTO/BuildResultsDTO.swift
+++ b/Sources/PeekieSDK/Models/DTO/BuildResultsDTO.swift
@@ -18,4 +18,32 @@ extension BuildResultsDTO.Issue {
             string: url.absoluteString.components(separatedBy: "#").first ?? url.absoluteString)
         return (fragmentTrimmed ?? url).lastPathComponent
     }
+
+    /// Parses Apple's `sourceURL` fragment (`...#StartingLineNumber=N&...`) into a typed location.
+    /// Returns `nil` when `sourceURL` is absent, has no fragment, or the fragment carries no
+    /// `StartingLineNumber` key — line is the minimum we need to surface a location at all.
+    var location: Report.Module.File.Issue.Location? {
+        guard let sourceURL else { return nil }
+        guard
+            let fragment = sourceURL.split(separator: "#", maxSplits: 1).dropFirst().first
+        else { return nil }
+
+        let params: [String: String] =
+            fragment
+            .split(separator: "&")
+            .reduce(into: [:]) { acc, part in
+                let kv = part.split(separator: "=", maxSplits: 1)
+                guard kv.count == 2 else { return }
+                acc[String(kv[0])] = String(kv[1])
+            }
+
+        guard let startLine = params["StartingLineNumber"].flatMap(Int.init) else { return nil }
+
+        return .init(
+            startLine: startLine,
+            startColumn: params["StartingColumnNumber"].flatMap(Int.init),
+            endLine: params["EndingLineNumber"].flatMap(Int.init),
+            endColumn: params["EndingColumnNumber"].flatMap(Int.init)
+        )
+    }
 }

--- a/Sources/PeekieSDK/Models/Report+Warnings.swift
+++ b/Sources/PeekieSDK/Models/Report+Warnings.swift
@@ -24,7 +24,8 @@ extension Report {
                 fileName,
                 Module.File.Issue(
                     type: Module.File.Issue.IssueType(rawValue: warning.issueType),
-                    message: normalized
+                    message: normalized,
+                    location: warning.location
                 )
             )
         }

--- a/Sources/PeekieSDK/Models/Report.swift
+++ b/Sources/PeekieSDK/Models/Report.swift
@@ -123,6 +123,39 @@ extension Report.Module.File {
         /// Human-readable message describing the issue
         public let message: String
 
+        /// Source location in the file the issue refers to, when xcresult provides one.
+        /// `nil` for project-level warnings or when the `sourceURL` fragment has no
+        /// `StartingLineNumber`.
+        public let location: Location?
+
+        public init(type: IssueType, message: String, location: Location? = nil) {
+            self.type = type
+            self.message = message
+            self.location = location
+        }
+
+        /// Source range inside a file. `startLine` is the minimum guarantee — the
+        /// other three fields are independently optional because `xcresulttool` is
+        /// not contractually obligated to emit all of them.
+        public struct Location: Equatable, Sendable, Codable {
+            public let startLine: Int
+            public let startColumn: Int?
+            public let endLine: Int?
+            public let endColumn: Int?
+
+            public init(
+                startLine: Int,
+                startColumn: Int? = nil,
+                endLine: Int? = nil,
+                endColumn: Int? = nil
+            ) {
+                self.startLine = startLine
+                self.startColumn = startColumn
+                self.endLine = endLine
+                self.endColumn = endColumn
+            }
+        }
+
         /// Types of build issues that can be reported.
         ///
         /// The set of `issueType` values emitted by `xcresulttool` is open — Apple

--- a/Tests/PeekieTests/BuildResultsDTOLocationTests.swift
+++ b/Tests/PeekieTests/BuildResultsDTOLocationTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import PeekieSDK
+
+@Suite
+struct BuildResultsDTOLocationTests {
+    private func issue(sourceURL: String?) -> BuildResultsDTO.Issue {
+        BuildResultsDTO.Issue(
+            issueType: "Swift Compiler Warning", message: "m", sourceURL: sourceURL)
+    }
+
+    @Test
+    func fullFragmentParsesAllFourFields() {
+        let url =
+            "file:///Users/foo/foo.swift#EndingColumnNumber=8&EndingLineNumber=4&"
+            + "StartingColumnNumber=4&StartingLineNumber=3&Timestamp=802245068.4496371"
+        let loc = issue(sourceURL: url).location
+        #expect(loc == .init(startLine: 3, startColumn: 4, endLine: 4, endColumn: 8))
+    }
+
+    @Test
+    func onlyStartingLinePopulatesStartLineAndNilsTheRest() {
+        let url = "file:///Users/foo/foo.swift#StartingLineNumber=12"
+        let loc = issue(sourceURL: url).location
+        #expect(loc == .init(startLine: 12, startColumn: nil, endLine: nil, endColumn: nil))
+    }
+
+    @Test
+    func nilSourceURLProducesNilLocation() {
+        #expect(issue(sourceURL: nil).location == nil)
+    }
+
+    @Test
+    func sourceURLWithoutFragmentProducesNilLocation() {
+        #expect(issue(sourceURL: "file:///Users/foo/foo.swift").location == nil)
+    }
+
+    @Test
+    func fragmentWithoutStartingLineProducesNilLocation() {
+        let url = "file:///Users/foo/foo.swift#EndingLineNumber=4&StartingColumnNumber=2"
+        #expect(issue(sourceURL: url).location == nil)
+    }
+
+    @Test
+    func malformedFragmentParsesGracefully() {
+        let url = "file:///Users/foo/foo.swift#garbage&no=equals=here&StartingLineNumber=7"
+        let loc = issue(sourceURL: url).location
+        #expect(loc?.startLine == 7)
+    }
+}

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -55,6 +61,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -86,6 +98,12 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }
@@ -100,6 +118,12 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -55,6 +61,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -86,6 +98,12 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }
@@ -100,6 +118,12 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -55,6 +61,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -86,6 +98,12 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }
@@ -100,6 +118,12 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -55,6 +61,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -86,6 +98,12 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }
@@ -100,6 +118,12 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -55,6 +61,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -86,6 +98,12 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }
@@ -100,6 +118,12 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -66,6 +72,12 @@
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
             }
@@ -99,18 +111,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -263,14 +299,32 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 72,
+                "startColumn" : 25,
+                "startLine" : 72
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 75,
+                "startColumn" : 32,
+                "startLine" : 75
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -285,18 +339,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -66,6 +72,12 @@
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
             }
@@ -99,18 +111,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -263,14 +299,32 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 72,
+                "startColumn" : 25,
+                "startLine" : 72
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 75,
+                "startColumn" : 32,
+                "startLine" : 75
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -285,18 +339,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -66,6 +72,12 @@
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
             }
@@ -99,18 +111,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -263,14 +299,32 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 72,
+                "startColumn" : 25,
+                "startLine" : 72
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 75,
+                "startColumn" : 32,
+                "startLine" : 75
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -285,18 +339,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -55,6 +61,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -86,6 +98,12 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }
@@ -100,6 +118,12 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -55,6 +61,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -86,6 +98,12 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }
@@ -100,6 +118,12 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -55,6 +61,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -86,6 +98,12 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }
@@ -100,6 +118,12 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -55,6 +61,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -86,6 +98,12 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }
@@ -100,6 +118,12 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -55,6 +61,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -86,6 +98,12 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }
@@ -100,6 +118,12 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -66,6 +72,12 @@
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
             }
@@ -99,18 +111,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -171,14 +207,32 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 72,
+                "startColumn" : 25,
+                "startLine" : 72
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 75,
+                "startColumn" : 32,
+                "startLine" : 75
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -193,18 +247,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -66,6 +72,12 @@
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
             }
@@ -99,18 +111,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -171,14 +207,32 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 72,
+                "startColumn" : 25,
+                "startLine" : 72
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 75,
+                "startColumn" : 32,
+                "startLine" : 75
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -193,18 +247,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
@@ -17,6 +17,12 @@
           "name" : "Calculator.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
             }
@@ -66,6 +72,12 @@
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
             }
@@ -99,18 +111,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -171,14 +207,32 @@
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 72,
+                "startColumn" : 25,
+                "startLine" : 72
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 75,
+                "startColumn" : 32,
+                "startLine" : 75
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }
@@ -193,18 +247,42 @@
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
             },
             {
+              "location" : {
+                "endColumn" : 25,
+                "endLine" : 50,
+                "startColumn" : 25,
+                "startLine" : 50
+              },
               "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 32,
+                "endLine" : 53,
+                "startColumn" : 32,
+                "startLine" : 53
+              },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             },
             {
+              "location" : {
+                "endColumn" : 36,
+                "endLine" : 64,
+                "startColumn" : 36,
+                "startLine" : 64
+              },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
             }

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
@@ -31,6 +31,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
       - name: "Calculator"
@@ -63,6 +72,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -74,6 +92,15 @@
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -85,6 +112,15 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
       - name: "ExamplesTests"

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
@@ -31,6 +31,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
       - name: "Calculator"
@@ -63,6 +72,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -74,6 +92,15 @@
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -85,6 +112,15 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
       - name: "ExamplesTests"

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
@@ -31,6 +31,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
       - name: "Calculator"
@@ -63,6 +72,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -74,6 +92,15 @@
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -85,6 +112,15 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
       - name: "ExamplesTests"

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
@@ -31,6 +31,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
       - name: "Calculator"
@@ -63,6 +72,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -74,6 +92,15 @@
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -85,6 +112,15 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
       - name: "ExamplesTests"

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
@@ -31,6 +31,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
       - name: "Calculator"
@@ -63,6 +72,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -74,6 +92,15 @@
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -85,6 +112,15 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
       - name: "ExamplesTests"

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
@@ -18,6 +18,15 @@
           - name: "TextProcessor.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 13
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 13
               - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerError
       - name: "XcodeprojExampleFramework.framework"
@@ -46,6 +55,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -78,15 +96,51 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 4 elements
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 25
+                  ▿ endLine: Optional<Int>
+                    - some: 50
+                  ▿ startColumn: Optional<Int>
+                    - some: 25
+                  - startLine: 50
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 32
+                  ▿ endLine: Optional<Int>
+                    - some: 53
+                  ▿ startColumn: Optional<Int>
+                    - some: 32
+                  - startLine: 53
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 36
+                  ▿ endLine: Optional<Int>
+                    - some: 64
+                  ▿ startColumn: Optional<Int>
+                    - some: 36
+                  - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests"
@@ -1057,12 +1111,39 @@
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 3 elements
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 25
+                  ▿ endLine: Optional<Int>
+                    - some: 72
+                  ▿ startColumn: Optional<Int>
+                    - some: 25
+                  - startLine: 72
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 32
+                  ▿ endLine: Optional<Int>
+                    - some: 75
+                  ▿ startColumn: Optional<Int>
+                    - some: 32
+                  - startLine: 75
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
         ▿ File
@@ -1074,15 +1155,51 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 4 elements
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 25
+                  ▿ endLine: Optional<Int>
+                    - some: 50
+                  ▿ startColumn: Optional<Int>
+                    - some: 25
+                  - startLine: 50
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 32
+                  ▿ endLine: Optional<Int>
+                    - some: 53
+                  ▿ startColumn: Optional<Int>
+                    - some: 32
+                  - startLine: 53
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 36
+                  ▿ endLine: Optional<Int>
+                    - some: 64
+                  ▿ startColumn: Optional<Int>
+                    - some: 36
+                  - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
@@ -18,6 +18,15 @@
           - name: "TextProcessor.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 13
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 13
               - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerError
       - name: "XcodeprojExampleFramework.framework"
@@ -46,6 +55,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -78,15 +96,51 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 4 elements
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 25
+                  ▿ endLine: Optional<Int>
+                    - some: 50
+                  ▿ startColumn: Optional<Int>
+                    - some: 25
+                  - startLine: 50
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 32
+                  ▿ endLine: Optional<Int>
+                    - some: 53
+                  ▿ startColumn: Optional<Int>
+                    - some: 32
+                  - startLine: 53
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 36
+                  ▿ endLine: Optional<Int>
+                    - some: 64
+                  ▿ startColumn: Optional<Int>
+                    - some: 36
+                  - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests"
@@ -1057,12 +1111,39 @@
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 3 elements
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 25
+                  ▿ endLine: Optional<Int>
+                    - some: 72
+                  ▿ startColumn: Optional<Int>
+                    - some: 25
+                  - startLine: 72
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 32
+                  ▿ endLine: Optional<Int>
+                    - some: 75
+                  ▿ startColumn: Optional<Int>
+                    - some: 32
+                  - startLine: 75
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
         ▿ File
@@ -1074,15 +1155,51 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 4 elements
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 25
+                  ▿ endLine: Optional<Int>
+                    - some: 50
+                  ▿ startColumn: Optional<Int>
+                    - some: 25
+                  - startLine: 50
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 32
+                  ▿ endLine: Optional<Int>
+                    - some: 53
+                  ▿ startColumn: Optional<Int>
+                    - some: 32
+                  - startLine: 53
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 36
+                  ▿ endLine: Optional<Int>
+                    - some: 64
+                  ▿ startColumn: Optional<Int>
+                    - some: 36
+                  - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
@@ -18,6 +18,15 @@
           - name: "TextProcessor.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 13
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 13
               - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerError
       - name: "XcodeprojExampleFramework.framework"
@@ -46,6 +55,15 @@
           - name: "Calculator.swift"
           ▿ warnings: 1 element
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
         ▿ File
@@ -78,15 +96,51 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 4 elements
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 25
+                  ▿ endLine: Optional<Int>
+                    - some: 50
+                  ▿ startColumn: Optional<Int>
+                    - some: 25
+                  - startLine: 50
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 32
+                  ▿ endLine: Optional<Int>
+                    - some: 53
+                  ▿ startColumn: Optional<Int>
+                    - some: 32
+                  - startLine: 53
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 36
+                  ▿ endLine: Optional<Int>
+                    - some: 64
+                  ▿ startColumn: Optional<Int>
+                    - some: 36
+                  - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests"
@@ -1057,12 +1111,39 @@
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 3 elements
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 25
+                  ▿ endLine: Optional<Int>
+                    - some: 72
+                  ▿ startColumn: Optional<Int>
+                    - some: 25
+                  - startLine: 72
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 32
+                  ▿ endLine: Optional<Int>
+                    - some: 75
+                  ▿ startColumn: Optional<Int>
+                    - some: 32
+                  - startLine: 75
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
         ▿ File
@@ -1074,15 +1155,51 @@
           - name: "XCTestTests.swift"
           ▿ warnings: 4 elements
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 25
+                  ▿ endLine: Optional<Int>
+                    - some: 50
+                  ▿ startColumn: Optional<Int>
+                    - some: 25
+                  - startLine: 50
               - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 32
+                  ▿ endLine: Optional<Int>
+                    - some: 53
+                  ▿ startColumn: Optional<Int>
+                    - some: 32
+                  - startLine: 53
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
             ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 36
+                  ▿ endLine: Optional<Int>
+                    - some: 64
+                  ▿ startColumn: Optional<Int>
+                    - some: 36
+                  - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"


### PR DESCRIPTION
## Summary

Resolves #160. xcresulttool encodes source location in the `sourceURL` fragment (`...#StartingLineNumber=N&StartingColumnNumber=M&...`). Peekie was throwing the fragment away after extracting `lastPathComponent` — `Report.Module.File.Issue` carried only `type` and `message`, so consumers couldn't tell which line a warning came from. Parse the fragment and expose it as an optional `Location` on each `Issue`.

## Key Changes

- New `Report.Module.File.Issue.Location` — `startLine` non-optional (the minimum guarantee), `startColumn` / `endLine` / `endColumn` each independently optional (Apple doesn't promise all four).
- `Issue` gains an optional `location` property and a memberwise-equivalent public init with `location` defaulting to `nil` — non-breaking for existing callers.
- `BuildResultsDTO.Issue.location` parses the form-encoded fragment; returns `nil` when `sourceURL` is missing, when there's no fragment, or when the fragment carries no `StartingLineNumber`.
- `JsonFormatter` surfaces `location` in output JSON.
- Unit tests on the fragment parser (full / partial / missing / malformed cases).
- Snapshots re-recorded to include the new location blocks.

## Additional Changes

_None._