### PR TITLE
Stop deduplicating identical warning messages within a file

### DIFF
--- a/Sources/PeekieSDK/Models/Report+Warnings.swift
+++ b/Sources/PeekieSDK/Models/Report+Warnings.swift
@@ -31,13 +31,7 @@ extension Report {
         }
 
         let grouped = Dictionary(grouping: parsed, by: { $0.0 })
-        return grouped.mapValues { pairs in
-            var seen = Set<String>()
-            return pairs.compactMap { _, issue in
-                guard seen.insert(issue.message).inserted else { return nil }
-                return issue
-            }
-        }
+        return grouped.mapValues { $0.map(\.1) }
     }
 
     /// Normalizes a warning message by removing duplicate patterns and cleaning up formatting
@@ -80,18 +74,12 @@ extension Report {
         return []
     }
 
-    /// Merges two arrays of warnings, removing duplicates based on message content
+    /// Concatenates two arrays of warnings. The SDK no longer deduplicates — every
+    /// xcresult record is surfaced; grouping/dedup is a consumer decision.
     static func mergeWarnings(
         _ existing: [Module.File.Issue],
         _ new: [Module.File.Issue]
     ) -> [Module.File.Issue] {
-        guard !new.isEmpty else { return existing }
-        var combined = existing
-        // Use normalized messages for comparison since warnings are already normalized
-        let existingMessages = Set(combined.map { $0.message })
-        for warning in new where !existingMessages.contains(warning.message) {
-            combined.append(warning)
-        }
-        return combined
+        existing + new
     }
 }

--- a/Tests/PeekieTests/ParseWarningsDedupTests.swift
+++ b/Tests/PeekieTests/ParseWarningsDedupTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+
+@testable import PeekieSDK
+
+@Suite
+struct ParseWarningsDedupTests {
+    @Test
+    func identicalMessagesInSameFileAreNotDeduplicated() async {
+        let dto = BuildResultsDTO(warnings: [
+            .init(
+                issueType: "DeprecatedDeclaration",
+                message: "'oldFoo()' is deprecated: use bar",
+                sourceURL: "file:///foo.swift#StartingLineNumber=4"
+            ),
+            .init(
+                issueType: "DeprecatedDeclaration",
+                message: "'oldFoo()' is deprecated: use bar",
+                sourceURL: "file:///foo.swift#StartingLineNumber=5"
+            ),
+            .init(
+                issueType: "DeprecatedDeclaration",
+                message: "'oldFoo()' is deprecated: use bar",
+                sourceURL: "file:///foo.swift#StartingLineNumber=12"
+            ),
+        ])
+
+        let result = await Report.parseWarnings(from: dto)
+
+        let issues = try? #require(result["foo.swift"])
+        #expect(issues?.count == 3)
+        #expect(issues?.compactMap { $0.location?.startLine }.sorted() == [4, 5, 12])
+    }
+}

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -69,6 +79,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -106,6 +126,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -126,6 +156,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -69,6 +79,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -106,6 +126,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -126,6 +156,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -69,6 +79,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -106,6 +126,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -126,6 +156,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -69,6 +79,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -106,6 +126,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -126,6 +156,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -69,6 +79,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -106,6 +126,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -126,6 +156,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -80,6 +90,16 @@
               },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }
@@ -119,6 +139,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {
@@ -310,6 +340,16 @@
             },
             {
               "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
                 "endColumn" : 25,
                 "endLine" : 72,
                 "startColumn" : 25,
@@ -347,6 +387,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -80,6 +90,16 @@
               },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }
@@ -119,6 +139,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {
@@ -310,6 +340,16 @@
             },
             {
               "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
                 "endColumn" : 25,
                 "endLine" : 72,
                 "startColumn" : 25,
@@ -347,6 +387,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -80,6 +90,16 @@
               },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }
@@ -119,6 +139,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {
@@ -310,6 +340,16 @@
             },
             {
               "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
                 "endColumn" : 25,
                 "endLine" : 72,
                 "startColumn" : 25,
@@ -347,6 +387,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -69,6 +79,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -106,6 +126,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -126,6 +156,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -69,6 +79,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -106,6 +126,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -126,6 +156,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -69,6 +79,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -106,6 +126,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -126,6 +156,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -69,6 +79,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -106,6 +126,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -126,6 +156,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -69,6 +79,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -106,6 +126,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -126,6 +156,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -80,6 +90,16 @@
               },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }
@@ -119,6 +139,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {
@@ -218,6 +248,16 @@
             },
             {
               "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
                 "endColumn" : 25,
                 "endLine" : 72,
                 "startColumn" : 25,
@@ -255,6 +295,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -80,6 +90,16 @@
               },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }
@@ -119,6 +139,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {
@@ -218,6 +248,16 @@
             },
             {
               "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
                 "endColumn" : 25,
                 "endLine" : 72,
                 "startColumn" : 25,
@@ -255,6 +295,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
@@ -25,6 +25,16 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -80,6 +90,16 @@
               },
               "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Warning"
             }
           ]
         }
@@ -119,6 +139,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {
@@ -218,6 +248,16 @@
             },
             {
               "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
                 "endColumn" : 25,
                 "endLine" : 72,
                 "startColumn" : 25,
@@ -255,6 +295,16 @@
               },
               "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
@@ -29,7 +29,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -42,6 +42,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
       - name: "Calculator"
       - suites: 0 members
     ▿ Module
@@ -70,7 +82,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -83,6 +95,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -90,7 +114,7 @@
               - coveredLines: 57
               - totalLines: 67
           - name: "SwiftTestingTests.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -103,6 +127,18 @@
                   - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -110,7 +146,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -123,6 +159,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
       ▿ suites: 2 members
         ▿ Suite

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
@@ -29,7 +29,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -42,6 +42,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
       - name: "Calculator"
       - suites: 0 members
     ▿ Module
@@ -70,7 +82,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -83,6 +95,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -90,7 +114,7 @@
               - coveredLines: 57
               - totalLines: 67
           - name: "SwiftTestingTests.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -103,6 +127,18 @@
                   - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -110,7 +146,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -123,6 +159,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
       ▿ suites: 2 members
         ▿ Suite

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
@@ -29,7 +29,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -42,6 +42,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
       - name: "Calculator"
       - suites: 0 members
     ▿ Module
@@ -70,7 +82,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -83,6 +95,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -90,7 +114,7 @@
               - coveredLines: 57
               - totalLines: 67
           - name: "SwiftTestingTests.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -103,6 +127,18 @@
                   - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -110,7 +146,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -123,6 +159,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
       ▿ suites: 2 members
         ▿ Suite

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
@@ -29,7 +29,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -42,6 +42,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
       - name: "Calculator"
       - suites: 0 members
     ▿ Module
@@ -70,7 +82,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -83,6 +95,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -90,7 +114,7 @@
               - coveredLines: 57
               - totalLines: 67
           - name: "SwiftTestingTests.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -103,6 +127,18 @@
                   - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -110,7 +146,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -123,6 +159,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
       ▿ suites: 2 members
         ▿ Suite

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
@@ -29,7 +29,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -42,6 +42,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
       - name: "Calculator"
       - suites: 0 members
     ▿ Module
@@ -70,7 +82,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -83,6 +95,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -90,7 +114,7 @@
               - coveredLines: 57
               - totalLines: 67
           - name: "SwiftTestingTests.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -103,6 +127,18 @@
                   - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -110,7 +146,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -123,6 +159,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
       ▿ suites: 2 members
         ▿ Suite

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
@@ -16,7 +16,7 @@
               - coveredLines: 0
               - totalLines: 23
           - name: "TextProcessor.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -29,6 +29,18 @@
                   - startLine: 13
               - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 13
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 13
+              - message: "Some warning from StringUtils"
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleFramework.framework"
       - suites: 0 members
     ▿ Module
@@ -53,7 +65,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -66,6 +78,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -94,7 +118,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 4 elements
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -107,6 +131,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1109,7 +1145,7 @@
               - coveredLines: 57
               - totalLines: 67
           - name: "SwiftTestingTests.swift"
-          ▿ warnings: 3 elements
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1122,6 +1158,18 @@
                   - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1153,7 +1201,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 4 elements
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1166,6 +1214,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
@@ -16,7 +16,7 @@
               - coveredLines: 0
               - totalLines: 23
           - name: "TextProcessor.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -29,6 +29,18 @@
                   - startLine: 13
               - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 13
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 13
+              - message: "Some warning from StringUtils"
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleFramework.framework"
       - suites: 0 members
     ▿ Module
@@ -53,7 +65,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -66,6 +78,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -94,7 +118,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 4 elements
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -107,6 +131,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1109,7 +1145,7 @@
               - coveredLines: 57
               - totalLines: 67
           - name: "SwiftTestingTests.swift"
-          ▿ warnings: 3 elements
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1122,6 +1158,18 @@
                   - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1153,7 +1201,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 4 elements
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1166,6 +1214,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
@@ -16,7 +16,7 @@
               - coveredLines: 0
               - totalLines: 23
           - name: "TextProcessor.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -29,6 +29,18 @@
                   - startLine: 13
               - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 13
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 13
+              - message: "Some warning from StringUtils"
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleFramework.framework"
       - suites: 0 members
     ▿ Module
@@ -53,7 +65,7 @@
               - coveredLines: 15
               - totalLines: 34
           - name: "Calculator.swift"
-          ▿ warnings: 1 element
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -66,6 +78,18 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -94,7 +118,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 4 elements
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -107,6 +131,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1109,7 +1145,7 @@
               - coveredLines: 57
               - totalLines: 67
           - name: "SwiftTestingTests.swift"
-          ▿ warnings: 3 elements
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1122,6 +1158,18 @@
                   - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 98
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 98
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1153,7 +1201,7 @@
               - coveredLines: 95
               - totalLines: 96
           - name: "XCTestTests.swift"
-          ▿ warnings: 4 elements
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1166,6 +1214,18 @@
                   - startLine: 102
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location


### PR DESCRIPTION
## Summary

Resolves #161. `parseWarnings(from:)` was keeping only one record per unique `(file, message)`. With #160 just shipped, location-aware consumers can't see that `'oldFoo() is deprecated'` fired at lines 4, 5 and 12 — only the first record survived. Drop dedup; the SDK now faithfully reports every record xcresult returned.

## Key Changes

- `parseWarnings(from:)` no longer filters duplicates by `message` within a file. Replaced the per-file `Set<String>`-based filter with a plain `mapValues { $0.map(\.1) }`.
- `mergeWarnings(_:_:)` collapses to plain `existing + new` — concat, no dedup.
- New unit test: three identical messages on different lines in the same file → all three survive, with their distinct `startLine` values intact.
- Snapshots re-recorded with the additional rows that previously got collapsed (existing fixtures had `Main actor-isolated …` duplicates that now show up multiple times).

## Breaking change

Semantic. Counts grow in existing reports; consumers that assumed message uniqueness per file will see new entries. API shape (`[Issue]`) is unchanged. Same `5.0.0` release as #159 and #160.

## Additional Changes

_None._