### PR TITLE
Parse errors[] from build-results (symmetric to warnings)

### DIFF
--- a/Sources/PeekieSDK/Formatters/JsonFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/JsonFormatter.swift
@@ -105,18 +105,18 @@ private struct JsonCoverage: Encodable {
 private struct JsonFile: Encodable {
     let coverage: JsonCoverage?
     let name: String
-    let warnings: [JsonWarning]
-    let errors: [JsonWarning]
+    let warnings: [JsonIssue]
+    let errors: [JsonIssue]
 
     init(from file: Report.Module.File) {
         self.name = file.name
         self.coverage = file.coverage.map { JsonCoverage(from: $0) }
-        self.warnings = file.warnings.map { JsonWarning(from: $0) }
-        self.errors = file.errors.map { JsonWarning(from: $0) }
+        self.warnings = file.warnings.map { JsonIssue(from: $0) }
+        self.errors = file.errors.map { JsonIssue(from: $0) }
     }
 }
 
-private struct JsonWarning: Encodable {
+private struct JsonIssue: Encodable {
     let message: String
     let type: String
     let location: Report.Module.File.Issue.Location?

--- a/Sources/PeekieSDK/Formatters/JsonFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/JsonFormatter.swift
@@ -106,11 +106,13 @@ private struct JsonFile: Encodable {
     let coverage: JsonCoverage?
     let name: String
     let warnings: [JsonWarning]
+    let errors: [JsonWarning]
 
     init(from file: Report.Module.File) {
         self.name = file.name
         self.coverage = file.coverage.map { JsonCoverage(from: $0) }
         self.warnings = file.warnings.map { JsonWarning(from: $0) }
+        self.errors = file.errors.map { JsonWarning(from: $0) }
     }
 }
 

--- a/Sources/PeekieSDK/Models/DTO/BuildResultsDTO.swift
+++ b/Sources/PeekieSDK/Models/DTO/BuildResultsDTO.swift
@@ -2,6 +2,23 @@ import Foundation
 
 struct BuildResultsDTO: Decodable, Sendable {
     let warnings: [Issue]
+    let errors: [Issue]
+
+    init(warnings: [Issue] = [], errors: [Issue] = []) {
+        self.warnings = warnings
+        self.errors = errors
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.warnings = try container.decodeIfPresent([Issue].self, forKey: .warnings) ?? []
+        self.errors = try container.decodeIfPresent([Issue].self, forKey: .errors) ?? []
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case warnings
+        case errors
+    }
 
     struct Issue: Decodable, Sendable {
         let issueType: String

--- a/Sources/PeekieSDK/Models/Report+Convenience.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience.swift
@@ -54,12 +54,15 @@ extension Report {
             }
         }
 
-        // Parse warnings from build results
+        // Parse warnings and errors from build results
         let warningsByFileName: [String: [Report.Module.File.Issue]]
+        let errorsByFileName: [String: [Report.Module.File.Issue]]
         if let buildResultsDTO = buildResultsDTO {
             warningsByFileName = await Self.parseWarnings(from: buildResultsDTO)
+            errorsByFileName = await Self.parseErrors(from: buildResultsDTO)
         } else {
             warningsByFileName = [:]
+            errorsByFileName = [:]
         }
 
         var modules = Set<Module>()
@@ -252,10 +255,14 @@ extension Report {
                         }
                     }
 
-                    // Get or create File with coverage and warnings
+                    // Get or create File with coverage, warnings and errors
                     let fileWarnings: [Report.Module.File.Issue] =
                         includeWarnings
-                        ? Self.warningsFor(fileName: fileName, in: warningsByFileName)
+                        ? Self.issuesFor(fileName: fileName, in: warningsByFileName)
+                        : []
+                    let fileErrors: [Report.Module.File.Issue] =
+                        includeWarnings
+                        ? Self.issuesFor(fileName: fileName, in: errorsByFileName)
                         : []
 
                     var file = module.files[fileName]
@@ -263,13 +270,17 @@ extension Report {
                         file = Report.Module.File(
                             name: fileName,
                             warnings: fileWarnings,
+                            errors: fileErrors,
                             coverage: fileCoverage
                         )
                         module.files.insert(file!)
                     } else {
-                        // Merge warnings if file already exists
+                        // Merge warnings/errors if file already exists
                         if includeWarnings && !fileWarnings.isEmpty {
-                            file!.warnings = Self.mergeWarnings(file!.warnings, fileWarnings)
+                            file!.warnings = Self.mergeIssues(file!.warnings, fileWarnings)
+                        }
+                        if includeWarnings && !fileErrors.isEmpty {
+                            file!.errors = Self.mergeIssues(file!.errors, fileErrors)
                         }
                     }
 
@@ -490,25 +501,33 @@ extension Report {
                     // Use the name as it appears in xcresult
                     let fileName = fileCoverageDTO.name
 
-                    // Get warnings for this file
+                    // Get warnings and errors for this file
                     let fileWarnings: [Report.Module.File.Issue] =
                         includeWarnings
-                        ? Self.warningsFor(fileName: fileName, in: warningsByFileName)
+                        ? Self.issuesFor(fileName: fileName, in: warningsByFileName)
+                        : []
+                    let fileErrors: [Report.Module.File.Issue] =
+                        includeWarnings
+                        ? Self.issuesFor(fileName: fileName, in: errorsByFileName)
                         : []
 
-                    // Create or update File with coverage and warnings
+                    // Create or update File with coverage, warnings and errors
                     var file = moduleFiles[fileName]
                     if file == nil {
                         file = Report.Module.File(
                             name: fileName,
                             warnings: fileWarnings,
+                            errors: fileErrors,
                             coverage: coverage
                         )
                         moduleFiles.insert(file!)
                     } else {
-                        // Merge warnings if file already exists
+                        // Merge warnings/errors if file already exists
                         if includeWarnings && !fileWarnings.isEmpty {
-                            file!.warnings = Self.mergeWarnings(file!.warnings, fileWarnings)
+                            file!.warnings = Self.mergeIssues(file!.warnings, fileWarnings)
+                        }
+                        if includeWarnings && !fileErrors.isEmpty {
+                            file!.errors = Self.mergeIssues(file!.errors, fileErrors)
                         }
                     }
                 }

--- a/Sources/PeekieSDK/Models/Report+Warnings.swift
+++ b/Sources/PeekieSDK/Models/Report+Warnings.swift
@@ -13,19 +13,35 @@ extension Report {
     static func parseWarnings(
         from buildResultsDTO: BuildResultsDTO
     ) async -> [String: [Module.File.Issue]] {
-        let parsed = await buildResultsDTO.warnings.concurrentCompactMap {
-            warning -> (String, Module.File.Issue)? in
-            guard let fileName = warning.fileName else { return nil }
+        await parseIssues(buildResultsDTO.warnings)
+    }
 
-            let normalized = normalizeWarningMessage(warning.message)
+    /// Parses errors from BuildResultsDTO and returns a map of file names to their issues.
+    /// Symmetric to ``parseWarnings(from:)``: same DTO shape, same normalization, same
+    /// per-file grouping. Errors without a `sourceURL` (link errors, project-level errors)
+    /// are dropped — same as warnings.
+    static func parseErrors(
+        from buildResultsDTO: BuildResultsDTO
+    ) async -> [String: [Module.File.Issue]] {
+        await parseIssues(buildResultsDTO.errors)
+    }
+
+    private static func parseIssues(
+        _ dtoIssues: [BuildResultsDTO.Issue]
+    ) async -> [String: [Module.File.Issue]] {
+        let parsed = await dtoIssues.concurrentCompactMap {
+            issue -> (String, Module.File.Issue)? in
+            guard let fileName = issue.fileName else { return nil }
+
+            let normalized = normalizeWarningMessage(issue.message)
             guard !normalized.isEmpty else { return nil }
 
             return (
                 fileName,
                 Module.File.Issue(
-                    type: Module.File.Issue.IssueType(rawValue: warning.issueType),
+                    type: Module.File.Issue.IssueType(rawValue: issue.issueType),
                     message: normalized,
-                    location: warning.location
+                    location: issue.location
                 )
             )
         }
@@ -60,23 +76,23 @@ extension Report {
         return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Retrieves warnings matching a file name, optionally trying with a `.swift` suffix
-    static func warningsFor(
+    /// Retrieves issues matching a file name, optionally trying with a `.swift` suffix
+    static func issuesFor(
         fileName: String,
-        in warningsByFileName: [String: [Module.File.Issue]]
+        in issuesByFileName: [String: [Module.File.Issue]]
     ) -> [Module.File.Issue] {
-        if let warnings = warningsByFileName[fileName] {
-            return warnings
+        if let issues = issuesByFileName[fileName] {
+            return issues
         }
         if !fileName.hasSuffix(".swift") {
-            return warningsByFileName[fileName + ".swift"] ?? []
+            return issuesByFileName[fileName + ".swift"] ?? []
         }
         return []
     }
 
-    /// Concatenates two arrays of warnings. The SDK no longer deduplicates — every
+    /// Concatenates two arrays of issues. The SDK no longer deduplicates — every
     /// xcresult record is surfaced; grouping/dedup is a consumer decision.
-    static func mergeWarnings(
+    static func mergeIssues(
         _ existing: [Module.File.Issue],
         _ new: [Module.File.Issue]
     ) -> [Module.File.Issue] {

--- a/Sources/PeekieSDK/Models/Report.swift
+++ b/Sources/PeekieSDK/Models/Report.swift
@@ -14,6 +14,12 @@ public struct Report {
     public var warnings: [Module.File.Issue] {
         modules.flatMap { $0.warnings }
     }
+
+    /// All errors from all modules in this report
+    /// - Note: Computed property that aggregates errors from all Module.File.errors
+    public var errors: [Module.File.Issue] {
+        modules.flatMap { $0.errors }
+    }
 }
 
 extension Report {
@@ -44,6 +50,12 @@ extension Report {
         /// - Note: Computed property that aggregates warnings from all File.warnings
         public var warnings: [File.Issue] {
             files.flatMap { $0.warnings }
+        }
+
+        /// All errors from all files in this module
+        /// - Note: Computed property that aggregates errors from all File.errors
+        public var errors: [File.Issue] {
+            files.flatMap { $0.errors }
         }
     }
 
@@ -91,7 +103,7 @@ extension Report.Module.File {
 }
 
 extension Report.Module {
-    /// A source file with coverage and warnings information
+    /// A source file with coverage, warnings, and errors information
     public struct File: Hashable {
         /// Name of the file (e.g., "Report.swift")
         public let name: String
@@ -100,9 +112,25 @@ extension Report.Module {
         /// - Note: Read directly from xcresult DTO
         public internal(set) var warnings: [File.Issue]
 
+        /// Build errors associated with this file
+        /// - Note: Read directly from xcresult DTO
+        public internal(set) var errors: [File.Issue]
+
         /// Code coverage information for this file
         /// - Note: Read directly from file-level coverage data in xcresult DTO
         public let coverage: File.Coverage?
+
+        public init(
+            name: String,
+            warnings: [File.Issue] = [],
+            errors: [File.Issue] = [],
+            coverage: File.Coverage? = nil
+        ) {
+            self.name = name
+            self.warnings = warnings
+            self.errors = errors
+            self.coverage = coverage
+        }
 
         public func hash(into hasher: inout Hasher) {
             hasher.combine(name)

--- a/Tests/PeekieTests/ParseErrorsTests.swift
+++ b/Tests/PeekieTests/ParseErrorsTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+
+@testable import PeekieSDK
+
+@Suite
+struct ParseErrorsTests {
+    @Test
+    func errorsArrayDecodesSymmetricallyToWarnings() throws {
+        let json = """
+            {
+                "warningCount": 1,
+                "errorCount": 1,
+                "warnings": [
+                    { "issueType": "DeprecatedDeclaration", "message": "warned",
+                      "sourceURL": "file:///foo.swift#StartingLineNumber=1" }
+                ],
+                "errors": [
+                    { "issueType": "Swift Compiler Error", "message": "expected expression",
+                      "sourceURL": "file:///foo.swift#StartingLineNumber=42" }
+                ]
+            }
+            """
+        let dto = try JSONDecoder().decode(BuildResultsDTO.self, from: Data(json.utf8))
+
+        #expect(dto.warnings.count == 1)
+        #expect(dto.errors.count == 1)
+        #expect(dto.errors.first?.issueType == "Swift Compiler Error")
+    }
+
+    @Test
+    func errorsArrayDefaultsToEmptyWhenAbsent() throws {
+        let json = """
+            { "warningCount": 0, "warnings": [] }
+            """
+        let dto = try JSONDecoder().decode(BuildResultsDTO.self, from: Data(json.utf8))
+
+        #expect(dto.warnings.isEmpty)
+        #expect(dto.errors.isEmpty)
+    }
+
+    @Test
+    func parseErrorsGroupsByFileNameAndPreservesLocation() async {
+        let dto = BuildResultsDTO(
+            warnings: [],
+            errors: [
+                .init(
+                    issueType: "Swift Compiler Error",
+                    message: "cannot find 'foo' in scope",
+                    sourceURL: "file:///Calculator.swift#StartingLineNumber=10"
+                ),
+                .init(
+                    issueType: "Swift Compiler Error",
+                    message: "another error",
+                    sourceURL: "file:///Calculator.swift#StartingLineNumber=12"
+                ),
+            ]
+        )
+
+        let result = await Report.parseErrors(from: dto)
+        let issues = try? #require(result["Calculator.swift"])
+        #expect(issues?.count == 2)
+        #expect(issues?.compactMap { $0.location?.startLine }.sorted() == [10, 12])
+        #expect(
+            issues?.allSatisfy {
+                $0.type == .swiftCompilerError
+            } == true
+        )
+    }
+
+    @Test
+    func parseErrorsDropsRecordsWithoutSourceURL() async {
+        let dto = BuildResultsDTO(
+            warnings: [],
+            errors: [
+                .init(
+                    issueType: "Swift Compiler Error",
+                    message: "linker error",
+                    sourceURL: nil
+                )
+            ]
+        )
+
+        let result = await Report.parseErrors(from: dto)
+        #expect(result.isEmpty)
+    }
+}

--- a/Tests/PeekieTests/SonarFormatterSnapshotTests.swift
+++ b/Tests/PeekieTests/SonarFormatterSnapshotTests.swift
@@ -18,8 +18,13 @@ struct SonarFormatterSnapshotTests {
         }
         let report = try await Report(xcresultPath: reportPath)
 
-        // Create temporary test directory with mock test files
-        let testsPath = try createTestDirectory(for: report, functionName: #function)
+        // Create temporary test directory with mock test files.
+        // Include `fileName` in the path so parallel parameterized cases don't share
+        // (and thus race-delete) the same directory.
+        let testsPath = try createTestDirectory(
+            for: report,
+            slug: "\(#function)-\(snapshotName(from: fileName))"
+        )
         defer {
             try? FileManager.default.removeItem(at: testsPath)
         }
@@ -38,10 +43,10 @@ struct SonarFormatterSnapshotTests {
 
     // MARK: - Helpers
 
-    private func createTestDirectory(for report: Report, functionName: String) throws -> URL {
-        // Use function name in temporary directory for stable snapshot paths per test
+    private func createTestDirectory(for report: Report, slug: String) throws -> URL {
+        // Use slug (function + fixture) in temporary directory for stable snapshot paths per test
         let tempDir = FileManager.default.temporaryDirectory
-        let testDir = tempDir.appendingPathComponent("PeekieSonarTests-\(functionName)")
+        let testDir = tempDir.appendingPathComponent("PeekieSonarTests-\(slug)")
 
         // Remove existing directory if present to ensure clean state
         if FileManager.default.fileExists(atPath: testDir.path) {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -68,6 +74,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -93,6 +102,9 @@
           ]
         },
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -104,6 +116,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -115,6 +130,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -145,6 +163,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -68,6 +74,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -93,6 +102,9 @@
           ]
         },
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -104,6 +116,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -115,6 +130,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -145,6 +163,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -68,6 +74,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -93,6 +102,9 @@
           ]
         },
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -104,6 +116,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -115,6 +130,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -145,6 +163,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -68,6 +74,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -93,6 +102,9 @@
           ]
         },
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -104,6 +116,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -115,6 +130,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -145,6 +163,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -68,6 +74,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -93,6 +102,9 @@
           ]
         },
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -104,6 +116,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -115,6 +130,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -145,6 +163,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -55,6 +61,9 @@
             "percentage" : 1,
             "totalLines" : 14
           },
+          "errors" : [
+
+          ],
           "name" : "XcodeprojExampleApp.swift",
           "warnings" : [
 
@@ -79,6 +88,9 @@
             "percentage" : 0,
             "totalLines" : 23
           },
+          "errors" : [
+
+          ],
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
@@ -117,6 +129,9 @@
       },
       "files" : [
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -128,6 +143,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
@@ -326,6 +344,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -376,6 +397,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -55,6 +61,9 @@
             "percentage" : 1,
             "totalLines" : 14
           },
+          "errors" : [
+
+          ],
           "name" : "XcodeprojExampleApp.swift",
           "warnings" : [
 
@@ -79,6 +88,9 @@
             "percentage" : 0,
             "totalLines" : 23
           },
+          "errors" : [
+
+          ],
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
@@ -117,6 +129,9 @@
       },
       "files" : [
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -128,6 +143,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
@@ -326,6 +344,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -376,6 +397,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -55,6 +61,9 @@
             "percentage" : 1,
             "totalLines" : 14
           },
+          "errors" : [
+
+          ],
           "name" : "XcodeprojExampleApp.swift",
           "warnings" : [
 
@@ -79,6 +88,9 @@
             "percentage" : 0,
             "totalLines" : 23
           },
+          "errors" : [
+
+          ],
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
@@ -117,6 +129,9 @@
       },
       "files" : [
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -128,6 +143,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
@@ -326,6 +344,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -376,6 +397,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -68,6 +74,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -93,6 +102,9 @@
           ]
         },
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -104,6 +116,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -115,6 +130,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -145,6 +163,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -68,6 +74,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -93,6 +102,9 @@
           ]
         },
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -104,6 +116,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -115,6 +130,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -145,6 +163,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -68,6 +74,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -93,6 +102,9 @@
           ]
         },
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -104,6 +116,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -115,6 +130,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -145,6 +163,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -68,6 +74,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -93,6 +102,9 @@
           ]
         },
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -104,6 +116,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -115,6 +130,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -145,6 +163,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -68,6 +74,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -93,6 +102,9 @@
           ]
         },
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -104,6 +116,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -115,6 +130,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -145,6 +163,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -55,6 +61,9 @@
             "percentage" : 1,
             "totalLines" : 14
           },
+          "errors" : [
+
+          ],
           "name" : "XcodeprojExampleApp.swift",
           "warnings" : [
 
@@ -79,6 +88,9 @@
             "percentage" : 0,
             "totalLines" : 23
           },
+          "errors" : [
+
+          ],
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
@@ -117,6 +129,9 @@
       },
       "files" : [
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -128,6 +143,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
@@ -234,6 +252,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -284,6 +305,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -55,6 +61,9 @@
             "percentage" : 1,
             "totalLines" : 14
           },
+          "errors" : [
+
+          ],
           "name" : "XcodeprojExampleApp.swift",
           "warnings" : [
 
@@ -79,6 +88,9 @@
             "percentage" : 0,
             "totalLines" : 23
           },
+          "errors" : [
+
+          ],
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
@@ -117,6 +129,9 @@
       },
       "files" : [
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -128,6 +143,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
@@ -234,6 +252,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -284,6 +305,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
@@ -14,6 +14,9 @@
             "percentage" : 0.4411764705882353,
             "totalLines" : 34
           },
+          "errors" : [
+
+          ],
           "name" : "Calculator.swift",
           "warnings" : [
             {
@@ -44,6 +47,9 @@
             "percentage" : 0,
             "totalLines" : 36
           },
+          "errors" : [
+
+          ],
           "name" : "NumberHelper.swift",
           "warnings" : [
 
@@ -55,6 +61,9 @@
             "percentage" : 1,
             "totalLines" : 14
           },
+          "errors" : [
+
+          ],
           "name" : "XcodeprojExampleApp.swift",
           "warnings" : [
 
@@ -79,6 +88,9 @@
             "percentage" : 0,
             "totalLines" : 23
           },
+          "errors" : [
+
+          ],
           "name" : "TextProcessor.swift",
           "warnings" : [
             {
@@ -117,6 +129,9 @@
       },
       "files" : [
         {
+          "errors" : [
+
+          ],
           "name" : "ExampleSUITests",
           "warnings" : [
 
@@ -128,6 +143,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {
@@ -234,6 +252,9 @@
             "percentage" : 0.8507462686567164,
             "totalLines" : 67
           },
+          "errors" : [
+
+          ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
             {
@@ -284,6 +305,9 @@
             "percentage" : 0.9895833333333334,
             "totalLines" : 96
           },
+          "errors" : [
+
+          ],
           "name" : "XCTestTests.swift",
           "warnings" : [
             {

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
@@ -20,6 +20,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -28,6 +29,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -65,6 +67,7 @@
       ▿ files: 5 members
         ▿ File
           - coverage: Optional<Coverage>.none
+          - errors: 0 elements
           - name: "ExampleSUITests"
           - warnings: 0 elements
         ▿ File
@@ -73,6 +76,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -81,6 +85,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -113,6 +118,7 @@
               - coverage: 0.8507462686567164
               - coveredLines: 57
               - totalLines: 67
+          - errors: 0 elements
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -145,6 +151,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
@@ -20,6 +20,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -28,6 +29,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -65,6 +67,7 @@
       ▿ files: 5 members
         ▿ File
           - coverage: Optional<Coverage>.none
+          - errors: 0 elements
           - name: "ExampleSUITests"
           - warnings: 0 elements
         ▿ File
@@ -73,6 +76,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -81,6 +85,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -113,6 +118,7 @@
               - coverage: 0.8507462686567164
               - coveredLines: 57
               - totalLines: 67
+          - errors: 0 elements
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -145,6 +151,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
@@ -20,6 +20,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -28,6 +29,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -65,6 +67,7 @@
       ▿ files: 5 members
         ▿ File
           - coverage: Optional<Coverage>.none
+          - errors: 0 elements
           - name: "ExampleSUITests"
           - warnings: 0 elements
         ▿ File
@@ -73,6 +76,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -81,6 +85,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -113,6 +118,7 @@
               - coverage: 0.8507462686567164
               - coveredLines: 57
               - totalLines: 67
+          - errors: 0 elements
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -145,6 +151,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
@@ -20,6 +20,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -28,6 +29,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -65,6 +67,7 @@
       ▿ files: 5 members
         ▿ File
           - coverage: Optional<Coverage>.none
+          - errors: 0 elements
           - name: "ExampleSUITests"
           - warnings: 0 elements
         ▿ File
@@ -73,6 +76,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -81,6 +85,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -113,6 +118,7 @@
               - coverage: 0.8507462686567164
               - coveredLines: 57
               - totalLines: 67
+          - errors: 0 elements
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -145,6 +151,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
@@ -20,6 +20,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -28,6 +29,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -65,6 +67,7 @@
       ▿ files: 5 members
         ▿ File
           - coverage: Optional<Coverage>.none
+          - errors: 0 elements
           - name: "ExampleSUITests"
           - warnings: 0 elements
         ▿ File
@@ -73,6 +76,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -81,6 +85,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -113,6 +118,7 @@
               - coverage: 0.8507462686567164
               - coveredLines: 57
               - totalLines: 67
+          - errors: 0 elements
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -145,6 +151,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
@@ -15,6 +15,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 23
+          - errors: 0 elements
           - name: "TextProcessor.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -56,6 +57,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -64,6 +66,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -96,6 +99,7 @@
               - coverage: 1.0
               - coveredLines: 14
               - totalLines: 14
+          - errors: 0 elements
           - name: "XcodeprojExampleApp.swift"
           - warnings: 0 elements
       - name: "XcodeprojExample.app"
@@ -109,6 +113,7 @@
       ▿ files: 2 members
         ▿ File
           - coverage: Optional<Coverage>.none
+          - errors: 0 elements
           - name: "ExampleSUITests"
           - warnings: 0 elements
         ▿ File
@@ -117,6 +122,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 5 elements
             ▿ Issue
@@ -1144,6 +1150,7 @@
               - coverage: 0.8507462686567164
               - coveredLines: 57
               - totalLines: 67
+          - errors: 0 elements
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 4 elements
             ▿ Issue
@@ -1200,6 +1207,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 5 elements
             ▿ Issue

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
@@ -15,6 +15,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 23
+          - errors: 0 elements
           - name: "TextProcessor.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -56,6 +57,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -64,6 +66,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -96,6 +99,7 @@
               - coverage: 1.0
               - coveredLines: 14
               - totalLines: 14
+          - errors: 0 elements
           - name: "XcodeprojExampleApp.swift"
           - warnings: 0 elements
       - name: "XcodeprojExample.app"
@@ -109,6 +113,7 @@
       ▿ files: 2 members
         ▿ File
           - coverage: Optional<Coverage>.none
+          - errors: 0 elements
           - name: "ExampleSUITests"
           - warnings: 0 elements
         ▿ File
@@ -117,6 +122,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 5 elements
             ▿ Issue
@@ -1144,6 +1150,7 @@
               - coverage: 0.8507462686567164
               - coveredLines: 57
               - totalLines: 67
+          - errors: 0 elements
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 4 elements
             ▿ Issue
@@ -1200,6 +1207,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 5 elements
             ▿ Issue

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
@@ -15,6 +15,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 23
+          - errors: 0 elements
           - name: "TextProcessor.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -56,6 +57,7 @@
               - coverage: 0.0
               - coveredLines: 0
               - totalLines: 36
+          - errors: 0 elements
           - name: "NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
@@ -64,6 +66,7 @@
               - coverage: 0.4411764705882353
               - coveredLines: 15
               - totalLines: 34
+          - errors: 0 elements
           - name: "Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
@@ -96,6 +99,7 @@
               - coverage: 1.0
               - coveredLines: 14
               - totalLines: 14
+          - errors: 0 elements
           - name: "XcodeprojExampleApp.swift"
           - warnings: 0 elements
       - name: "XcodeprojExample.app"
@@ -109,6 +113,7 @@
       ▿ files: 2 members
         ▿ File
           - coverage: Optional<Coverage>.none
+          - errors: 0 elements
           - name: "ExampleSUITests"
           - warnings: 0 elements
         ▿ File
@@ -117,6 +122,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 5 elements
             ▿ Issue
@@ -1144,6 +1150,7 @@
               - coverage: 0.8507462686567164
               - coveredLines: 57
               - totalLines: 67
+          - errors: 0 elements
           - name: "SwiftTestingTests.swift"
           ▿ warnings: 4 elements
             ▿ Issue
@@ -1200,6 +1207,7 @@
               - coverage: 0.9895833333333334
               - coveredLines: 95
               - totalLines: 96
+          - errors: 0 elements
           - name: "XCTestTests.swift"
           ▿ warnings: 5 elements
             ▿ Issue

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-iOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-iOS_sonar.txt
@@ -1,5 +1,5 @@
 <testExecutions version="1">
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/ExampleSUITests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-iOS/ExampleSUITests.swift">
         <testCase name="async()" duration="35" />
         <testCase name="disabled()" duration="0">
             <skipped message="Test skipped: Disabled reason" />
@@ -19,7 +19,7 @@
         </testCase>
         <testCase name="withAttachment()" duration="2" />
     </file>
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/XCTestTests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-iOS/XCTestTests.swift">
         <testCase name="test_async()" duration="20" />
         <testCase name="test_asyncWithExpectation()" duration="16" />
         <testCase name="test_expectedFailure()" duration="966" />

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-macOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-macOS_sonar.txt
@@ -1,5 +1,5 @@
 <testExecutions version="1">
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/ExampleSUITests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-macOS/ExampleSUITests.swift">
         <testCase name="async()" duration="43" />
         <testCase name="disabled()" duration="2">
             <skipped message="Test skipped: Disabled reason" />
@@ -19,7 +19,7 @@
         </testCase>
         <testCase name="withAttachment()" duration="10" />
     </file>
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/XCTestTests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-macOS/XCTestTests.swift">
         <testCase name="test_async()" duration="14" />
         <testCase name="test_asyncWithExpectation()" duration="13" />
         <testCase name="test_expectedFailure()" duration="479" />

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-tvOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-tvOS_sonar.txt
@@ -1,5 +1,5 @@
 <testExecutions version="1">
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/ExampleSUITests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-tvOS/ExampleSUITests.swift">
         <testCase name="async()" duration="36" />
         <testCase name="disabled()" duration="0">
             <skipped message="Test skipped: Disabled reason" />
@@ -19,7 +19,7 @@
         </testCase>
         <testCase name="withAttachment()" duration="0" />
     </file>
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/XCTestTests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-tvOS/XCTestTests.swift">
         <testCase name="test_async()" duration="12" />
         <testCase name="test_asyncWithExpectation()" duration="13" />
         <testCase name="test_expectedFailure()" duration="420" />

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-visionOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-visionOS_sonar.txt
@@ -1,5 +1,5 @@
 <testExecutions version="1">
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/ExampleSUITests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-visionOS/ExampleSUITests.swift">
         <testCase name="async()" duration="45" />
         <testCase name="disabled()" duration="0">
             <skipped message="Test skipped: Disabled reason" />
@@ -19,7 +19,7 @@
         </testCase>
         <testCase name="withAttachment()" duration="8" />
     </file>
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/XCTestTests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-visionOS/XCTestTests.swift">
         <testCase name="test_async()" duration="14" />
         <testCase name="test_asyncWithExpectation()" duration="13" />
         <testCase name="test_expectedFailure()" duration="395" />

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-watchOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-watchOS_sonar.txt
@@ -1,5 +1,5 @@
 <testExecutions version="1">
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/ExampleSUITests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-watchOS/ExampleSUITests.swift">
         <testCase name="async()" duration="38" />
         <testCase name="disabled()" duration="0">
             <skipped message="Test skipped: Disabled reason" />
@@ -19,7 +19,7 @@
         </testCase>
         <testCase name="withAttachment()" duration="3" />
     </file>
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/XCTestTests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-watchOS/XCTestTests.swift">
         <testCase name="test_async()" duration="14" />
         <testCase name="test_asyncWithExpectation()" duration="11" />
         <testCase name="test_expectedFailure()" duration="265" />

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-iOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-iOS_sonar.txt
@@ -1,5 +1,5 @@
 <testExecutions version="1">
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/ExampleSUITests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-iOS/ExampleSUITests.swift">
         <testCase name="async()" duration="362" />
         <testCase name="disabled()" duration="2">
             <skipped message="Test skipped: Disabled reason" />
@@ -19,7 +19,7 @@
         </testCase>
         <testCase name="withAttachment()" duration="109" />
     </file>
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/XCTestTests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-iOS/XCTestTests.swift">
         <testCase name="test_async()" duration="13" />
         <testCase name="test_asyncWithExpectation()" duration="11" />
         <testCase name="test_expectedFailure()" duration="395" />

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-macOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-macOS_sonar.txt
@@ -1,5 +1,5 @@
 <testExecutions version="1">
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/ExampleSUITests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-macOS/ExampleSUITests.swift">
         <testCase name="async()" duration="35" />
         <testCase name="disabled()" duration="0">
             <skipped message="Test skipped: Disabled reason" />
@@ -19,7 +19,7 @@
         </testCase>
         <testCase name="withAttachment()" duration="2" />
     </file>
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/XCTestTests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-macOS/XCTestTests.swift">
         <testCase name="test_async()" duration="13" />
         <testCase name="test_asyncWithExpectation()" duration="11" />
         <testCase name="test_expectedFailure()" duration="63" />

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-visionOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-visionOS_sonar.txt
@@ -1,5 +1,5 @@
 <testExecutions version="1">
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/ExampleSUITests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-visionOS/ExampleSUITests.swift">
         <testCase name="async()" duration="61" />
         <testCase name="disabled()" duration="19">
             <skipped message="Test skipped: Disabled reason" />
@@ -19,7 +19,7 @@
         </testCase>
         <testCase name="withAttachment()" duration="26" />
     </file>
-    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)/XCTestTests.swift">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-visionOS/XCTestTests.swift">
         <testCase name="test_async()" duration="14" />
         <testCase name="test_asyncWithExpectation()" duration="12" />
         <testCase name="test_expectedFailure()" duration="1198" />


### PR DESCRIPTION
## Summary

Resolves #165. `xcrun xcresulttool get build-results --format json` returns `errors[]` alongside `warnings[]` with identical shape — Peekie was decoding only `warnings[]`. Use cases like "list reasons a build failed", "track broken commits", "pre-merge sanity check" were unreachable through the SDK. Mirror the warnings pipeline at every layer.

## Key Changes

- `BuildResultsDTO` gains `errors: [Issue]` with `decodeIfPresent ?? []` for both arrays (tolerates missing keys on success builds). Same `Issue` type, same `fileName`/`location` helpers.
- `Report`, `Report.Module`, `Report.Module.File` each expose an `errors` array symmetric to `warnings`. `File` gets an explicit `public init(name:warnings:errors:coverage:)` with defaults so external callers (if any) aren't broken.
- `Report+Warnings` extracts the per-file grouping logic into a private `parseIssues(_:)` helper; `parseWarnings(from:)` and new `parseErrors(from:)` both delegate to it. Lookup/merge helpers renamed `warningsFor` → `issuesFor`, `mergeWarnings` → `mergeIssues` — broader name, same semantics.
- `Report+Convenience` builds an `errorsByFileName` map alongside `warningsByFileName` and plumbs both through `File` creation/merge at both call sites.
- `JsonFormatter` surfaces `"errors": [...]` symmetric to `"warnings": [...]`.

## Out of scope (deferred)

The issue's open question about project-level errors (`sourceURL == nil` — link errors, missing files) — currently dropped, same behavior as warnings. None of the existing fixtures hit that path (`errorCount=0` everywhere), so the silent-drop is invisible today. If real broken-build fixtures show pain, a top-level `Report.unboundErrors` bucket can be a follow-up. Tests assert the drop is intentional, not accidental.

## Additional Changes

_None._