### PR TITLE
Refactor Report around File primary, Module as projection

### DIFF
--- a/Sources/PeekieSDK/Formatters/JsonFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/JsonFormatter.swift
@@ -95,7 +95,7 @@ private struct JsonCoverage: Encodable {
         self.percentage = coverage.coverage
     }
 
-    init(from coverage: Report.Module.File.Coverage) {
+    init(from coverage: Report.File.Coverage) {
         self.coveredLines = coverage.coveredLines
         self.totalLines = coverage.totalLines
         self.percentage = coverage.coverage
@@ -108,7 +108,7 @@ private struct JsonFile: Encodable {
     let warnings: [JsonIssue]
     let errors: [JsonIssue]
 
-    init(from file: Report.Module.File) {
+    init(from file: Report.File) {
         self.name = file.name
         self.coverage = file.coverage.map { JsonCoverage(from: $0) }
         self.warnings = file.warnings.map { JsonIssue(from: $0) }
@@ -119,9 +119,9 @@ private struct JsonFile: Encodable {
 private struct JsonIssue: Encodable {
     let message: String
     let type: String
-    let location: Report.Module.File.Issue.Location?
+    let location: Report.File.Issue.Location?
 
-    init(from issue: Report.Module.File.Issue) {
+    init(from issue: Report.File.Issue) {
         self.type = issue.type.rawValue
         self.message = issue.message
         self.location = issue.location

--- a/Sources/PeekieSDK/Models/DTO/BuildResultsDTO.swift
+++ b/Sources/PeekieSDK/Models/DTO/BuildResultsDTO.swift
@@ -39,7 +39,7 @@ extension BuildResultsDTO.Issue {
     /// Parses Apple's `sourceURL` fragment (`...#StartingLineNumber=N&...`) into a typed location.
     /// Returns `nil` when `sourceURL` is absent, has no fragment, or the fragment carries no
     /// `StartingLineNumber` key — line is the minimum we need to surface a location at all.
-    var location: Report.Module.File.Issue.Location? {
+    var location: Report.File.Issue.Location? {
         guard let sourceURL else { return nil }
         guard
             let fragment = sourceURL.split(separator: "#", maxSplits: 1).dropFirst().first

--- a/Sources/PeekieSDK/Models/Report+Convenience.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience.swift
@@ -3,13 +3,20 @@ import Logging
 
 extension Report {
     private static let logger = Logger(label: "com.peekie.report")
+
     /// Initializes a new instance of the `Report` using the provided `xcresultPath`.
-    /// The initialization process involves parsing the `.xcresult` file to extract various reports.
+    ///
+    /// `files` is built as the primary index — every file the bundle has any signal about
+    /// (coverage, warnings, errors) appears exactly once. `modules` is a projection: one
+    /// entry per known target name, files filtered by `File.module`, test suites
+    /// attached by target. Files belonging to test-less targets or to project-level
+    /// build issues with no module signal still appear in `files` (with `module == nil`),
+    /// so their warnings/errors are not silently lost.
     ///
     /// - Parameters:
     ///   - xcresultPath: The file URL of the `.xcresult` file to parse.
     ///   - includeCoverage: Whether to parse and include code coverage data. Defaults to `true`.
-    ///   - includeWarnings: Whether to parse and include build warnings. Defaults to `true`.
+    ///   - includeWarnings: Whether to parse and include build warnings/errors. Defaults to `true`.
     /// - Throws: An error if the `.xcresult` file cannot be parsed.
     public init(
         xcresultPath: URL,
@@ -26,38 +33,15 @@ extension Report {
         )
 
         let testResultsDTO = try await TestResultsDTO(from: xcresultPath)
-        Self.logger.debug("TestResultsDTO loaded")
-
         let buildResultsDTO: BuildResultsDTO? =
             includeWarnings ? try await BuildResultsDTO(from: xcresultPath) : nil
-        if includeWarnings {
-            Self.logger.debug("BuildResultsDTO loaded")
-        }
-
         let coverageReportDTO: CoverageReportDTO? =
             includeCoverage ? try await CoverageReportDTO(from: xcresultPath) : nil
-        if includeCoverage {
-            Self.logger.debug("CoverageReportDTO loaded")
-        }
 
-        // Build a map of file paths to coverage data
-        var fileCoverageMap: [String: FileCoverageDTO] = [:]
-        if let coverageReportDTO = coverageReportDTO {
-            for target in coverageReportDTO.targets {
-                for fileCoverage in target.files {
-                    // Use both path and name as keys for matching
-                    let path = fileCoverage.path
-                    let name = fileCoverage.name
-                    fileCoverageMap[path] = fileCoverage
-                    fileCoverageMap[name] = fileCoverage
-                }
-            }
-        }
-
-        // Parse warnings and errors from build results
-        let warningsByFileName: [String: [Report.Module.File.Issue]]
-        let errorsByFileName: [String: [Report.Module.File.Issue]]
-        if let buildResultsDTO = buildResultsDTO {
+        // Parse build issues
+        let warningsByFileName: [String: [File.Issue]]
+        let errorsByFileName: [String: [File.Issue]]
+        if let buildResultsDTO {
             warningsByFileName = await Self.parseWarnings(from: buildResultsDTO)
             errorsByFileName = await Self.parseErrors(from: buildResultsDTO)
         } else {
@@ -65,510 +49,385 @@ extension Report {
             errorsByFileName = [:]
         }
 
-        var modules = Set<Module>()
+        let files = Self.buildFiles(
+            coverageReportDTO: coverageReportDTO,
+            warningsByFileName: warningsByFileName,
+            errorsByFileName: errorsByFileName
+        )
 
-        // Process test nodes: Test Plan -> Unit test bundle -> Test Suite -> Test Case -> Repetition
-        for rootNode in testResultsDTO.testNodes {
-            // Root node is "Test Plan", process its children (Unit test bundles)
-            guard rootNode.nodeType == .testPlan, let unitTestBundles = rootNode.children else {
-                continue
-            }
-
-            for testNode in unitTestBundles {
-                guard testNode.nodeType == .unitTestBundle else { continue }
-
-                // Extract module name from unit test bundle name (e.g., "PeekieTests")
-                let moduleName = testNode.name
-                Self.logger.debug(
-                    "Processing module",
-                    metadata: [
-                        "moduleName": "\(moduleName)"
-                    ]
-                )
-
-                // Find coverage suites for this module
-                // Coverage is organized by target (source module), not test module
-                // We need to find all coverage suites that belong to this test module's source
-                var moduleCoverageFiles: [String: FileCoverageDTO] = [:]
-                var matchedTargetCoverage: Report.Coverage? = nil
-                if let coverageReportDTO = coverageReportDTO {
-                    for target in coverageReportDTO.targets {
-                        // Try to match target name with module name
-                        // Module name is like "MyPackageTests", target might be "MyPackage"
-                        let targetBaseName = target.name.replacingOccurrences(of: "Tests", with: "")
-                        let moduleBaseName = moduleName.replacingOccurrences(of: "Tests", with: "")
-
-                        if target.name == moduleName || targetBaseName == moduleBaseName
-                            || moduleName.contains(target.name)
-                            || target.name.contains(moduleBaseName)
-                        {
-                            // Store target-level coverage
-                            if target.executableLines > 0 {
-                                matchedTargetCoverage = Report.Coverage(
-                                    coveredLines: target.coveredLines,
-                                    totalLines: target.executableLines,
-                                    coverage: target.lineCoverage
-                                )
-                            }
-
-                            for fileCoverage in target.files {
-                                // Use suite name (without path) as key
-                                moduleCoverageFiles[fileCoverage.name] = fileCoverage
-                                // Also use path as key for matching
-                                moduleCoverageFiles[fileCoverage.path] = fileCoverage
-                            }
-                        }
-                    }
-                }
-
-                var module =
-                    modules[moduleName]
-                    ?? Report.Module(
-                        name: moduleName,
-                        suites: [],
-                        files: [],
-                        coverage: matchedTargetCoverage
-                    )
-
-                // Process test suites
-                guard let testSuites = testNode.children else { continue }
-                for testSuite in testSuites {
-                    guard testSuite.nodeType == .testSuite else { continue }
-
-                    // Extract suite name from test suite name (e.g., "ReportTests")
-                    let suiteName = testSuite.name
-
-                    Self.logger.debug(
-                        "Parsing Test Suite",
-                        metadata: [
-                            "suiteName": "\(suiteName)",
-                            "module": "\(moduleName)",
-                        ]
-                    )
-
-                    // Store nodeIdentifierURL for fileName computation
-                    guard let nodeIdentifierURL = testSuite.nodeIdentifierURL else {
-                        // Skip test suites without nodeIdentifierURL (should not happen in practice)
-                        Self.logger.debug(
-                            "Skipping Test Suite: missing nodeIdentifierURL",
-                            metadata: [
-                                "suiteName": "\(suiteName)",
-                                "module": "\(moduleName)",
-                            ]
-                        )
-                        continue
-                    }
-
-                    Self.logger.debug(
-                        "Creating Suite from DTO",
-                        metadata: [
-                            "suiteName": "\(suiteName)",
-                            "module": "\(moduleName)",
-                            "nodeIdentifierURL": "\(nodeIdentifierURL)",
-                        ]
-                    )
-
-                    // Try to find coverage for this file by name or path
-                    let fileCoverage: Report.Module.File.Coverage?
-                    if includeCoverage {
-                        // First try by exact suite name
-                        if let coverageDTO = fileCoverageMap[suiteName] {
-                            fileCoverage = Report.Module.File.Coverage(from: coverageDTO)
-                        } else {
-                            // Try with .swift extension
-                            let suiteNameWithExtension = suiteName + ".swift"
-                            if let coverageDTO = fileCoverageMap[suiteNameWithExtension] {
-                                fileCoverage = Report.Module.File.Coverage(from: coverageDTO)
-                            } else {
-                                // Try to match by extracting base name from test suite
-                                // Test suite names might be like "ReportTests" but file might be "Report.swift"
-                                let baseName = suiteName.replacingOccurrences(of: "Tests", with: "")
-                                let possibleNames = [
-                                    baseName + ".swift",
-                                    baseName,
-                                ]
-                                var found: FileCoverageDTO? = nil
-                                for possibleName in possibleNames {
-                                    if let coverageDTO = fileCoverageMap[possibleName] {
-                                        found = coverageDTO
-                                        break
-                                    }
-                                }
-                                if found == nil {
-                                    // Try to find in module-specific coverage files
-                                    for (key, coverageDTO) in moduleCoverageFiles {
-                                        // Match by exact key or by comparing names (with/without .swift)
-                                        let coverageNameWithoutExt =
-                                            coverageDTO.name.hasSuffix(".swift")
-                                            ? String(coverageDTO.name.dropLast(6))
-                                            : coverageDTO.name
-                                        if key == suiteName
-                                            || key == suiteName + ".swift"
-                                            || key.contains(suiteName)
-                                            || suiteName == coverageNameWithoutExt
-                                            || suiteName == coverageDTO.name
-                                        {
-                                            found = coverageDTO
-                                            break
-                                        }
-                                    }
-                                }
-                                if found == nil {
-                                    // Try to find by matching suite name in path
-                                    for (path, coverageDTO) in fileCoverageMap {
-                                        // Match by exact path or by comparing names (with/without .swift)
-                                        let coverageNameWithoutExt =
-                                            coverageDTO.name.hasSuffix(".swift")
-                                            ? String(coverageDTO.name.dropLast(6))
-                                            : coverageDTO.name
-                                        if path == suiteName
-                                            || path == suiteName + ".swift"
-                                            || path.contains(suiteName)
-                                            || suiteName == coverageNameWithoutExt
-                                            || suiteName == coverageDTO.name
-                                        {
-                                            found = coverageDTO
-                                            break
-                                        }
-                                    }
-                                }
-                                fileCoverage = found.map { Report.Module.File.Coverage(from: $0) }
-                            }
-                        }
-                    } else {
-                        fileCoverage = nil
-                    }
-
-                    // Try to get file name from coverage DTO or use suite name
-                    var fileName = suiteName
-                    if let coverageDTO = fileCoverageMap[suiteName] {
-                        fileName = coverageDTO.name
-                    } else if let coverageDTO = fileCoverageMap[suiteName + ".swift"] {
-                        fileName = coverageDTO.name
-                    } else {
-                        // Try to find in moduleCoverageFiles
-                        for (key, coverageDTO) in moduleCoverageFiles {
-                            if key == suiteName || key == suiteName + ".swift" {
-                                fileName = coverageDTO.name
-                                break
-                            }
-                        }
-                    }
-
-                    // Get or create File with coverage, warnings and errors
-                    let fileWarnings: [Report.Module.File.Issue] =
-                        includeWarnings
-                        ? Self.issuesFor(fileName: fileName, in: warningsByFileName)
-                        : []
-                    let fileErrors: [Report.Module.File.Issue] =
-                        includeWarnings
-                        ? Self.issuesFor(fileName: fileName, in: errorsByFileName)
-                        : []
-
-                    var file = module.files[fileName]
-                    if file == nil {
-                        file = Report.Module.File(
-                            name: fileName,
-                            warnings: fileWarnings,
-                            errors: fileErrors,
-                            coverage: fileCoverage
-                        )
-                        module.files.insert(file!)
-                    } else {
-                        // Merge warnings/errors if file already exists
-                        if includeWarnings && !fileWarnings.isEmpty {
-                            file!.warnings = Self.mergeIssues(file!.warnings, fileWarnings)
-                        }
-                        if includeWarnings && !fileErrors.isEmpty {
-                            file!.errors = Self.mergeIssues(file!.errors, fileErrors)
-                        }
-                    }
-
-                    // Get existing suite or create new one
-                    var suite: Report.Module.Suite
-                    if let existingSuite = module.suites[suiteName] {
-                        Self.logger.debug(
-                            "Using existing Suite",
-                            metadata: [
-                                "suiteName": "\(suiteName)",
-                                "module": "\(moduleName)",
-                            ]
-                        )
-                        suite = existingSuite
-                    } else {
-                        Self.logger.debug(
-                            "Created new Suite",
-                            metadata: [
-                                "suiteName": "\(suiteName)",
-                                "module": "\(moduleName)",
-                            ]
-                        )
-                        suite = .init(
-                            name: suiteName,
-                            nodeIdentifierURL: nodeIdentifierURL,
-                            repeatableTests: []
-                        )
-                    }
-
-                    // Process test cases
-                    guard let testCases = testSuite.children else { continue }
-                    for testCase in testCases {
-                        guard testCase.nodeType == .testCase else { continue }
-
-                        let testName = testCase.name
-                        var repeatableTest =
-                            suite.repeatableTests[testName]
-                            ?? Report.Module.Suite.RepeatableTest(
-                                name: testName,
-                                tests: []
-                            )
-
-                        // Filter out metadata nodes from test case children
-                        let filteredTestCaseChildren = (testCase.children ?? []).filter {
-                            !$0.isMetadata
-                        }
-
-                        // Process test case children and create Test objects with paths
-                        func processNode(
-                            _ node: TestResultsDTO.TestNode,
-                            path: [Report.Module.Suite.RepeatableTest.PathNode],
-                            testCase: TestResultsDTO.TestNode
-                        ) throws {
-                            // Check if this node should be added to path
-                            let pathNode: Report.Module.Suite.RepeatableTest.PathNode?
-                            switch node.nodeType {
-                            case .device, .arguments, .repetition:
-                                // Convert result from DTO to Test.Status
-                                let result: Report.Module.Suite.RepeatableTest.Test.Status? = {
-                                    guard let dtoResult = node.result else { return nil }
-                                    switch dtoResult {
-                                    case .passed:
-                                        return .success
-                                    case .failed:
-                                        return .failure
-                                    case .skipped:
-                                        return .skipped
-                                    case .expectedFailure:
-                                        return .expectedFailure
-                                    }
-                                }()
-
-                                // Convert duration from DTO
-                                let duration: Measurement<UnitDuration>? = {
-                                    guard let durationSeconds = node.durationInSeconds else {
-                                        return nil
-                                    }
-                                    return .init(
-                                        value: durationSeconds * 1000,
-                                        unit: Report.Module.Suite.RepeatableTest.Test
-                                            .defaultDurationUnit
-                                    )
-                                }()
-
-                                // Extract message from DTO
-                                let message = node.failureMessage ?? node.skipMessage
-
-                                pathNode = Report.Module.Suite.RepeatableTest.PathNode(
-                                    name: node.name,
-                                    type: .init(from: node.nodeType),
-                                    result: result,
-                                    duration: duration,
-                                    message: message
-                                )
-                            default:
-                                pathNode = nil
-                            }
-
-                            var newPath = path
-                            if let pathNode = pathNode {
-                                newPath.append(pathNode)
-                            }
-
-                            // If this is a repetition node, create test and stop recursion
-                            if node.nodeType == .repetition {
-                                let test = try Report.Module.Suite.RepeatableTest.Test(
-                                    from: node,
-                                    path: newPath,
-                                    testCaseName: testCase.name,
-                                    testCase: testCase
-                                )
-                                repeatableTest.tests.append(test)
-                                return
-                            }
-
-                            guard let nodeChildren = node.children else {
-                                // Leaf node - create test if it's an arguments node without children
-                                if node.nodeType == .arguments {
-                                    let test = Report.Module.Suite.RepeatableTest.Test(
-                                        from: node,
-                                        path: newPath,
-                                        testCase: testCase
-                                    )
-                                    repeatableTest.tests.append(test)
-                                }
-                                return
-                            }
-
-                            // Filter out metadata nodes from node children
-                            let filteredNodeChildren = nodeChildren.filter { !$0.isMetadata }
-
-                            // If this is an arguments node, check if it has repetitions
-                            if node.nodeType == .arguments {
-                                let hasRepetitions = filteredNodeChildren.contains {
-                                    $0.nodeType == .repetition
-                                }
-                                if !hasRepetitions {
-                                    // Arguments without repetitions - create test and stop recursion
-                                    let test = Report.Module.Suite.RepeatableTest.Test(
-                                        from: node,
-                                        path: newPath,
-                                        testCase: testCase
-                                    )
-                                    repeatableTest.tests.append(test)
-                                    return
-                                }
-                                // Arguments with repetitions - continue recursion to process repetitions
-                            }
-
-                            // Recursively process children (already filtered)
-                            for child in filteredNodeChildren {
-                                try processNode(child, path: newPath, testCase: testCase)
-                            }
-                        }
-
-                        // Start processing from filtered test case children
-                        for child in filteredTestCaseChildren {
-                            try processNode(child, path: [], testCase: testCase)
-                        }
-
-                        // If no tests were created (no children or only metadata), create test from test case itself
-                        if repeatableTest.tests.isEmpty {
-                            let test = Report.Module.Suite.RepeatableTest.Test(from: testCase)
-                            repeatableTest.tests.append(test)
-                        }
-
-                        suite.repeatableTests.update(with: repeatableTest)
-                    }
-
-                    module.suites.update(with: suite)
-                }
-
-                // Update module in set, preserving coverage
-                if let existingModule = modules[moduleName] {
-                    modules.remove(existingModule)
-                }
-                modules.insert(module)
-            }
+        // Build suites grouped by their test bundle name; alias test-bundle names to
+        // canonical coverage-target names so they project onto the same Module.
+        let suitesByBundle = Self.buildSuites(from: testResultsDTO)
+        let coverageTargetNames = Set(coverageReportDTO?.targets.map(\.name) ?? [])
+        let aliasing = Self.aliasTestBundlesToCoverageTargets(
+            testBundleNames: Set(suitesByBundle.keys),
+            coverageTargetNames: coverageTargetNames
+        )
+        var suitesByModule: [String: [Module.Suite]] = [:]
+        for (bundle, suites) in suitesByBundle {
+            let canonical = aliasing[bundle] ?? bundle
+            suitesByModule[canonical, default: []].append(contentsOf: suites)
         }
 
-        // Add all suites with coverage to modules, even if they don't have test suites
-        if let coverageReportDTO = coverageReportDTO {
-            for target in coverageReportDTO.targets {
-                // Create coverage from target-level data if available
-                let targetCoverage: Report.Coverage? = {
-                    guard target.executableLines > 0 else { return nil }
-                    return Report.Coverage(
-                        coveredLines: target.coveredLines,
-                        totalLines: target.executableLines,
-                        coverage: target.lineCoverage
-                    )
-                }()
+        let modules = Self.buildModules(
+            files: files,
+            suitesByModule: suitesByModule,
+            coverageReportDTO: coverageReportDTO
+        )
 
-                // Try to find existing module by target name or create a new one
-                // Target name might be like "MyPackage", module might be "MyPackageTests"
-                var moduleName = target.name
-                var existingModule = modules[moduleName]
+        let totalCoverage: Double? = Self.computeTotalCoverage(
+            includeCoverage: includeCoverage,
+            coverageReportDTO: coverageReportDTO,
+            files: files
+        )
 
-                // If not found, try to find module with "Tests" suffix
-                if existingModule == nil {
-                    let moduleNameWithTests = target.name + "Tests"
-                    if let foundModule = modules[moduleNameWithTests] {
-                        existingModule = foundModule
-                        moduleName = moduleNameWithTests
-                    }
-                }
-
-                // Start with existing module suites and files or empty sets
-                let moduleSuites = existingModule?.suites ?? Set<Report.Module.Suite>()
-                var moduleFiles = existingModule?.files ?? Set<Report.Module.File>()
-
-                // Determine module coverage: use target coverage if module doesn't have one, or keep existing
-                let moduleCoverage = existingModule?.coverage ?? targetCoverage
-
-                // Add all coverage files to this module
-                for fileCoverageDTO in target.files {
-                    let coverage = Report.Module.File.Coverage(from: fileCoverageDTO)
-                    // Use the name as it appears in xcresult
-                    let fileName = fileCoverageDTO.name
-
-                    // Get warnings and errors for this file
-                    let fileWarnings: [Report.Module.File.Issue] =
-                        includeWarnings
-                        ? Self.issuesFor(fileName: fileName, in: warningsByFileName)
-                        : []
-                    let fileErrors: [Report.Module.File.Issue] =
-                        includeWarnings
-                        ? Self.issuesFor(fileName: fileName, in: errorsByFileName)
-                        : []
-
-                    // Create or update File with coverage, warnings and errors
-                    var file = moduleFiles[fileName]
-                    if file == nil {
-                        file = Report.Module.File(
-                            name: fileName,
-                            warnings: fileWarnings,
-                            errors: fileErrors,
-                            coverage: coverage
-                        )
-                        moduleFiles.insert(file!)
-                    } else {
-                        // Merge warnings/errors if file already exists
-                        if includeWarnings && !fileWarnings.isEmpty {
-                            file!.warnings = Self.mergeIssues(file!.warnings, fileWarnings)
-                        }
-                        if includeWarnings && !fileErrors.isEmpty {
-                            file!.errors = Self.mergeIssues(file!.errors, fileErrors)
-                        }
-                    }
-                }
-
-                // Remove old module if it existed and add updated one
-                if let oldModule = existingModule {
-                    modules.remove(oldModule)
-                }
-
-                // Create or update module with all suites, files and coverage
-                let updatedModule = Report.Module(
-                    name: moduleName, suites: moduleSuites, files: moduleFiles,
-                    coverage: moduleCoverage)
-                modules.insert(updatedModule)
-            }
-        }
-
-        // Use total coverage from xcresult file if available, otherwise calculate from suites
-        let totalCoverage: Double? =
-            includeCoverage
-            ? {
-                if let lineCoverage = coverageReportDTO?.lineCoverage, lineCoverage > 0 {
-                    return lineCoverage
-                }
-
-                let fileCoverages = modules.flatMap { $0.files }.compactMap { $0.coverage }
-                guard !fileCoverages.isEmpty else { return nil }
-                let totalLines = fileCoverages.reduce(0) { $0 + $1.totalLines }
-                let totalCoveredLines = fileCoverages.reduce(0) { $0 + $1.coveredLines }
-                return totalLines != 0 ? Double(totalCoveredLines) / Double(totalLines) : 0.0
-            }() : nil
-
+        self.files = files
         self.modules = modules
         self.coverage = totalCoverage
 
         Self.logger.debug(
             "Report initialization completed",
             metadata: [
-                "modulesCount": "\(modules.count)",
+                "files": "\(files.count)",
+                "modules": "\(modules.count)",
                 "totalCoverage": totalCoverage.map { "\($0)" } ?? "nil",
             ]
         )
+    }
+
+    // MARK: - File index
+
+    /// Seeds the file index from coverage (paths give us identity and module attribution),
+    /// then folds in warnings/errors keyed by basename. Issues whose basename matches an
+    /// already-indexed file attach to it. Issues whose basename matches nothing produce a
+    /// new `File` with `module == nil` — these come from test-less targets that coverage
+    /// didn't see.
+    private static func buildFiles(
+        coverageReportDTO: CoverageReportDTO?,
+        warningsByFileName: [String: [File.Issue]],
+        errorsByFileName: [String: [File.Issue]]
+    ) -> [File] {
+        // path → builder
+        var byPath: [String: FileBuilder] = [:]
+        // basename → set of paths (for issue attribution); a basename can map to several
+        // distinct files (e.g. helper file in two targets).
+        var pathsByBasename: [String: [String]] = [:]
+
+        if let coverageReportDTO {
+            for target in coverageReportDTO.targets {
+                for fc in target.files {
+                    let key = fc.path
+                    byPath[key] = FileBuilder(
+                        name: fc.name,
+                        path: fc.path,
+                        module: target.name,
+                        coverage: File.Coverage(from: fc)
+                    )
+                    pathsByBasename[fc.name, default: []].append(fc.path)
+                    // Also index by stem (without .swift) so a warning fileName "Foo" can
+                    // find "Foo.swift" coverage.
+                    if fc.name.hasSuffix(".swift") {
+                        let stem = String(fc.name.dropLast(6))
+                        pathsByBasename[stem, default: []].append(fc.path)
+                    }
+                }
+            }
+        }
+
+        // For files known only from build issues: keyed by basename (no path).
+        var byBasename: [String: FileBuilder] = [:]
+
+        func attach(issues: [String: [File.Issue]], asErrors: Bool) {
+            for (basename, list) in issues {
+                if let paths = pathsByBasename[basename], let firstPath = paths.first {
+                    // Attach to every coverage-matched file with that basename — typically one.
+                    for path in paths {
+                        if asErrors {
+                            byPath[path]?.errors.append(contentsOf: list)
+                        } else {
+                            byPath[path]?.warnings.append(contentsOf: list)
+                        }
+                    }
+                    _ = firstPath  // silence "unused" if future change drops the var
+                } else {
+                    let key = basename
+                    if byBasename[key] == nil {
+                        byBasename[key] = FileBuilder(
+                            name: basename,
+                            path: nil,
+                            module: nil,
+                            coverage: nil
+                        )
+                    }
+                    if asErrors {
+                        byBasename[key]?.errors.append(contentsOf: list)
+                    } else {
+                        byBasename[key]?.warnings.append(contentsOf: list)
+                    }
+                }
+            }
+        }
+
+        attach(issues: warningsByFileName, asErrors: false)
+        attach(issues: errorsByFileName, asErrors: true)
+
+        let pathed = byPath.values.map { $0.build() }
+        let unpathed = byBasename.values.map { $0.build() }
+
+        return (pathed + unpathed).sorted { lhs, rhs in
+            let lk = lhs.path ?? lhs.name
+            let rk = rhs.path ?? rhs.name
+            return lk < rk
+        }
+    }
+
+    private struct FileBuilder {
+        var name: String
+        var path: String?
+        var module: String?
+        var coverage: File.Coverage?
+        var warnings: [File.Issue] = []
+        var errors: [File.Issue] = []
+
+        func build() -> File {
+            File(
+                name: name,
+                path: path,
+                module: module,
+                coverage: coverage,
+                warnings: warnings,
+                errors: errors
+            )
+        }
+    }
+
+    // MARK: - Suite parsing
+
+    /// Walks `testResultsDTO` and produces a `[testBundleName: [Suite]]` mapping. The
+    /// bundle name comes straight from the unit test bundle node — aliasing to a
+    /// coverage-target name (e.g. `PeekieTests` → `Peekie`) happens at the call site.
+    private static func buildSuites(
+        from testResultsDTO: TestResultsDTO
+    ) -> [String: [Module.Suite]] {
+        var byBundle: [String: [Module.Suite]] = [:]
+
+        for rootNode in testResultsDTO.testNodes where rootNode.nodeType == .testPlan {
+            guard let unitTestBundles = rootNode.children else { continue }
+            for testNode in unitTestBundles where testNode.nodeType == .unitTestBundle {
+                let bundleName = testNode.name
+                var suites: [Module.Suite] = []
+                for testSuite in testNode.children ?? [] where testSuite.nodeType == .testSuite {
+                    guard let nodeIdentifierURL = testSuite.nodeIdentifierURL else { continue }
+                    let suite = buildSuite(
+                        from: testSuite,
+                        nodeIdentifierURL: nodeIdentifierURL
+                    )
+                    suites.append(suite)
+                }
+                byBundle[bundleName, default: []].append(contentsOf: suites)
+            }
+        }
+
+        return byBundle
+    }
+
+    private static func buildSuite(
+        from testSuite: TestResultsDTO.TestNode,
+        nodeIdentifierURL: String
+    ) -> Module.Suite {
+        var repeatableTests: Set<Module.Suite.RepeatableTest> = []
+        let filteredCases = (testSuite.children ?? []).filter { !$0.isMetadata }
+        for testCase in filteredCases where testCase.nodeType == .testCase {
+            var repeatable = Module.Suite.RepeatableTest(name: testCase.name, tests: [])
+
+            let filteredChildren = (testCase.children ?? []).filter { !$0.isMetadata }
+            for child in filteredChildren {
+                processTestNode(
+                    child,
+                    path: [],
+                    testCase: testCase,
+                    into: &repeatable
+                )
+            }
+
+            if repeatable.tests.isEmpty {
+                repeatable.tests.append(.init(from: testCase))
+            }
+            repeatableTests.insert(repeatable)
+        }
+
+        return Module.Suite(
+            name: testSuite.name,
+            nodeIdentifierURL: nodeIdentifierURL,
+            repeatableTests: repeatableTests
+        )
+    }
+
+    private static func processTestNode(
+        _ node: TestResultsDTO.TestNode,
+        path: [Module.Suite.RepeatableTest.PathNode],
+        testCase: TestResultsDTO.TestNode,
+        into repeatable: inout Module.Suite.RepeatableTest
+    ) {
+        let pathNode: Module.Suite.RepeatableTest.PathNode?
+        switch node.nodeType {
+        case .device, .arguments, .repetition:
+            let result: Module.Suite.RepeatableTest.Test.Status? = {
+                guard let r = node.result else { return nil }
+                switch r {
+                case .passed: return .success
+                case .failed: return .failure
+                case .skipped: return .skipped
+                case .expectedFailure: return .expectedFailure
+                }
+            }()
+            let duration: Measurement<UnitDuration>? = node.durationInSeconds.map {
+                .init(value: $0 * 1000, unit: Module.Suite.RepeatableTest.Test.defaultDurationUnit)
+            }
+            pathNode = .init(
+                name: node.name,
+                type: .init(from: node.nodeType),
+                result: result,
+                duration: duration,
+                message: node.failureMessage ?? node.skipMessage
+            )
+        default:
+            pathNode = nil
+        }
+
+        var newPath = path
+        if let pathNode { newPath.append(pathNode) }
+
+        if node.nodeType == .repetition {
+            do {
+                let test = try Module.Suite.RepeatableTest.Test(
+                    from: node,
+                    path: newPath,
+                    testCaseName: testCase.name,
+                    testCase: testCase
+                )
+                repeatable.tests.append(test)
+            } catch {
+                // Skip malformed repetition node; we surface what we can.
+            }
+            return
+        }
+
+        guard let nodeChildren = node.children else {
+            if node.nodeType == .arguments {
+                let test = Module.Suite.RepeatableTest.Test(
+                    from: node,
+                    path: newPath,
+                    testCase: testCase
+                )
+                repeatable.tests.append(test)
+            }
+            return
+        }
+
+        let filteredChildren = nodeChildren.filter { !$0.isMetadata }
+
+        if node.nodeType == .arguments {
+            let hasRepetitions = filteredChildren.contains { $0.nodeType == .repetition }
+            if !hasRepetitions {
+                let test = Module.Suite.RepeatableTest.Test(
+                    from: node,
+                    path: newPath,
+                    testCase: testCase
+                )
+                repeatable.tests.append(test)
+                return
+            }
+        }
+
+        for child in filteredChildren {
+            processTestNode(child, path: newPath, testCase: testCase, into: &repeatable)
+        }
+    }
+
+    // MARK: - Module projection
+
+    /// Maps test-bundle names to their canonical coverage-target names so suites land on
+    /// the same Module as coverage. Mirrors the matching rules used in `4.x`:
+    /// equality, equality after stripping a `Tests` suffix, or one name containing the
+    /// other's base name.
+    private static func aliasTestBundlesToCoverageTargets(
+        testBundleNames: Set<String>,
+        coverageTargetNames: Set<String>
+    ) -> [String: String] {
+        // Iterate both sides in sorted order so the chosen alias is deterministic
+        // when more than one coverage target satisfies the matching predicate.
+        let sortedTargets = coverageTargetNames.sorted()
+        var aliases: [String: String] = [:]
+        for bundle in testBundleNames.sorted() {
+            if coverageTargetNames.contains(bundle) { continue }
+            let bundleBase = bundle.replacingOccurrences(of: "Tests", with: "")
+            var match: String?
+            for target in sortedTargets {
+                let targetBase = target.replacingOccurrences(of: "Tests", with: "")
+                if target == bundle || targetBase == bundleBase
+                    || bundle.contains(target) || target.contains(bundleBase)
+                {
+                    match = target
+                    break
+                }
+            }
+            if let match { aliases[bundle] = match }
+        }
+        return aliases
+    }
+
+    private static func buildModules(
+        files: [File],
+        suitesByModule: [String: [Module.Suite]],
+        coverageReportDTO: CoverageReportDTO?
+    ) -> [Module] {
+        var moduleNames = Set<String>()
+        if let coverageReportDTO {
+            moduleNames.formUnion(coverageReportDTO.targets.map(\.name))
+        }
+        moduleNames.formUnion(suitesByModule.keys)
+
+        return moduleNames.sorted().map { name in
+            let moduleFiles = files.filter { $0.module == name }
+
+            let moduleCoverage: Coverage?
+            if let target = coverageReportDTO?.targets.first(where: { $0.name == name }),
+                target.executableLines > 0
+            {
+                moduleCoverage = Coverage(
+                    coveredLines: target.coveredLines,
+                    totalLines: target.executableLines,
+                    coverage: target.lineCoverage
+                )
+            } else {
+                moduleCoverage = nil
+            }
+
+            return Module(
+                name: name,
+                files: moduleFiles,
+                coverage: moduleCoverage,
+                suites: suitesByModule[name] ?? []
+            )
+        }
+    }
+
+    // MARK: - Total coverage
+
+    private static func computeTotalCoverage(
+        includeCoverage: Bool,
+        coverageReportDTO: CoverageReportDTO?,
+        files: [File]
+    ) -> Double? {
+        guard includeCoverage else { return nil }
+        if let lineCoverage = coverageReportDTO?.lineCoverage, lineCoverage > 0 {
+            return lineCoverage
+        }
+        let fileCoverages = files.compactMap(\.coverage)
+        guard !fileCoverages.isEmpty else { return nil }
+        let total = fileCoverages.reduce(0) { $0 + $1.totalLines }
+        let covered = fileCoverages.reduce(0) { $0 + $1.coveredLines }
+        return total != 0 ? Double(covered) / Double(total) : 0.0
     }
 }

--- a/Sources/PeekieSDK/Models/Report+Warnings.swift
+++ b/Sources/PeekieSDK/Models/Report+Warnings.swift
@@ -12,7 +12,7 @@ extension Report {
     /// Parses warnings from BuildResultsDTO and returns a map of file names to their issues
     static func parseWarnings(
         from buildResultsDTO: BuildResultsDTO
-    ) async -> [String: [Module.File.Issue]] {
+    ) async -> [String: [File.Issue]] {
         await parseIssues(buildResultsDTO.warnings)
     }
 
@@ -22,15 +22,15 @@ extension Report {
     /// are dropped — same as warnings.
     static func parseErrors(
         from buildResultsDTO: BuildResultsDTO
-    ) async -> [String: [Module.File.Issue]] {
+    ) async -> [String: [File.Issue]] {
         await parseIssues(buildResultsDTO.errors)
     }
 
     private static func parseIssues(
         _ dtoIssues: [BuildResultsDTO.Issue]
-    ) async -> [String: [Module.File.Issue]] {
+    ) async -> [String: [File.Issue]] {
         let parsed = await dtoIssues.concurrentCompactMap {
-            issue -> (String, Module.File.Issue)? in
+            issue -> (String, File.Issue)? in
             guard let fileName = issue.fileName else { return nil }
 
             let normalized = normalizeWarningMessage(issue.message)
@@ -38,8 +38,8 @@ extension Report {
 
             return (
                 fileName,
-                Module.File.Issue(
-                    type: Module.File.Issue.IssueType(rawValue: issue.issueType),
+                File.Issue(
+                    type: File.Issue.IssueType(rawValue: issue.issueType),
                     message: normalized,
                     location: issue.location
                 )
@@ -47,7 +47,22 @@ extension Report {
         }
 
         let grouped = Dictionary(grouping: parsed, by: { $0.0 })
-        return grouped.mapValues { $0.map(\.1) }
+        // Sort issues within each file deterministically — concurrentCompactMap
+        // doesn't guarantee order, and snapshot tests are sensitive to it.
+        return grouped.mapValues { pairs in
+            pairs.map(\.1).sorted { lhs, rhs in
+                let lhsLine = lhs.location?.startLine ?? .max
+                let rhsLine = rhs.location?.startLine ?? .max
+                if lhsLine != rhsLine { return lhsLine < rhsLine }
+                let lhsCol = lhs.location?.startColumn ?? .max
+                let rhsCol = rhs.location?.startColumn ?? .max
+                if lhsCol != rhsCol { return lhsCol < rhsCol }
+                if lhs.type.rawValue != rhs.type.rawValue {
+                    return lhs.type.rawValue < rhs.type.rawValue
+                }
+                return lhs.message < rhs.message
+            }
+        }
     }
 
     /// Normalizes a warning message by removing duplicate patterns and cleaning up formatting
@@ -76,26 +91,4 @@ extension Report {
         return collapsed.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Retrieves issues matching a file name, optionally trying with a `.swift` suffix
-    static func issuesFor(
-        fileName: String,
-        in issuesByFileName: [String: [Module.File.Issue]]
-    ) -> [Module.File.Issue] {
-        if let issues = issuesByFileName[fileName] {
-            return issues
-        }
-        if !fileName.hasSuffix(".swift") {
-            return issuesByFileName[fileName + ".swift"] ?? []
-        }
-        return []
-    }
-
-    /// Concatenates two arrays of issues. The SDK no longer deduplicates — every
-    /// xcresult record is surfaced; grouping/dedup is a consumer decision.
-    static func mergeIssues(
-        _ existing: [Module.File.Issue],
-        _ new: [Module.File.Issue]
-    ) -> [Module.File.Issue] {
-        existing + new
-    }
 }

--- a/Sources/PeekieSDK/Models/Report.swift
+++ b/Sources/PeekieSDK/Models/Report.swift
@@ -1,42 +1,132 @@
 import Foundation
 
-/// Parsed report from an `.xcresult` file containing test results, coverage, and warnings
+/// Parsed report from an `.xcresult` file.
+///
+/// `files` is the primary index — every file we have any signal about (coverage,
+/// warnings, errors) lives here exactly once, regardless of which target it
+/// belongs to. `modules` is a projection over `files` for the subset where a
+/// target name is known. Build issues with no module signal (`xcresulttool`
+/// doesn't currently surface `producingTarget` for them) still surface — they
+/// appear in `files` with `File.module == nil` and are reachable via
+/// `Report.warnings` / `Report.errors`.
 public struct Report {
-    /// Set of all modules in this report
-    public let modules: Set<Module>
+    /// Every file the bundle has any signal about (coverage, warnings, errors).
+    public let files: [File]
 
-    /// Total code coverage percentage (0.0 to 1.0)
-    /// - Note: Read directly from xcresult DTO (not calculated)
+    /// Module projection — one entry per target name we could identify
+    /// (from coverage or from tests). Files whose target is unknown are
+    /// **not** represented here; reach them via `files`.
+    public let modules: [Module]
+
+    /// Total code coverage percentage (0.0 to 1.0).
+    /// - Note: Read directly from xcresult coverage data (not calculated from files).
     public let coverage: Double?
 
-    /// All warnings from all modules in this report
-    /// - Note: Computed property that aggregates warnings from all Module.File.warnings
-    public var warnings: [Module.File.Issue] {
-        modules.flatMap { $0.warnings }
+    /// All warnings from all files in this report.
+    public var warnings: [File.Issue] {
+        files.flatMap { $0.warnings }
     }
 
-    /// All errors from all modules in this report
-    /// - Note: Computed property that aggregates errors from all Module.File.errors
-    public var errors: [Module.File.Issue] {
-        modules.flatMap { $0.errors }
+    /// All errors from all files in this report.
+    public var errors: [File.Issue] {
+        files.flatMap { $0.errors }
+    }
+
+    public init(
+        files: [File],
+        modules: [Module],
+        coverage: Double?
+    ) {
+        self.files = files
+        self.modules = modules
+        self.coverage = coverage
     }
 }
 
 extension Report {
-    /// A module (test target) containing test suites and coverage files
-    public struct Module: Hashable {
-        /// Name of the module (e.g., "PeekieTests")
+    /// A source file with coverage, warnings, and errors information.
+    ///
+    /// `File` is the primary entity in the model — every data source xcresult
+    /// emits identifies files by `sourceURL` or coverage path. `module` is the
+    /// only optional identity field: build-issue records don't carry target
+    /// ownership, so a file known only from `warnings[]` / `errors[]` has
+    /// `module == nil`. Identity (hash, equality) is `path ?? name`: two files
+    /// with the same basename but different paths are distinct.
+    public struct File: Hashable {
+        /// Basename of the file (e.g., "Report.swift").
         public let name: String
 
-        /// Set of test suites in this module
-        public internal(set) var suites: Set<Suite>
+        /// Absolute path when xcresult provided one (coverage and warnings/errors do).
+        public let path: String?
 
-        /// Set of files with coverage and warnings data
-        public internal(set) var files: Set<File>
+        /// Owning target name when known. `nil` for files known only from
+        /// build issues (xcresult doesn't emit `producingTarget` for those).
+        public let module: String?
 
-        /// Code coverage for this module
-        /// - Note: Read directly from target-level coverage data in xcresult DTO
+        /// Code coverage for this file when present.
         public let coverage: Coverage?
+
+        /// Build warnings on this file.
+        public let warnings: [Issue]
+
+        /// Build errors on this file.
+        public let errors: [Issue]
+
+        public init(
+            name: String,
+            path: String? = nil,
+            module: String? = nil,
+            coverage: Coverage? = nil,
+            warnings: [Issue] = [],
+            errors: [Issue] = []
+        ) {
+            self.name = name
+            self.path = path
+            self.module = module
+            self.coverage = coverage
+            self.warnings = warnings
+            self.errors = errors
+        }
+
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(path ?? name)
+        }
+
+        public static func == (lhs: Self, rhs: Self) -> Bool {
+            (lhs.path ?? lhs.name) == (rhs.path ?? rhs.name)
+        }
+    }
+
+    /// Projection over `Report.files` grouped by target name.
+    ///
+    /// `Module` is built from coverage targets and test bundles — the two data
+    /// sources xcresult emits that name a target. A module's `files` slice is
+    /// every `Report.files` entry whose `File.module` matches; `suites` is the
+    /// tests xcresult reported for that target.
+    public struct Module: Hashable {
+        /// Target name (e.g., "Bonuses", "PeekieTests").
+        public let name: String
+
+        /// Files in this report whose `File.module == self.name`.
+        public let files: [File]
+
+        /// Target-level coverage when xcresult reported one.
+        public let coverage: Coverage?
+
+        /// Test suites this target ran.
+        public let suites: [Suite]
+
+        public init(
+            name: String,
+            files: [File] = [],
+            coverage: Coverage? = nil,
+            suites: [Suite] = []
+        ) {
+            self.name = name
+            self.files = files
+            self.coverage = coverage
+            self.suites = suites
+        }
 
         public func hash(into hasher: inout Hasher) {
             hasher.combine(name)
@@ -46,49 +136,39 @@ extension Report {
             lhs.name == rhs.name
         }
 
-        /// All warnings from all files in this module
-        /// - Note: Computed property that aggregates warnings from all File.warnings
+        /// All warnings from all files in this module.
         public var warnings: [File.Issue] {
             files.flatMap { $0.warnings }
         }
 
-        /// All errors from all files in this module
-        /// - Note: Computed property that aggregates errors from all File.errors
+        /// All errors from all files in this module.
         public var errors: [File.Issue] {
             files.flatMap { $0.errors }
         }
     }
 
-    /// Code coverage information for a module or file
+    /// Aggregate code coverage at the module or report scope.
     public struct Coverage: Equatable {
-        /// Number of lines covered by tests
         public let coveredLines: Int
-
-        /// Total number of executable lines
         public let totalLines: Int
-
-        /// Coverage percentage (0.0 to 1.0)
         public let coverage: Double
+
+        public init(coveredLines: Int, totalLines: Int, coverage: Double) {
+            self.coveredLines = coveredLines
+            self.totalLines = totalLines
+            self.coverage = coverage
+        }
     }
 }
 
-extension Report.Module.File {
-    /// Code coverage information for a specific file
+extension Report.File {
+    /// Code coverage information for a specific file.
     public struct Coverage: Equatable {
-        /// Number of lines covered by tests
         public let coveredLines: Int
-
-        /// Total number of executable lines
         public let totalLines: Int
-
-        /// Coverage percentage (0.0 to 1.0)
         public let coverage: Double
 
-        init(
-            coveredLines: Int,
-            totalLines: Int,
-            coverage: Double
-        ) {
+        public init(coveredLines: Int, totalLines: Int, coverage: Double) {
             self.coveredLines = coveredLines
             self.totalLines = totalLines
             self.coverage = coverage
@@ -100,60 +180,15 @@ extension Report.Module.File {
             self.coverage = dto.lineCoverage
         }
     }
-}
 
-extension Report.Module {
-    /// A source file with coverage, warnings, and errors information
-    public struct File: Hashable {
-        /// Name of the file (e.g., "Report.swift")
-        public let name: String
-
-        /// Build warnings associated with this file
-        /// - Note: Read directly from xcresult DTO
-        public internal(set) var warnings: [File.Issue]
-
-        /// Build errors associated with this file
-        /// - Note: Read directly from xcresult DTO
-        public internal(set) var errors: [File.Issue]
-
-        /// Code coverage information for this file
-        /// - Note: Read directly from file-level coverage data in xcresult DTO
-        public let coverage: File.Coverage?
-
-        public init(
-            name: String,
-            warnings: [File.Issue] = [],
-            errors: [File.Issue] = [],
-            coverage: File.Coverage? = nil
-        ) {
-            self.name = name
-            self.warnings = warnings
-            self.errors = errors
-            self.coverage = coverage
-        }
-
-        public func hash(into hasher: inout Hasher) {
-            hasher.combine(name)
-        }
-
-        public static func == (lhs: Self, rhs: Self) -> Bool {
-            lhs.name == rhs.name
-        }
-    }
-}
-
-extension Report.Module.File {
-    /// A build issue (warning or error) associated with a file
+    /// A build issue (warning or error) associated with a file.
     public struct Issue: Equatable, Sendable {
-        /// Type of the issue
         public let type: IssueType
-
-        /// Human-readable message describing the issue
         public let message: String
 
-        /// Source location in the file the issue refers to, when xcresult provides one.
-        /// `nil` for project-level warnings or when the `sourceURL` fragment has no
-        /// `StartingLineNumber`.
+        /// Source location in the file when xcresult provided one.
+        /// `nil` for project-level issues or when the `sourceURL` fragment has
+        /// no `StartingLineNumber`.
         public let location: Location?
 
         public init(type: IssueType, message: String, location: Location? = nil) {
@@ -162,9 +197,9 @@ extension Report.Module.File {
             self.location = location
         }
 
-        /// Source range inside a file. `startLine` is the minimum guarantee — the
-        /// other three fields are independently optional because `xcresulttool` is
-        /// not contractually obligated to emit all of them.
+        /// Source range inside a file. `startLine` is the minimum guarantee;
+        /// other three fields are independently optional because `xcresulttool`
+        /// is not contractually obligated to emit all of them.
         public struct Location: Equatable, Sendable, Codable {
             public let startLine: Int
             public let startColumn: Int?
@@ -186,9 +221,10 @@ extension Report.Module.File {
 
         /// Types of build issues that can be reported.
         ///
-        /// The set of `issueType` values emitted by `xcresulttool` is open — Apple
-        /// adds new typed diagnostics in newer Xcode releases. Use `.unknown(_)`
-        /// for forward compatibility; the raw string is preserved verbatim.
+        /// The set of `issueType` values emitted by `xcresulttool` is open —
+        /// Apple adds new typed diagnostics in newer Xcode releases. Use
+        /// `.unknown(_)` for forward compatibility; the raw string is preserved
+        /// verbatim.
         public enum IssueType: Equatable, Sendable {
             case swiftCompilerWarning
             case swiftCompilerError
@@ -199,7 +235,7 @@ extension Report.Module.File {
     }
 }
 
-extension Report.Module.File.Issue.IssueType {
+extension Report.File.Issue.IssueType {
     public init(rawValue: String) {
         switch rawValue {
         case "Swift Compiler Warning": self = .swiftCompilerWarning
@@ -221,7 +257,7 @@ extension Report.Module.File.Issue.IssueType {
     }
 }
 
-extension Report.Module.File.Issue.IssueType: Codable {
+extension Report.File.Issue.IssueType: Codable {
     public init(from decoder: Decoder) throws {
         let raw = try decoder.singleValueContainer().decode(String.self)
         self.init(rawValue: raw)
@@ -249,6 +285,16 @@ extension Report.Module {
 
         /// Set of repeatable tests in this suite
         public internal(set) var repeatableTests: Set<RepeatableTest>
+
+        public init(
+            name: String,
+            nodeIdentifierURL: String,
+            repeatableTests: Set<RepeatableTest> = []
+        ) {
+            self.name = name
+            self.nodeIdentifierURL = nodeIdentifierURL
+            self.repeatableTests = repeatableTests
+        }
 
         public func hash(into hasher: inout Hasher) {
             hasher.combine(name)
@@ -783,26 +829,20 @@ extension Array where Element: Equatable {
     }
 }
 
-extension Set where Element == Report.Module.Suite {
-    subscript(_ name: String) -> Element? {
+extension Array where Element == Report.Module.Suite {
+    public subscript(_ name: String) -> Element? {
         first { $0.name == name }
     }
 }
 
-extension Set where Element == Report.Module.File {
-    subscript(_ name: String) -> Element? {
+extension Array where Element == Report.File {
+    public subscript(_ name: String) -> Element? {
         first { $0.name == name }
     }
 }
 
-extension Set where Element == Report.Module.Suite.RepeatableTest {
-    subscript(_ name: String) -> Element? {
-        first { $0.name == name }
-    }
-}
-
-extension Set where Element == Report.Module {
-    subscript(_ name: String) -> Element? {
+extension Array where Element == Report.Module {
+    public subscript(_ name: String) -> Element? {
         first { $0.name == name }
     }
 }

--- a/Sources/PeekieTestHelpers/Report+TestHelpers.swift
+++ b/Sources/PeekieTestHelpers/Report+TestHelpers.swift
@@ -4,7 +4,8 @@ import Foundation
 
 extension Report {
     public static func testMake(
-        modules: Set<Module> = [],
+        files: [File] = [],
+        modules: [Module] = [],
         coverage: Double? = nil
     ) -> Self {
         // Calculate coverage from files if not provided
@@ -12,7 +13,7 @@ extension Report {
         if let coverage = coverage {
             calculatedCoverage = coverage
         } else {
-            let fileCoverages = modules.flatMap { $0.files }.compactMap { $0.coverage }
+            let fileCoverages = files.compactMap { $0.coverage }
             if fileCoverages.count > 0 {
                 let totalLines = fileCoverages.reduce(into: 0) { $0 += $1.totalLines }
                 let totalCoveredLines = fileCoverages.reduce(into: 0) { $0 += $1.coveredLines }
@@ -26,6 +27,7 @@ extension Report {
             }
         }
         return .init(
+            files: files,
             modules: modules,
             coverage: calculatedCoverage
         )
@@ -35,15 +37,15 @@ extension Report {
 extension Report.Module {
     public static func testMake(
         name: String = "",
-        suites: Set<Suite> = [],
-        files: Set<File> = [],
-        coverage: Report.Coverage? = nil
+        files: [Report.File] = [],
+        coverage: Report.Coverage? = nil,
+        suites: [Suite] = []
     ) -> Self {
-        .init(name: name, suites: suites, files: files, coverage: coverage)
+        .init(name: name, files: files, coverage: coverage, suites: suites)
     }
 }
 
-extension Report.Module.File.Coverage {
+extension Report.File.Coverage {
     public static func testMake(
         coveredLines: Int = 0,
         totalLines: Int = 0,
@@ -56,13 +58,23 @@ extension Report.Module.File.Coverage {
     }
 }
 
-extension Report.Module.File {
+extension Report.File {
     public static func testMake(
         name: String = "",
-        warnings: [Report.Module.File.Issue] = [],
-        coverage: Report.Module.File.Coverage? = nil
+        path: String? = nil,
+        module: String? = nil,
+        coverage: Report.File.Coverage? = nil,
+        warnings: [Report.File.Issue] = [],
+        errors: [Report.File.Issue] = []
     ) -> Self {
-        .init(name: name, warnings: warnings, coverage: coverage)
+        .init(
+            name: name,
+            path: path,
+            module: module,
+            coverage: coverage,
+            warnings: warnings,
+            errors: errors
+        )
     }
 }
 

--- a/Tests/PeekieTests/FileIdentityTests.swift
+++ b/Tests/PeekieTests/FileIdentityTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import PeekieSDK
+
+@Suite
+struct FileIdentityTests {
+    @Test
+    func filesWithSamePathAreEqual() {
+        let a = Report.File(name: "Foo.swift", path: "/x/Foo.swift", module: "X")
+        let b = Report.File(name: "Foo.swift", path: "/x/Foo.swift", module: "Y")
+        #expect(a == b)
+        #expect(a.hashValue == b.hashValue)
+    }
+
+    @Test
+    func filesWithSameNameButDifferentPathsAreDistinct() {
+        let a = Report.File(name: "Foo.swift", path: "/x/Foo.swift", module: "X")
+        let b = Report.File(name: "Foo.swift", path: "/y/Foo.swift", module: "Y")
+        #expect(a != b)
+    }
+
+    @Test
+    func filesWithoutPathFallBackToNameForIdentity() {
+        let a = Report.File(name: "Foo.swift", path: nil)
+        let b = Report.File(name: "Foo.swift", path: nil)
+        #expect(a == b)
+    }
+}

--- a/Tests/PeekieTests/IssueTypeTests.swift
+++ b/Tests/PeekieTests/IssueTypeTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import PeekieSDK
 
-private typealias IssueType = Report.Module.File.Issue.IssueType
+private typealias IssueType = Report.File.Issue.IssueType
 
 @Suite
 struct IssueTypeTests {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
@@ -8,53 +8,7 @@
         "totalLines" : 70
       },
       "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 15,
-            "percentage" : 0.4411764705882353,
-            "totalLines" : 34
-          },
-          "errors" : [
 
-          ],
-          "name" : "Calculator.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 36
-          },
-          "errors" : [
-
-          ],
-          "name" : "NumberHelper.swift",
-          "warnings" : [
-
-          ]
-        }
       ],
       "name" : "Calculator",
       "suites" : [
@@ -98,16 +52,27 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
-          ]
-        },
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
           ]
         },
         {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
@@ -8,53 +8,7 @@
         "totalLines" : 70
       },
       "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 15,
-            "percentage" : 0.4411764705882353,
-            "totalLines" : 34
-          },
-          "errors" : [
 
-          ],
-          "name" : "Calculator.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 36
-          },
-          "errors" : [
-
-          ],
-          "name" : "NumberHelper.swift",
-          "warnings" : [
-
-          ]
-        }
       ],
       "name" : "Calculator",
       "suites" : [
@@ -98,16 +52,27 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
-          ]
-        },
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
           ]
         },
         {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
@@ -8,53 +8,7 @@
         "totalLines" : 70
       },
       "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 15,
-            "percentage" : 0.4411764705882353,
-            "totalLines" : 34
-          },
-          "errors" : [
 
-          ],
-          "name" : "Calculator.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 36
-          },
-          "errors" : [
-
-          ],
-          "name" : "NumberHelper.swift",
-          "warnings" : [
-
-          ]
-        }
       ],
       "name" : "Calculator",
       "suites" : [
@@ -98,16 +52,27 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
-          ]
-        },
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
           ]
         },
         {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
@@ -8,53 +8,7 @@
         "totalLines" : 70
       },
       "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 15,
-            "percentage" : 0.4411764705882353,
-            "totalLines" : 34
-          },
-          "errors" : [
 
-          ],
-          "name" : "Calculator.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 36
-          },
-          "errors" : [
-
-          ],
-          "name" : "NumberHelper.swift",
-          "warnings" : [
-
-          ]
-        }
       ],
       "name" : "Calculator",
       "suites" : [
@@ -98,16 +52,27 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
-          ]
-        },
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
           ]
         },
         {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
@@ -8,53 +8,7 @@
         "totalLines" : 70
       },
       "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 15,
-            "percentage" : 0.4411764705882353,
-            "totalLines" : 34
-          },
-          "errors" : [
 
-          ],
-          "name" : "Calculator.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 36
-          },
-          "errors" : [
-
-          ],
-          "name" : "NumberHelper.swift",
-          "warnings" : [
-
-          ]
-        }
       ],
       "name" : "Calculator",
       "suites" : [
@@ -98,16 +52,27 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
-          ]
-        },
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
           ]
         },
         {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
@@ -72,137 +72,6 @@
       ],
       "name" : "XcodeprojExample.app",
       "suites" : [
-
-      ]
-    },
-    {
-      "coverage" : {
-        "coveredLines" : 0,
-        "percentage" : 0,
-        "totalLines" : 23
-      },
-      "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 23
-          },
-          "errors" : [
-
-          ],
-          "name" : "TextProcessor.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        }
-      ],
-      "name" : "XcodeprojExampleFramework.framework",
-      "suites" : [
-
-      ]
-    },
-    {
-      "coverage" : {
-        "coveredLines" : 152,
-        "percentage" : 0.9325153374233128,
-        "totalLines" : 163
-      },
-      "files" : [
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 95,
-            "percentage" : 0.9895833333333334,
-            "totalLines" : 96
-          },
-          "errors" : [
-
-          ],
-          "name" : "XCTestTests.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 25,
-                "endLine" : 50,
-                "startColumn" : 25,
-                "startLine" : 50
-              },
-              "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 32,
-                "endLine" : 53,
-                "startColumn" : 32,
-                "startLine" : 53
-              },
-              "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 36,
-                "endLine" : 64,
-                "startColumn" : 36,
-                "startLine" : 64
-              },
-              "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        }
-      ],
-      "name" : "XcodeprojExampleTests",
-      "suites" : [
         {
           "name" : "ExampleSUITests",
           "tests" : [
@@ -333,6 +202,52 @@
     },
     {
       "coverage" : {
+        "coveredLines" : 0,
+        "percentage" : 0,
+        "totalLines" : 23
+      },
+      "files" : [
+        {
+          "coverage" : {
+            "coveredLines" : 0,
+            "percentage" : 0,
+            "totalLines" : 23
+          },
+          "errors" : [
+
+          ],
+          "name" : "TextProcessor.swift",
+          "warnings" : [
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Warning"
+            }
+          ]
+        }
+      ],
+      "name" : "XcodeprojExampleFramework.framework",
+      "suites" : [
+
+      ]
+    },
+    {
+      "coverage" : {
         "coveredLines" : 152,
         "percentage" : 0.9325153374233128,
         "totalLines" : 163
@@ -349,26 +264,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -388,6 +283,26 @@
               },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -402,26 +317,6 @@
           ],
           "name" : "XCTestTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -450,6 +345,26 @@
                 "startLine" : 64
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             }
           ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
@@ -72,137 +72,6 @@
       ],
       "name" : "XcodeprojExample.app",
       "suites" : [
-
-      ]
-    },
-    {
-      "coverage" : {
-        "coveredLines" : 0,
-        "percentage" : 0,
-        "totalLines" : 23
-      },
-      "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 23
-          },
-          "errors" : [
-
-          ],
-          "name" : "TextProcessor.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        }
-      ],
-      "name" : "XcodeprojExampleFramework.framework",
-      "suites" : [
-
-      ]
-    },
-    {
-      "coverage" : {
-        "coveredLines" : 152,
-        "percentage" : 0.9325153374233128,
-        "totalLines" : 163
-      },
-      "files" : [
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 95,
-            "percentage" : 0.9895833333333334,
-            "totalLines" : 96
-          },
-          "errors" : [
-
-          ],
-          "name" : "XCTestTests.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 25,
-                "endLine" : 50,
-                "startColumn" : 25,
-                "startLine" : 50
-              },
-              "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 32,
-                "endLine" : 53,
-                "startColumn" : 32,
-                "startLine" : 53
-              },
-              "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 36,
-                "endLine" : 64,
-                "startColumn" : 36,
-                "startLine" : 64
-              },
-              "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        }
-      ],
-      "name" : "XcodeprojExampleTests",
-      "suites" : [
         {
           "name" : "ExampleSUITests",
           "tests" : [
@@ -333,6 +202,52 @@
     },
     {
       "coverage" : {
+        "coveredLines" : 0,
+        "percentage" : 0,
+        "totalLines" : 23
+      },
+      "files" : [
+        {
+          "coverage" : {
+            "coveredLines" : 0,
+            "percentage" : 0,
+            "totalLines" : 23
+          },
+          "errors" : [
+
+          ],
+          "name" : "TextProcessor.swift",
+          "warnings" : [
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Warning"
+            }
+          ]
+        }
+      ],
+      "name" : "XcodeprojExampleFramework.framework",
+      "suites" : [
+
+      ]
+    },
+    {
+      "coverage" : {
         "coveredLines" : 152,
         "percentage" : 0.9325153374233128,
         "totalLines" : 163
@@ -349,26 +264,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -388,6 +283,26 @@
               },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -402,26 +317,6 @@
           ],
           "name" : "XCTestTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -450,6 +345,26 @@
                 "startLine" : 64
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             }
           ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
@@ -72,137 +72,6 @@
       ],
       "name" : "XcodeprojExample.app",
       "suites" : [
-
-      ]
-    },
-    {
-      "coverage" : {
-        "coveredLines" : 0,
-        "percentage" : 0,
-        "totalLines" : 23
-      },
-      "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 23
-          },
-          "errors" : [
-
-          ],
-          "name" : "TextProcessor.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        }
-      ],
-      "name" : "XcodeprojExampleFramework.framework",
-      "suites" : [
-
-      ]
-    },
-    {
-      "coverage" : {
-        "coveredLines" : 152,
-        "percentage" : 0.9325153374233128,
-        "totalLines" : 163
-      },
-      "files" : [
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 95,
-            "percentage" : 0.9895833333333334,
-            "totalLines" : 96
-          },
-          "errors" : [
-
-          ],
-          "name" : "XCTestTests.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 25,
-                "endLine" : 50,
-                "startColumn" : 25,
-                "startLine" : 50
-              },
-              "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 32,
-                "endLine" : 53,
-                "startColumn" : 32,
-                "startLine" : 53
-              },
-              "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 36,
-                "endLine" : 64,
-                "startColumn" : 36,
-                "startLine" : 64
-              },
-              "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        }
-      ],
-      "name" : "XcodeprojExampleTests",
-      "suites" : [
         {
           "name" : "ExampleSUITests",
           "tests" : [
@@ -333,6 +202,52 @@
     },
     {
       "coverage" : {
+        "coveredLines" : 0,
+        "percentage" : 0,
+        "totalLines" : 23
+      },
+      "files" : [
+        {
+          "coverage" : {
+            "coveredLines" : 0,
+            "percentage" : 0,
+            "totalLines" : 23
+          },
+          "errors" : [
+
+          ],
+          "name" : "TextProcessor.swift",
+          "warnings" : [
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 13,
+                "startColumn" : 9,
+                "startLine" : 13
+              },
+              "message" : "Some warning from StringUtils",
+              "type" : "Swift Compiler Warning"
+            }
+          ]
+        }
+      ],
+      "name" : "XcodeprojExampleFramework.framework",
+      "suites" : [
+
+      ]
+    },
+    {
+      "coverage" : {
         "coveredLines" : 152,
         "percentage" : 0.9325153374233128,
         "totalLines" : 163
@@ -349,26 +264,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -388,6 +283,26 @@
               },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -402,26 +317,6 @@
           ],
           "name" : "XCTestTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -450,6 +345,26 @@
                 "startLine" : 64
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             }
           ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
@@ -8,53 +8,7 @@
         "totalLines" : 70
       },
       "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 15,
-            "percentage" : 0.4411764705882353,
-            "totalLines" : 34
-          },
-          "errors" : [
 
-          ],
-          "name" : "Calculator.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 36
-          },
-          "errors" : [
-
-          ],
-          "name" : "NumberHelper.swift",
-          "warnings" : [
-
-          ]
-        }
       ],
       "name" : "Calculator",
       "suites" : [
@@ -98,16 +52,27 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
-          ]
-        },
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
           ]
         },
         {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
@@ -8,53 +8,7 @@
         "totalLines" : 70
       },
       "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 15,
-            "percentage" : 0.4411764705882353,
-            "totalLines" : 34
-          },
-          "errors" : [
 
-          ],
-          "name" : "Calculator.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 36
-          },
-          "errors" : [
-
-          ],
-          "name" : "NumberHelper.swift",
-          "warnings" : [
-
-          ]
-        }
       ],
       "name" : "Calculator",
       "suites" : [
@@ -98,16 +52,27 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
-          ]
-        },
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
           ]
         },
         {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
@@ -8,53 +8,7 @@
         "totalLines" : 70
       },
       "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 15,
-            "percentage" : 0.4411764705882353,
-            "totalLines" : 34
-          },
-          "errors" : [
 
-          ],
-          "name" : "Calculator.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 36
-          },
-          "errors" : [
-
-          ],
-          "name" : "NumberHelper.swift",
-          "warnings" : [
-
-          ]
-        }
       ],
       "name" : "Calculator",
       "suites" : [
@@ -98,16 +52,27 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
-          ]
-        },
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
           ]
         },
         {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
@@ -8,53 +8,7 @@
         "totalLines" : 70
       },
       "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 15,
-            "percentage" : 0.4411764705882353,
-            "totalLines" : 34
-          },
-          "errors" : [
 
-          ],
-          "name" : "Calculator.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 36
-          },
-          "errors" : [
-
-          ],
-          "name" : "NumberHelper.swift",
-          "warnings" : [
-
-          ]
-        }
       ],
       "name" : "Calculator",
       "suites" : [
@@ -98,16 +52,27 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
-          ]
-        },
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
           ]
         },
         {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
@@ -8,53 +8,7 @@
         "totalLines" : 70
       },
       "files" : [
-        {
-          "coverage" : {
-            "coveredLines" : 15,
-            "percentage" : 0.4411764705882353,
-            "totalLines" : 34
-          },
-          "errors" : [
 
-          ],
-          "name" : "Calculator.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 0,
-            "percentage" : 0,
-            "totalLines" : 36
-          },
-          "errors" : [
-
-          ],
-          "name" : "NumberHelper.swift",
-          "warnings" : [
-
-          ]
-        }
       ],
       "name" : "Calculator",
       "suites" : [
@@ -98,16 +52,27 @@
               },
               "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 17,
+                "endLine" : 7,
+                "startColumn" : 17,
+                "startLine" : 7
+              },
+              "message" : "Some warning from Calculator",
+              "type" : "Swift Compiler Warning"
             }
-          ]
-        },
-        {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
           ]
         },
         {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
@@ -72,7 +72,40 @@
       ],
       "name" : "XcodeprojExample.app",
       "suites" : [
-
+        {
+          "name" : "ExampleSUITests",
+          "tests" : [
+            {
+              "durationMs" : 207.5040340423584,
+              "message" : "Expected 5.0 but got 6.0",
+              "name" : "failure()",
+              "status" : "failure"
+            },
+            {
+              "durationMs" : 364.1691207885742,
+              "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero",
+              "name" : "throwing()",
+              "status" : "failure"
+            }
+          ]
+        },
+        {
+          "name" : "XCTestTests",
+          "tests" : [
+            {
+              "durationMs" : 2239.737033843994,
+              "message" : "Expected 5.0 but got 6.0",
+              "name" : "test_failure()",
+              "status" : "failure"
+            },
+            {
+              "durationMs" : 6.775975227355957,
+              "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\"",
+              "name" : "test_throwing()",
+              "status" : "failure"
+            }
+          ]
+        }
       ]
     },
     {
@@ -129,124 +162,6 @@
       },
       "files" : [
         {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 95,
-            "percentage" : 0.9895833333333334,
-            "totalLines" : 96
-          },
-          "errors" : [
-
-          ],
-          "name" : "XCTestTests.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 25,
-                "endLine" : 50,
-                "startColumn" : 25,
-                "startLine" : 50
-              },
-              "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 32,
-                "endLine" : 53,
-                "startColumn" : 32,
-                "startLine" : 53
-              },
-              "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 36,
-                "endLine" : 64,
-                "startColumn" : 36,
-                "startLine" : 64
-              },
-              "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        }
-      ],
-      "name" : "XcodeprojExampleTests",
-      "suites" : [
-        {
-          "name" : "ExampleSUITests",
-          "tests" : [
-            {
-              "durationMs" : 207.5040340423584,
-              "message" : "Expected 5.0 but got 6.0",
-              "name" : "failure()",
-              "status" : "failure"
-            },
-            {
-              "durationMs" : 364.1691207885742,
-              "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero",
-              "name" : "throwing()",
-              "status" : "failure"
-            }
-          ]
-        },
-        {
-          "name" : "XCTestTests",
-          "tests" : [
-            {
-              "durationMs" : 2239.737033843994,
-              "message" : "Expected 5.0 but got 6.0",
-              "name" : "test_failure()",
-              "status" : "failure"
-            },
-            {
-              "durationMs" : 6.775975227355957,
-              "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\"",
-              "name" : "test_throwing()",
-              "status" : "failure"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "coverage" : {
-        "coveredLines" : 152,
-        "percentage" : 0.9325153374233128,
-        "totalLines" : 163
-      },
-      "files" : [
-        {
           "coverage" : {
             "coveredLines" : 57,
             "percentage" : 0.8507462686567164,
@@ -257,26 +172,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -296,6 +191,26 @@
               },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -310,26 +225,6 @@
           ],
           "name" : "XCTestTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -358,6 +253,26 @@
                 "startLine" : 64
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             }
           ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
@@ -72,7 +72,40 @@
       ],
       "name" : "XcodeprojExample.app",
       "suites" : [
-
+        {
+          "name" : "ExampleSUITests",
+          "tests" : [
+            {
+              "durationMs" : 2.2590160369873047,
+              "message" : "Expected 5.0 but got 6.0",
+              "name" : "failure()",
+              "status" : "failure"
+            },
+            {
+              "durationMs" : 2.6693344116210938,
+              "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero",
+              "name" : "throwing()",
+              "status" : "failure"
+            }
+          ]
+        },
+        {
+          "name" : "XCTestTests",
+          "tests" : [
+            {
+              "durationMs" : 2.5730133056640625,
+              "message" : "Expected 5.0 but got 6.0",
+              "name" : "test_failure()",
+              "status" : "failure"
+            },
+            {
+              "durationMs" : 8.183121681213379,
+              "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\"",
+              "name" : "test_throwing()",
+              "status" : "failure"
+            }
+          ]
+        }
       ]
     },
     {
@@ -129,124 +162,6 @@
       },
       "files" : [
         {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 95,
-            "percentage" : 0.9895833333333334,
-            "totalLines" : 96
-          },
-          "errors" : [
-
-          ],
-          "name" : "XCTestTests.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 25,
-                "endLine" : 50,
-                "startColumn" : 25,
-                "startLine" : 50
-              },
-              "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 32,
-                "endLine" : 53,
-                "startColumn" : 32,
-                "startLine" : 53
-              },
-              "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 36,
-                "endLine" : 64,
-                "startColumn" : 36,
-                "startLine" : 64
-              },
-              "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        }
-      ],
-      "name" : "XcodeprojExampleTests",
-      "suites" : [
-        {
-          "name" : "ExampleSUITests",
-          "tests" : [
-            {
-              "durationMs" : 2.2590160369873047,
-              "message" : "Expected 5.0 but got 6.0",
-              "name" : "failure()",
-              "status" : "failure"
-            },
-            {
-              "durationMs" : 2.6693344116210938,
-              "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero",
-              "name" : "throwing()",
-              "status" : "failure"
-            }
-          ]
-        },
-        {
-          "name" : "XCTestTests",
-          "tests" : [
-            {
-              "durationMs" : 2.5730133056640625,
-              "message" : "Expected 5.0 but got 6.0",
-              "name" : "test_failure()",
-              "status" : "failure"
-            },
-            {
-              "durationMs" : 8.183121681213379,
-              "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\"",
-              "name" : "test_throwing()",
-              "status" : "failure"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "coverage" : {
-        "coveredLines" : 152,
-        "percentage" : 0.9325153374233128,
-        "totalLines" : 163
-      },
-      "files" : [
-        {
           "coverage" : {
             "coveredLines" : 57,
             "percentage" : 0.8507462686567164,
@@ -257,26 +172,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -296,6 +191,26 @@
               },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -310,26 +225,6 @@
           ],
           "name" : "XCTestTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -358,6 +253,26 @@
                 "startLine" : 64
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             }
           ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
@@ -72,7 +72,40 @@
       ],
       "name" : "XcodeprojExample.app",
       "suites" : [
-
+        {
+          "name" : "ExampleSUITests",
+          "tests" : [
+            {
+              "durationMs" : 44.786930084228516,
+              "message" : "Expected 5.0 but got 6.0",
+              "name" : "failure()",
+              "status" : "failure"
+            },
+            {
+              "durationMs" : 45.06516456604004,
+              "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero",
+              "name" : "throwing()",
+              "status" : "failure"
+            }
+          ]
+        },
+        {
+          "name" : "XCTestTests",
+          "tests" : [
+            {
+              "durationMs" : 1141.6420936584473,
+              "message" : "Expected 5.0 but got 6.0",
+              "name" : "test_failure()",
+              "status" : "failure"
+            },
+            {
+              "durationMs" : 7.061958312988281,
+              "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\"",
+              "name" : "test_throwing()",
+              "status" : "failure"
+            }
+          ]
+        }
       ]
     },
     {
@@ -129,124 +162,6 @@
       },
       "files" : [
         {
-          "errors" : [
-
-          ],
-          "name" : "ExampleSUITests",
-          "warnings" : [
-
-          ]
-        },
-        {
-          "coverage" : {
-            "coveredLines" : 95,
-            "percentage" : 0.9895833333333334,
-            "totalLines" : 96
-          },
-          "errors" : [
-
-          ],
-          "name" : "XCTestTests.swift",
-          "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 25,
-                "endLine" : 50,
-                "startColumn" : 25,
-                "startLine" : 50
-              },
-              "message" : "Main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 32,
-                "endLine" : 53,
-                "startColumn" : 32,
-                "startLine" : 53
-              },
-              "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 36,
-                "endLine" : 64,
-                "startColumn" : 36,
-                "startLine" : 64
-              },
-              "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
-              "type" : "Swift Compiler Warning"
-            }
-          ]
-        }
-      ],
-      "name" : "XcodeprojExampleTests",
-      "suites" : [
-        {
-          "name" : "ExampleSUITests",
-          "tests" : [
-            {
-              "durationMs" : 44.786930084228516,
-              "message" : "Expected 5.0 but got 6.0",
-              "name" : "failure()",
-              "status" : "failure"
-            },
-            {
-              "durationMs" : 45.06516456604004,
-              "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero",
-              "name" : "throwing()",
-              "status" : "failure"
-            }
-          ]
-        },
-        {
-          "name" : "XCTestTests",
-          "tests" : [
-            {
-              "durationMs" : 1141.6420936584473,
-              "message" : "Expected 5.0 but got 6.0",
-              "name" : "test_failure()",
-              "status" : "failure"
-            },
-            {
-              "durationMs" : 7.061958312988281,
-              "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\"",
-              "name" : "test_throwing()",
-              "status" : "failure"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "coverage" : {
-        "coveredLines" : 152,
-        "percentage" : 0.9325153374233128,
-        "totalLines" : 163
-      },
-      "files" : [
-        {
           "coverage" : {
             "coveredLines" : 57,
             "percentage" : 0.8507462686567164,
@@ -257,26 +172,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 98,
-                "startColumn" : 9,
-                "startLine" : 98
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -296,6 +191,26 @@
               },
               "message" : "Main actor-isolated instance method 'add' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 98,
+                "startColumn" : 9,
+                "startLine" : 98
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Warning"
             }
           ]
         },
@@ -310,26 +225,6 @@
           ],
           "name" : "XCTestTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 102,
-                "startColumn" : 9,
-                "startLine" : 102
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Warning"
-            },
             {
               "location" : {
                 "endColumn" : 25,
@@ -358,6 +253,26 @@
                 "startLine" : 64
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
+              "type" : "Swift Compiler Warning"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
+              "type" : "Swift Compiler Error"
+            },
+            {
+              "location" : {
+                "endColumn" : 9,
+                "endLine" : 102,
+                "startColumn" : 9,
+                "startLine" : 102
+              },
+              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             }
           ]

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
@@ -1,84 +1,203 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6006600660066007
-  ▿ modules: 3 members
-    ▿ Module
+  ▿ files: 5 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.4411764705882353
+          - coveredLines: 15
+          - totalLines: 34
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "Calculator.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
+      ▿ warnings: 4 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 36
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "NumberHelper.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.8507462686567164
+          - coveredLines: 57
+          - totalLines: 67
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "SwiftTestingTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9895833333333334
+          - coveredLines: 95
+          - totalLines: 96
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "XCTestTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
       - coverage: Optional<Coverage>.none
-      - files: 0 members
-      - name: "StringUtils"
-      - suites: 0 members
+      - errors: 0 elements
+      - module: Optional<String>.none
+      - name: "TextProcessor.swift"
+      - path: Optional<String>.none
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerWarning
+  ▿ modules: 3 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.21428571428571427
           - coveredLines: 15
           - totalLines: 70
-      ▿ files: 2 members
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.4411764705882353
-              - coveredLines: 15
-              - totalLines: 34
-          - errors: 0 elements
-          - name: "Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
+      - files: 0 elements
       - name: "Calculator"
-      - suites: 0 members
+      - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.7167381974248928
           - coveredLines: 167
           - totalLines: 233
-      ▿ files: 5 members
-        ▿ File
-          - coverage: Optional<Coverage>.none
-          - errors: 0 elements
-          - name: "ExampleSUITests"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
+      ▿ files: 4 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -86,8 +205,12 @@
               - coveredLines: 15
               - totalLines: 34
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "Calculator.swift"
-          ▿ warnings: 2 elements
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -112,6 +235,43 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerWarning
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 36
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
+          - name: "NumberHelper.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
+          - warnings: 0 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -119,7 +279,11 @@
               - coveredLines: 57
               - totalLines: 67
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "SwiftTestingTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -152,7 +316,11 @@
               - coveredLines: 95
               - totalLines: 96
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "XCTestTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -179,7 +347,285 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
-      ▿ suites: 2 members
+      ▿ suites: 2 elements
+        ▿ Suite
+          - name: "XCTestTests"
+          - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
+          ▿ repeatableTests: 11 members
+            ▿ RepeatableTest
+              - name: "test_async()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 20.943045616149902 ms
+                    - value: 20.943045616149902
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_async()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_asyncWithExpectation()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 16.31605625152588 ms
+                    - value: 16.31605625152588
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_asyncWithExpectation()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_expectedFailure()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 966.454029083252 ms
+                    - value: 966.454029083252
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Failure is expected"
+                  - name: "test_expectedFailure()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.expectedFailure
+            ▿ RepeatableTest
+              - name: "test_failure()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 15.686988830566406 ms
+                    - value: 15.686988830566406
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 15.686988830566406 ms
+                          - value: 15.686988830566406
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 3.2339096069335938 ms
+                    - value: 3.2339096069335938
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 3.2339096069335938 ms
+                          - value: 3.2339096069335938
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 5.242109298706055 ms
+                    - value: 5.242109298706055
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 5.242109298706055 ms
+                          - value: 5.242109298706055
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_flacky()"
+              ▿ tests: 2 elements
+                ▿ Test
+                  ▿ duration: 5.561947822570801 ms
+                    - value: 5.561947822570801
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Flacky failure message: result was 2.0"
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 5.561947822570801 ms
+                          - value: 5.561947822570801
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Flacky failure message: result was 2.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.7899999618530273 ms
+                    - value: 0.7899999618530273
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.7899999618530273 ms
+                          - value: 0.7899999618530273
+                          - unit: "ms"
+                      - message: Optional<String>.none
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.success
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_performance()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 254.44507598876953 ms
+                    - value: 254.44507598876953
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_performance()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_skip()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 10.33008098602295 ms
+                    - value: 10.33008098602295
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Test skipped - Skip message"
+                  - name: "test_skip()"
+                  - path: 0 elements
+                  ▿ skipMessage: Optional<String>
+                    - some: "Skip message"
+                  - status: Status.skipped
+            ▿ RepeatableTest
+              - name: "test_success()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.926971435546875 ms
+                    - value: 0.926971435546875
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_success()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_throwing()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 2.8510093688964844 ms
+                    - value: 2.8510093688964844
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 2.8510093688964844 ms
+                          - value: 2.8510093688964844
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 3.1529664993286133 ms
+                    - value: 3.1529664993286133
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 3.1529664993286133 ms
+                          - value: 3.1529664993286133
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.6809701919555664 ms
+                    - value: 1.6809701919555664
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.6809701919555664 ms
+                          - value: 1.6809701919555664
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_withAttachment()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 3.0139684677124023 ms
+                    - value: 3.0139684677124023
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withAttachment()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_withWarning()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.47600269317626953 ms
+                    - value: 0.47600269317626953
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withWarning()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
         ▿ Suite
           - name: "ExampleSUITests"
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/ExampleSUITests"
@@ -852,281 +1298,8 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-        ▿ Suite
-          - name: "XCTestTests"
-          - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
-          ▿ repeatableTests: 11 members
-            ▿ RepeatableTest
-              - name: "test_async()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 20.943045616149902 ms
-                    - value: 20.943045616149902
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_async()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_asyncWithExpectation()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 16.31605625152588 ms
-                    - value: 16.31605625152588
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_asyncWithExpectation()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_expectedFailure()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 966.454029083252 ms
-                    - value: 966.454029083252
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Failure is expected"
-                  - name: "test_expectedFailure()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.expectedFailure
-            ▿ RepeatableTest
-              - name: "test_failure()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 15.686988830566406 ms
-                    - value: 15.686988830566406
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 15.686988830566406 ms
-                          - value: 15.686988830566406
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 3.2339096069335938 ms
-                    - value: 3.2339096069335938
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 3.2339096069335938 ms
-                          - value: 3.2339096069335938
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 5.242109298706055 ms
-                    - value: 5.242109298706055
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 5.242109298706055 ms
-                          - value: 5.242109298706055
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_flacky()"
-              ▿ tests: 2 elements
-                ▿ Test
-                  ▿ duration: 5.561947822570801 ms
-                    - value: 5.561947822570801
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Flacky failure message: result was 2.0"
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 5.561947822570801 ms
-                          - value: 5.561947822570801
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Flacky failure message: result was 2.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.7899999618530273 ms
-                    - value: 0.7899999618530273
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.7899999618530273 ms
-                          - value: 0.7899999618530273
-                          - unit: "ms"
-                      - message: Optional<String>.none
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.success
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_performance()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 254.44507598876953 ms
-                    - value: 254.44507598876953
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_performance()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_skip()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 10.33008098602295 ms
-                    - value: 10.33008098602295
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Test skipped - Skip message"
-                  - name: "test_skip()"
-                  - path: 0 elements
-                  ▿ skipMessage: Optional<String>
-                    - some: "Skip message"
-                  - status: Status.skipped
-            ▿ RepeatableTest
-              - name: "test_success()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.926971435546875 ms
-                    - value: 0.926971435546875
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_success()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_throwing()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 2.8510093688964844 ms
-                    - value: 2.8510093688964844
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 2.8510093688964844 ms
-                          - value: 2.8510093688964844
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 3.1529664993286133 ms
-                    - value: 3.1529664993286133
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 3.1529664993286133 ms
-                          - value: 3.1529664993286133
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.6809701919555664 ms
-                    - value: 1.6809701919555664
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.6809701919555664 ms
-                          - value: 1.6809701919555664
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_withAttachment()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 3.0139684677124023 ms
-                    - value: 3.0139684677124023
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withAttachment()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_withWarning()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.47600269317626953 ms
-                    - value: 0.47600269317626953
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withWarning()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
+    ▿ Module
+      - coverage: Optional<Coverage>.none
+      - files: 0 elements
+      - name: "StringUtils"
+      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
@@ -1,84 +1,203 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6006600660066007
-  ▿ modules: 3 members
-    ▿ Module
+  ▿ files: 5 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.4411764705882353
+          - coveredLines: 15
+          - totalLines: 34
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "Calculator.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
+      ▿ warnings: 4 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 36
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "NumberHelper.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.8507462686567164
+          - coveredLines: 57
+          - totalLines: 67
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "SwiftTestingTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9895833333333334
+          - coveredLines: 95
+          - totalLines: 96
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "XCTestTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
       - coverage: Optional<Coverage>.none
-      - files: 0 members
-      - name: "StringUtils"
-      - suites: 0 members
+      - errors: 0 elements
+      - module: Optional<String>.none
+      - name: "TextProcessor.swift"
+      - path: Optional<String>.none
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerWarning
+  ▿ modules: 3 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.21428571428571427
           - coveredLines: 15
           - totalLines: 70
-      ▿ files: 2 members
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.4411764705882353
-              - coveredLines: 15
-              - totalLines: 34
-          - errors: 0 elements
-          - name: "Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
+      - files: 0 elements
       - name: "Calculator"
-      - suites: 0 members
+      - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.7167381974248928
           - coveredLines: 167
           - totalLines: 233
-      ▿ files: 5 members
-        ▿ File
-          - coverage: Optional<Coverage>.none
-          - errors: 0 elements
-          - name: "ExampleSUITests"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
+      ▿ files: 4 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -86,8 +205,12 @@
               - coveredLines: 15
               - totalLines: 34
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "Calculator.swift"
-          ▿ warnings: 2 elements
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -112,6 +235,43 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerWarning
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 36
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
+          - name: "NumberHelper.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
+          - warnings: 0 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -119,7 +279,11 @@
               - coveredLines: 57
               - totalLines: 67
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "SwiftTestingTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -152,7 +316,11 @@
               - coveredLines: 95
               - totalLines: 96
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "XCTestTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -179,7 +347,285 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
-      ▿ suites: 2 members
+      ▿ suites: 2 elements
+        ▿ Suite
+          - name: "XCTestTests"
+          - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
+          ▿ repeatableTests: 11 members
+            ▿ RepeatableTest
+              - name: "test_async()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 14.665961265563965 ms
+                    - value: 14.665961265563965
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_async()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_asyncWithExpectation()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 13.393998146057129 ms
+                    - value: 13.393998146057129
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_asyncWithExpectation()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_expectedFailure()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 479.96699810028076 ms
+                    - value: 479.96699810028076
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Failure is expected"
+                  - name: "test_expectedFailure()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.expectedFailure
+            ▿ RepeatableTest
+              - name: "test_failure()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 0.9859800338745117 ms
+                    - value: 0.9859800338745117
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.9859800338745117 ms
+                          - value: 0.9859800338745117
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.9039640426635742 ms
+                    - value: 0.9039640426635742
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.9039640426635742 ms
+                          - value: 0.9039640426635742
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.8350610733032227 ms
+                    - value: 0.8350610733032227
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.8350610733032227 ms
+                          - value: 0.8350610733032227
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_flacky()"
+              ▿ tests: 2 elements
+                ▿ Test
+                  ▿ duration: 0.9180307388305664 ms
+                    - value: 0.9180307388305664
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Flacky failure message: result was 2.0"
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.9180307388305664 ms
+                          - value: 0.9180307388305664
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Flacky failure message: result was 2.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.42808055877685547 ms
+                    - value: 0.42808055877685547
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.42808055877685547 ms
+                          - value: 0.42808055877685547
+                          - unit: "ms"
+                      - message: Optional<String>.none
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.success
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_performance()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 264.117956161499 ms
+                    - value: 264.117956161499
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_performance()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_skip()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 1.4600753784179688 ms
+                    - value: 1.4600753784179688
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Test skipped - Skip message"
+                  - name: "test_skip()"
+                  - path: 0 elements
+                  ▿ skipMessage: Optional<String>
+                    - some: "Skip message"
+                  - status: Status.skipped
+            ▿ RepeatableTest
+              - name: "test_success()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.42498111724853516 ms
+                    - value: 0.42498111724853516
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_success()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_throwing()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 1.9450187683105469 ms
+                    - value: 1.9450187683105469
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.9450187683105469 ms
+                          - value: 1.9450187683105469
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.2379884719848633 ms
+                    - value: 1.2379884719848633
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.2379884719848633 ms
+                          - value: 1.2379884719848633
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 2.089977264404297 ms
+                    - value: 2.089977264404297
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 2.089977264404297 ms
+                          - value: 2.089977264404297
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_withAttachment()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 1.8069744110107422 ms
+                    - value: 1.8069744110107422
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withAttachment()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_withWarning()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.9820461273193359 ms
+                    - value: 0.9820461273193359
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withWarning()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
         ▿ Suite
           - name: "ExampleSUITests"
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/ExampleSUITests"
@@ -852,281 +1298,8 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-        ▿ Suite
-          - name: "XCTestTests"
-          - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
-          ▿ repeatableTests: 11 members
-            ▿ RepeatableTest
-              - name: "test_async()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 14.665961265563965 ms
-                    - value: 14.665961265563965
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_async()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_asyncWithExpectation()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 13.393998146057129 ms
-                    - value: 13.393998146057129
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_asyncWithExpectation()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_expectedFailure()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 479.96699810028076 ms
-                    - value: 479.96699810028076
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Failure is expected"
-                  - name: "test_expectedFailure()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.expectedFailure
-            ▿ RepeatableTest
-              - name: "test_failure()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 0.9859800338745117 ms
-                    - value: 0.9859800338745117
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.9859800338745117 ms
-                          - value: 0.9859800338745117
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.9039640426635742 ms
-                    - value: 0.9039640426635742
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.9039640426635742 ms
-                          - value: 0.9039640426635742
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.8350610733032227 ms
-                    - value: 0.8350610733032227
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.8350610733032227 ms
-                          - value: 0.8350610733032227
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_flacky()"
-              ▿ tests: 2 elements
-                ▿ Test
-                  ▿ duration: 0.9180307388305664 ms
-                    - value: 0.9180307388305664
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Flacky failure message: result was 2.0"
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.9180307388305664 ms
-                          - value: 0.9180307388305664
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Flacky failure message: result was 2.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.42808055877685547 ms
-                    - value: 0.42808055877685547
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.42808055877685547 ms
-                          - value: 0.42808055877685547
-                          - unit: "ms"
-                      - message: Optional<String>.none
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.success
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_performance()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 264.117956161499 ms
-                    - value: 264.117956161499
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_performance()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_skip()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 1.4600753784179688 ms
-                    - value: 1.4600753784179688
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Test skipped - Skip message"
-                  - name: "test_skip()"
-                  - path: 0 elements
-                  ▿ skipMessage: Optional<String>
-                    - some: "Skip message"
-                  - status: Status.skipped
-            ▿ RepeatableTest
-              - name: "test_success()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.42498111724853516 ms
-                    - value: 0.42498111724853516
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_success()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_throwing()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 1.9450187683105469 ms
-                    - value: 1.9450187683105469
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.9450187683105469 ms
-                          - value: 1.9450187683105469
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.2379884719848633 ms
-                    - value: 1.2379884719848633
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.2379884719848633 ms
-                          - value: 1.2379884719848633
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 2.089977264404297 ms
-                    - value: 2.089977264404297
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 2.089977264404297 ms
-                          - value: 2.089977264404297
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_withAttachment()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 1.8069744110107422 ms
-                    - value: 1.8069744110107422
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withAttachment()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_withWarning()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.9820461273193359 ms
-                    - value: 0.9820461273193359
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withWarning()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
+    ▿ Module
+      - coverage: Optional<Coverage>.none
+      - files: 0 elements
+      - name: "StringUtils"
+      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
@@ -1,84 +1,203 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6006600660066007
-  ▿ modules: 3 members
-    ▿ Module
+  ▿ files: 5 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.4411764705882353
+          - coveredLines: 15
+          - totalLines: 34
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "Calculator.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
+      ▿ warnings: 4 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 36
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "NumberHelper.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.8507462686567164
+          - coveredLines: 57
+          - totalLines: 67
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "SwiftTestingTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9895833333333334
+          - coveredLines: 95
+          - totalLines: 96
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "XCTestTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
       - coverage: Optional<Coverage>.none
-      - files: 0 members
-      - name: "StringUtils"
-      - suites: 0 members
+      - errors: 0 elements
+      - module: Optional<String>.none
+      - name: "TextProcessor.swift"
+      - path: Optional<String>.none
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerWarning
+  ▿ modules: 3 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.21428571428571427
           - coveredLines: 15
           - totalLines: 70
-      ▿ files: 2 members
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.4411764705882353
-              - coveredLines: 15
-              - totalLines: 34
-          - errors: 0 elements
-          - name: "Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
+      - files: 0 elements
       - name: "Calculator"
-      - suites: 0 members
+      - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.7167381974248928
           - coveredLines: 167
           - totalLines: 233
-      ▿ files: 5 members
-        ▿ File
-          - coverage: Optional<Coverage>.none
-          - errors: 0 elements
-          - name: "ExampleSUITests"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
+      ▿ files: 4 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -86,8 +205,12 @@
               - coveredLines: 15
               - totalLines: 34
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "Calculator.swift"
-          ▿ warnings: 2 elements
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -112,6 +235,43 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerWarning
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 36
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
+          - name: "NumberHelper.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
+          - warnings: 0 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -119,7 +279,11 @@
               - coveredLines: 57
               - totalLines: 67
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "SwiftTestingTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -152,7 +316,11 @@
               - coveredLines: 95
               - totalLines: 96
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "XCTestTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -179,7 +347,285 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
-      ▿ suites: 2 members
+      ▿ suites: 2 elements
+        ▿ Suite
+          - name: "XCTestTests"
+          - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
+          ▿ repeatableTests: 11 members
+            ▿ RepeatableTest
+              - name: "test_async()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 12.179017066955566 ms
+                    - value: 12.179017066955566
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_async()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_asyncWithExpectation()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 13.779997825622559 ms
+                    - value: 13.779997825622559
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_asyncWithExpectation()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_expectedFailure()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 420.05908489227295 ms
+                    - value: 420.05908489227295
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Failure is expected"
+                  - name: "test_expectedFailure()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.expectedFailure
+            ▿ RepeatableTest
+              - name: "test_failure()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 2.6819705963134766 ms
+                    - value: 2.6819705963134766
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 2.6819705963134766 ms
+                          - value: 2.6819705963134766
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.8509159088134766 ms
+                    - value: 0.8509159088134766
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.8509159088134766 ms
+                          - value: 0.8509159088134766
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.8330345153808594 ms
+                    - value: 0.8330345153808594
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.8330345153808594 ms
+                          - value: 0.8330345153808594
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_flacky()"
+              ▿ tests: 2 elements
+                ▿ Test
+                  ▿ duration: 0.8319616317749023 ms
+                    - value: 0.8319616317749023
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Flacky failure message: result was 2.0"
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.8319616317749023 ms
+                          - value: 0.8319616317749023
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Flacky failure message: result was 2.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.34999847412109375 ms
+                    - value: 0.34999847412109375
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.34999847412109375 ms
+                          - value: 0.34999847412109375
+                          - unit: "ms"
+                      - message: Optional<String>.none
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.success
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_performance()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 258.120059967041 ms
+                    - value: 258.120059967041
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_performance()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_skip()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 4.318952560424805 ms
+                    - value: 4.318952560424805
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Test skipped - Skip message"
+                  - name: "test_skip()"
+                  - path: 0 elements
+                  ▿ skipMessage: Optional<String>
+                    - some: "Skip message"
+                  - status: Status.skipped
+            ▿ RepeatableTest
+              - name: "test_success()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.5609989166259766 ms
+                    - value: 0.5609989166259766
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_success()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_throwing()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 2.429962158203125 ms
+                    - value: 2.429962158203125
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 2.429962158203125 ms
+                          - value: 2.429962158203125
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.0750293731689453 ms
+                    - value: 1.0750293731689453
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.0750293731689453 ms
+                          - value: 1.0750293731689453
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.0629892349243164 ms
+                    - value: 1.0629892349243164
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.0629892349243164 ms
+                          - value: 1.0629892349243164
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_withAttachment()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.7790327072143555 ms
+                    - value: 0.7790327072143555
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withAttachment()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_withWarning()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.4169940948486328 ms
+                    - value: 0.4169940948486328
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withWarning()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
         ▿ Suite
           - name: "ExampleSUITests"
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/ExampleSUITests"
@@ -852,281 +1298,8 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-        ▿ Suite
-          - name: "XCTestTests"
-          - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
-          ▿ repeatableTests: 11 members
-            ▿ RepeatableTest
-              - name: "test_async()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 12.179017066955566 ms
-                    - value: 12.179017066955566
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_async()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_asyncWithExpectation()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 13.779997825622559 ms
-                    - value: 13.779997825622559
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_asyncWithExpectation()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_expectedFailure()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 420.05908489227295 ms
-                    - value: 420.05908489227295
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Failure is expected"
-                  - name: "test_expectedFailure()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.expectedFailure
-            ▿ RepeatableTest
-              - name: "test_failure()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 2.6819705963134766 ms
-                    - value: 2.6819705963134766
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 2.6819705963134766 ms
-                          - value: 2.6819705963134766
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.8509159088134766 ms
-                    - value: 0.8509159088134766
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.8509159088134766 ms
-                          - value: 0.8509159088134766
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.8330345153808594 ms
-                    - value: 0.8330345153808594
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.8330345153808594 ms
-                          - value: 0.8330345153808594
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_flacky()"
-              ▿ tests: 2 elements
-                ▿ Test
-                  ▿ duration: 0.8319616317749023 ms
-                    - value: 0.8319616317749023
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Flacky failure message: result was 2.0"
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.8319616317749023 ms
-                          - value: 0.8319616317749023
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Flacky failure message: result was 2.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.34999847412109375 ms
-                    - value: 0.34999847412109375
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.34999847412109375 ms
-                          - value: 0.34999847412109375
-                          - unit: "ms"
-                      - message: Optional<String>.none
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.success
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_performance()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 258.120059967041 ms
-                    - value: 258.120059967041
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_performance()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_skip()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 4.318952560424805 ms
-                    - value: 4.318952560424805
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Test skipped - Skip message"
-                  - name: "test_skip()"
-                  - path: 0 elements
-                  ▿ skipMessage: Optional<String>
-                    - some: "Skip message"
-                  - status: Status.skipped
-            ▿ RepeatableTest
-              - name: "test_success()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.5609989166259766 ms
-                    - value: 0.5609989166259766
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_success()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_throwing()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 2.429962158203125 ms
-                    - value: 2.429962158203125
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 2.429962158203125 ms
-                          - value: 2.429962158203125
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.0750293731689453 ms
-                    - value: 1.0750293731689453
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.0750293731689453 ms
-                          - value: 1.0750293731689453
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.0629892349243164 ms
-                    - value: 1.0629892349243164
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.0629892349243164 ms
-                          - value: 1.0629892349243164
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_withAttachment()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.7790327072143555 ms
-                    - value: 0.7790327072143555
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withAttachment()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_withWarning()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.4169940948486328 ms
-                    - value: 0.4169940948486328
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withWarning()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
+    ▿ Module
+      - coverage: Optional<Coverage>.none
+      - files: 0 elements
+      - name: "StringUtils"
+      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
@@ -1,84 +1,203 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6006600660066007
-  ▿ modules: 3 members
-    ▿ Module
+  ▿ files: 5 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.4411764705882353
+          - coveredLines: 15
+          - totalLines: 34
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "Calculator.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
+      ▿ warnings: 4 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 36
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "NumberHelper.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.8507462686567164
+          - coveredLines: 57
+          - totalLines: 67
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "SwiftTestingTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9895833333333334
+          - coveredLines: 95
+          - totalLines: 96
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "XCTestTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
       - coverage: Optional<Coverage>.none
-      - files: 0 members
-      - name: "StringUtils"
-      - suites: 0 members
+      - errors: 0 elements
+      - module: Optional<String>.none
+      - name: "TextProcessor.swift"
+      - path: Optional<String>.none
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerWarning
+  ▿ modules: 3 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.21428571428571427
           - coveredLines: 15
           - totalLines: 70
-      ▿ files: 2 members
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.4411764705882353
-              - coveredLines: 15
-              - totalLines: 34
-          - errors: 0 elements
-          - name: "Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
+      - files: 0 elements
       - name: "Calculator"
-      - suites: 0 members
+      - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.7167381974248928
           - coveredLines: 167
           - totalLines: 233
-      ▿ files: 5 members
-        ▿ File
-          - coverage: Optional<Coverage>.none
-          - errors: 0 elements
-          - name: "ExampleSUITests"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
+      ▿ files: 4 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -86,8 +205,12 @@
               - coveredLines: 15
               - totalLines: 34
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "Calculator.swift"
-          ▿ warnings: 2 elements
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -112,6 +235,43 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerWarning
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 36
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
+          - name: "NumberHelper.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
+          - warnings: 0 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -119,7 +279,11 @@
               - coveredLines: 57
               - totalLines: 67
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "SwiftTestingTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -152,7 +316,11 @@
               - coveredLines: 95
               - totalLines: 96
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "XCTestTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -179,7 +347,285 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
-      ▿ suites: 2 members
+      ▿ suites: 2 elements
+        ▿ Suite
+          - name: "XCTestTests"
+          - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
+          ▿ repeatableTests: 11 members
+            ▿ RepeatableTest
+              - name: "test_async()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 14.413952827453613 ms
+                    - value: 14.413952827453613
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_async()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_asyncWithExpectation()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 13.530969619750977 ms
+                    - value: 13.530969619750977
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_asyncWithExpectation()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_expectedFailure()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 395.1590061187744 ms
+                    - value: 395.1590061187744
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Failure is expected"
+                  - name: "test_expectedFailure()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.expectedFailure
+            ▿ RepeatableTest
+              - name: "test_failure()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 5.090951919555664 ms
+                    - value: 5.090951919555664
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 5.090951919555664 ms
+                          - value: 5.090951919555664
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.8000602722167969 ms
+                    - value: 1.8000602722167969
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.8000602722167969 ms
+                          - value: 1.8000602722167969
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 4.80198860168457 ms
+                    - value: 4.80198860168457
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 4.80198860168457 ms
+                          - value: 4.80198860168457
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_flacky()"
+              ▿ tests: 2 elements
+                ▿ Test
+                  ▿ duration: 6.7549943923950195 ms
+                    - value: 6.7549943923950195
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Flacky failure message: result was 2.0"
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 6.7549943923950195 ms
+                          - value: 6.7549943923950195
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Flacky failure message: result was 2.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 2.3180246353149414 ms
+                    - value: 2.3180246353149414
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 2.3180246353149414 ms
+                          - value: 2.3180246353149414
+                          - unit: "ms"
+                      - message: Optional<String>.none
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.success
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_performance()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 260.1979970932007 ms
+                    - value: 260.1979970932007
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_performance()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_skip()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 29.132962226867676 ms
+                    - value: 29.132962226867676
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Test skipped - Skip message"
+                  - name: "test_skip()"
+                  - path: 0 elements
+                  ▿ skipMessage: Optional<String>
+                    - some: "Skip message"
+                  - status: Status.skipped
+            ▿ RepeatableTest
+              - name: "test_success()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 2.454996109008789 ms
+                    - value: 2.454996109008789
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_success()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_throwing()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 3.408074378967285 ms
+                    - value: 3.408074378967285
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 3.408074378967285 ms
+                          - value: 3.408074378967285
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.710057258605957 ms
+                    - value: 1.710057258605957
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.710057258605957 ms
+                          - value: 1.710057258605957
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 3.4459829330444336 ms
+                    - value: 3.4459829330444336
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 3.4459829330444336 ms
+                          - value: 3.4459829330444336
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_withAttachment()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 18.209099769592285 ms
+                    - value: 18.209099769592285
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withAttachment()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_withWarning()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 1.1410713195800781 ms
+                    - value: 1.1410713195800781
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withWarning()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
         ▿ Suite
           - name: "ExampleSUITests"
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/ExampleSUITests"
@@ -852,281 +1298,8 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-        ▿ Suite
-          - name: "XCTestTests"
-          - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
-          ▿ repeatableTests: 11 members
-            ▿ RepeatableTest
-              - name: "test_async()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 14.413952827453613 ms
-                    - value: 14.413952827453613
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_async()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_asyncWithExpectation()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 13.530969619750977 ms
-                    - value: 13.530969619750977
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_asyncWithExpectation()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_expectedFailure()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 395.1590061187744 ms
-                    - value: 395.1590061187744
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Failure is expected"
-                  - name: "test_expectedFailure()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.expectedFailure
-            ▿ RepeatableTest
-              - name: "test_failure()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 5.090951919555664 ms
-                    - value: 5.090951919555664
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 5.090951919555664 ms
-                          - value: 5.090951919555664
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.8000602722167969 ms
-                    - value: 1.8000602722167969
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.8000602722167969 ms
-                          - value: 1.8000602722167969
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 4.80198860168457 ms
-                    - value: 4.80198860168457
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 4.80198860168457 ms
-                          - value: 4.80198860168457
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_flacky()"
-              ▿ tests: 2 elements
-                ▿ Test
-                  ▿ duration: 6.7549943923950195 ms
-                    - value: 6.7549943923950195
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Flacky failure message: result was 2.0"
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 6.7549943923950195 ms
-                          - value: 6.7549943923950195
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Flacky failure message: result was 2.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 2.3180246353149414 ms
-                    - value: 2.3180246353149414
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 2.3180246353149414 ms
-                          - value: 2.3180246353149414
-                          - unit: "ms"
-                      - message: Optional<String>.none
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.success
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_performance()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 260.1979970932007 ms
-                    - value: 260.1979970932007
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_performance()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_skip()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 29.132962226867676 ms
-                    - value: 29.132962226867676
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Test skipped - Skip message"
-                  - name: "test_skip()"
-                  - path: 0 elements
-                  ▿ skipMessage: Optional<String>
-                    - some: "Skip message"
-                  - status: Status.skipped
-            ▿ RepeatableTest
-              - name: "test_success()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 2.454996109008789 ms
-                    - value: 2.454996109008789
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_success()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_throwing()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 3.408074378967285 ms
-                    - value: 3.408074378967285
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 3.408074378967285 ms
-                          - value: 3.408074378967285
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.710057258605957 ms
-                    - value: 1.710057258605957
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.710057258605957 ms
-                          - value: 1.710057258605957
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 3.4459829330444336 ms
-                    - value: 3.4459829330444336
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 3.4459829330444336 ms
-                          - value: 3.4459829330444336
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_withAttachment()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 18.209099769592285 ms
-                    - value: 18.209099769592285
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withAttachment()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_withWarning()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 1.1410713195800781 ms
-                    - value: 1.1410713195800781
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withWarning()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
+    ▿ Module
+      - coverage: Optional<Coverage>.none
+      - files: 0 elements
+      - name: "StringUtils"
+      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
@@ -1,84 +1,203 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6006600660066007
-  ▿ modules: 3 members
-    ▿ Module
+  ▿ files: 5 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.4411764705882353
+          - coveredLines: 15
+          - totalLines: 34
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "Calculator.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
+      ▿ warnings: 4 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 36
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "NumberHelper.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.8507462686567164
+          - coveredLines: 57
+          - totalLines: 67
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "SwiftTestingTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9895833333333334
+          - coveredLines: 95
+          - totalLines: 96
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "ExamplesTests"
+      - name: "XCTestTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
       - coverage: Optional<Coverage>.none
-      - files: 0 members
-      - name: "StringUtils"
-      - suites: 0 members
+      - errors: 0 elements
+      - module: Optional<String>.none
+      - name: "TextProcessor.swift"
+      - path: Optional<String>.none
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerWarning
+  ▿ modules: 3 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.21428571428571427
           - coveredLines: 15
           - totalLines: 70
-      ▿ files: 2 members
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.4411764705882353
-              - coveredLines: 15
-              - totalLines: 34
-          - errors: 0 elements
-          - name: "Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
+      - files: 0 elements
       - name: "Calculator"
-      - suites: 0 members
+      - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.7167381974248928
           - coveredLines: 167
           - totalLines: 233
-      ▿ files: 5 members
-        ▿ File
-          - coverage: Optional<Coverage>.none
-          - errors: 0 elements
-          - name: "ExampleSUITests"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
+      ▿ files: 4 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -86,8 +205,12 @@
               - coveredLines: 15
               - totalLines: 34
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "Calculator.swift"
-          ▿ warnings: 2 elements
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -112,6 +235,43 @@
                   - startLine: 7
               - message: "Some warning from Calculator"
               - type: IssueType.swiftCompilerWarning
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 17
+                  ▿ endLine: Optional<Int>
+                    - some: 7
+                  ▿ startColumn: Optional<Int>
+                    - some: 17
+                  - startLine: 7
+              - message: "Some warning from Calculator"
+              - type: IssueType.swiftCompilerWarning
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 36
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
+          - name: "NumberHelper.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
+          - warnings: 0 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -119,7 +279,11 @@
               - coveredLines: 57
               - totalLines: 67
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "SwiftTestingTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -152,7 +316,11 @@
               - coveredLines: 95
               - totalLines: 96
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "ExamplesTests"
           - name: "XCTestTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -179,7 +347,285 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
-      ▿ suites: 2 members
+      ▿ suites: 2 elements
+        ▿ Suite
+          - name: "XCTestTests"
+          - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
+          ▿ repeatableTests: 11 members
+            ▿ RepeatableTest
+              - name: "test_async()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 14.248967170715332 ms
+                    - value: 14.248967170715332
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_async()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_asyncWithExpectation()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 11.571049690246582 ms
+                    - value: 11.571049690246582
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_asyncWithExpectation()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_expectedFailure()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 265.2930021286011 ms
+                    - value: 265.2930021286011
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Failure is expected"
+                  - name: "test_expectedFailure()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.expectedFailure
+            ▿ RepeatableTest
+              - name: "test_failure()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 2.102017402648926 ms
+                    - value: 2.102017402648926
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 2.102017402648926 ms
+                          - value: 2.102017402648926
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.8540153503417969 ms
+                    - value: 0.8540153503417969
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.8540153503417969 ms
+                          - value: 0.8540153503417969
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.8920431137084961 ms
+                    - value: 0.8920431137084961
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.8920431137084961 ms
+                          - value: 0.8920431137084961
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_flacky()"
+              ▿ tests: 2 elements
+                ▿ Test
+                  ▿ duration: 2.1779537200927734 ms
+                    - value: 2.1779537200927734
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Flacky failure message: result was 2.0"
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 2.1779537200927734 ms
+                          - value: 2.1779537200927734
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Flacky failure message: result was 2.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.35202503204345703 ms
+                    - value: 0.35202503204345703
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.35202503204345703 ms
+                          - value: 0.35202503204345703
+                          - unit: "ms"
+                      - message: Optional<String>.none
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.success
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_performance()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 258.83805751800537 ms
+                    - value: 258.83805751800537
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_performance()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_skip()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 4.939913749694824 ms
+                    - value: 4.939913749694824
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Test skipped - Skip message"
+                  - name: "test_skip()"
+                  - path: 0 elements
+                  ▿ skipMessage: Optional<String>
+                    - some: "Skip message"
+                  - status: Status.skipped
+            ▿ RepeatableTest
+              - name: "test_success()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.6730556488037109 ms
+                    - value: 0.6730556488037109
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_success()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_throwing()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 3.805994987487793 ms
+                    - value: 3.805994987487793
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 3.805994987487793 ms
+                          - value: 3.805994987487793
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.3469457626342773 ms
+                    - value: 1.3469457626342773
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.3469457626342773 ms
+                          - value: 1.3469457626342773
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.5549659729003906 ms
+                    - value: 1.5549659729003906
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.5549659729003906 ms
+                          - value: 1.5549659729003906
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_withAttachment()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 1.0700225830078125 ms
+                    - value: 1.0700225830078125
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withAttachment()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_withWarning()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.8500814437866211 ms
+                    - value: 0.8500814437866211
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withWarning()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
         ▿ Suite
           - name: "ExampleSUITests"
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/ExampleSUITests"
@@ -852,281 +1298,8 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-        ▿ Suite
-          - name: "XCTestTests"
-          - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
-          ▿ repeatableTests: 11 members
-            ▿ RepeatableTest
-              - name: "test_async()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 14.248967170715332 ms
-                    - value: 14.248967170715332
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_async()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_asyncWithExpectation()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 11.571049690246582 ms
-                    - value: 11.571049690246582
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_asyncWithExpectation()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_expectedFailure()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 265.2930021286011 ms
-                    - value: 265.2930021286011
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Failure is expected"
-                  - name: "test_expectedFailure()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.expectedFailure
-            ▿ RepeatableTest
-              - name: "test_failure()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 2.102017402648926 ms
-                    - value: 2.102017402648926
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 2.102017402648926 ms
-                          - value: 2.102017402648926
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.8540153503417969 ms
-                    - value: 0.8540153503417969
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.8540153503417969 ms
-                          - value: 0.8540153503417969
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.8920431137084961 ms
-                    - value: 0.8920431137084961
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.8920431137084961 ms
-                          - value: 0.8920431137084961
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_flacky()"
-              ▿ tests: 2 elements
-                ▿ Test
-                  ▿ duration: 2.1779537200927734 ms
-                    - value: 2.1779537200927734
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Flacky failure message: result was 2.0"
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 2.1779537200927734 ms
-                          - value: 2.1779537200927734
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Flacky failure message: result was 2.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.35202503204345703 ms
-                    - value: 0.35202503204345703
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.35202503204345703 ms
-                          - value: 0.35202503204345703
-                          - unit: "ms"
-                      - message: Optional<String>.none
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.success
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_performance()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 258.83805751800537 ms
-                    - value: 258.83805751800537
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_performance()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_skip()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 4.939913749694824 ms
-                    - value: 4.939913749694824
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Test skipped - Skip message"
-                  - name: "test_skip()"
-                  - path: 0 elements
-                  ▿ skipMessage: Optional<String>
-                    - some: "Skip message"
-                  - status: Status.skipped
-            ▿ RepeatableTest
-              - name: "test_success()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.6730556488037109 ms
-                    - value: 0.6730556488037109
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_success()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_throwing()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 3.805994987487793 ms
-                    - value: 3.805994987487793
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 3.805994987487793 ms
-                          - value: 3.805994987487793
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.3469457626342773 ms
-                    - value: 1.3469457626342773
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.3469457626342773 ms
-                          - value: 1.3469457626342773
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.5549659729003906 ms
-                    - value: 1.5549659729003906
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.5549659729003906 ms
-                          - value: 1.5549659729003906
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Calculator.swift:26: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_withAttachment()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 1.0700225830078125 ms
-                    - value: 1.0700225830078125
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withAttachment()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_withWarning()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.8500814437866211 ms
-                    - value: 0.8500814437866211
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withWarning()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
+    ▿ Module
+      - coverage: Optional<Coverage>.none
+      - files: 0 elements
+      - name: "StringUtils"
+      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
@@ -1,65 +1,249 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6703703703703704
-  ▿ modules: 4 members
-    ▿ Module
+  ▿ files: 6 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.4411764705882353
+          - coveredLines: 15
+          - totalLines: 34
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExample.app"
+      - name: "Calculator.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 36
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExample.app"
+      - name: "NumberHelper.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/NumberHelper.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 1.0
+          - coveredLines: 14
+          - totalLines: 14
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExample.app"
+      - name: "XcodeprojExampleApp.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.8507462686567164
+          - coveredLines: 57
+          - totalLines: 67
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExampleTests.xctest"
+      - name: "SwiftTestingTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
+      ▿ warnings: 4 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 25
+              ▿ endLine: Optional<Int>
+                - some: 72
+              ▿ startColumn: Optional<Int>
+                - some: 25
+              - startLine: 72
+          - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 32
+              ▿ endLine: Optional<Int>
+                - some: 75
+              ▿ startColumn: Optional<Int>
+                - some: 32
+              - startLine: 75
+          - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9895833333333334
+          - coveredLines: 95
+          - totalLines: 96
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExampleTests.xctest"
+      - name: "XCTestTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
+      ▿ warnings: 5 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 25
+              ▿ endLine: Optional<Int>
+                - some: 50
+              ▿ startColumn: Optional<Int>
+                - some: 25
+              - startLine: 50
+          - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 32
+              ▿ endLine: Optional<Int>
+                - some: 53
+              ▿ startColumn: Optional<Int>
+                - some: 32
+              - startLine: 53
+          - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 36
+              ▿ endLine: Optional<Int>
+                - some: 64
+              ▿ startColumn: Optional<Int>
+                - some: 36
+              - startLine: 64
+          - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.0
           - coveredLines: 0
           - totalLines: 23
-      ▿ files: 1 member
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 23
-          - errors: 0 elements
-          - name: "TextProcessor.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleFramework.framework"
-      - suites: 0 members
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExampleFramework.framework"
+      - name: "TextProcessor.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerWarning
+  ▿ modules: 3 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.34523809523809523
           - coveredLines: 29
           - totalLines: 84
-      ▿ files: 3 members
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
+      ▿ files: 3 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -67,7 +251,11 @@
               - coveredLines: 15
               - totalLines: 34
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExample.app"
           - name: "Calculator.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -96,97 +284,309 @@
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
-              - coverage: 1.0
-              - coveredLines: 14
-              - totalLines: 14
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 36
           - errors: 0 elements
-          - name: "XcodeprojExampleApp.swift"
-          - warnings: 0 elements
-      - name: "XcodeprojExample.app"
-      - suites: 0 members
-    ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.9325153374233128
-          - coveredLines: 152
-          - totalLines: 163
-      ▿ files: 2 members
-        ▿ File
-          - coverage: Optional<Coverage>.none
-          - errors: 0 elements
-          - name: "ExampleSUITests"
+          ▿ module: Optional<String>
+            - some: "XcodeprojExample.app"
+          - name: "NumberHelper.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
-              - coverage: 0.9895833333333334
-              - coveredLines: 95
-              - totalLines: 96
+              - coverage: 1.0
+              - coveredLines: 14
+              - totalLines: 14
           - errors: 0 elements
-          - name: "XCTestTests.swift"
-          ▿ warnings: 5 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 102
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 102
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 102
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 102
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 25
-                  ▿ endLine: Optional<Int>
-                    - some: 50
-                  ▿ startColumn: Optional<Int>
-                    - some: 25
-                  - startLine: 50
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 32
-                  ▿ endLine: Optional<Int>
-                    - some: 53
-                  ▿ startColumn: Optional<Int>
-                    - some: 32
-                  - startLine: 53
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 36
-                  ▿ endLine: Optional<Int>
-                    - some: 64
-                  ▿ startColumn: Optional<Int>
-                    - some: 36
-                  - startLine: 64
-              - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleTests"
-      ▿ suites: 2 members
+          ▿ module: Optional<String>
+            - some: "XcodeprojExample.app"
+          - name: "XcodeprojExampleApp.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
+          - warnings: 0 elements
+      - name: "XcodeprojExample.app"
+      ▿ suites: 2 elements
+        ▿ Suite
+          - name: "XCTestTests"
+          - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/XCTestTests"
+          ▿ repeatableTests: 11 members
+            ▿ RepeatableTest
+              - name: "test_async()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 13.841032981872559 ms
+                    - value: 13.841032981872559
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_async()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_asyncWithExpectation()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 11.62099838256836 ms
+                    - value: 11.62099838256836
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_asyncWithExpectation()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_expectedFailure()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 395.0389623641968 ms
+                    - value: 395.0389623641968
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Failure is expected"
+                  - name: "test_expectedFailure()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.expectedFailure
+            ▿ RepeatableTest
+              - name: "test_failure()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 15.00701904296875 ms
+                    - value: 15.00701904296875
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 15.00701904296875 ms
+                          - value: 15.00701904296875
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.0110139846801758 ms
+                    - value: 1.0110139846801758
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.0110139846801758 ms
+                          - value: 1.0110139846801758
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 2223.719000816345 ms
+                    - value: 2223.719000816345
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 2223.719000816345 ms
+                          - value: 2223.719000816345
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_flacky()"
+              ▿ tests: 2 elements
+                ▿ Test
+                  ▿ duration: 1.0019540786743164 ms
+                    - value: 1.0019540786743164
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Flacky failure message: result was 2.0"
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.0019540786743164 ms
+                          - value: 1.0019540786743164
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Flacky failure message: result was 2.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.3129243850708008 ms
+                    - value: 0.3129243850708008
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.3129243850708008 ms
+                          - value: 0.3129243850708008
+                          - unit: "ms"
+                      - message: Optional<String>.none
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.success
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_performance()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 267.13407039642334 ms
+                    - value: 267.13407039642334
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_performance()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_skip()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 40.708065032958984 ms
+                    - value: 40.708065032958984
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Test skipped - Skip message"
+                  - name: "test_skip()"
+                  - path: 0 elements
+                  ▿ skipMessage: Optional<String>
+                    - some: "Skip message"
+                  - status: Status.skipped
+            ▿ RepeatableTest
+              - name: "test_success()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.39589405059814453 ms
+                    - value: 0.39589405059814453
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_success()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_throwing()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 4.260063171386719 ms
+                    - value: 4.260063171386719
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 4.260063171386719 ms
+                          - value: 4.260063171386719
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.2710094451904297 ms
+                    - value: 1.2710094451904297
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.2710094451904297 ms
+                          - value: 1.2710094451904297
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.2449026107788086 ms
+                    - value: 1.2449026107788086
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.2449026107788086 ms
+                          - value: 1.2449026107788086
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_withAttachment()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.7349252700805664 ms
+                    - value: 0.7349252700805664
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withAttachment()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_withWarning()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.3190040588378906 ms
+                    - value: 0.3190040588378906
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withWarning()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
         ▿ Suite
           - name: "ExampleSUITests"
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/ExampleSUITests"
@@ -859,311 +1259,37 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-        ▿ Suite
-          - name: "XCTestTests"
-          - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/XCTestTests"
-          ▿ repeatableTests: 11 members
-            ▿ RepeatableTest
-              - name: "test_async()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 13.841032981872559 ms
-                    - value: 13.841032981872559
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_async()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_asyncWithExpectation()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 11.62099838256836 ms
-                    - value: 11.62099838256836
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_asyncWithExpectation()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_expectedFailure()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 395.0389623641968 ms
-                    - value: 395.0389623641968
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Failure is expected"
-                  - name: "test_expectedFailure()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.expectedFailure
-            ▿ RepeatableTest
-              - name: "test_failure()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 15.00701904296875 ms
-                    - value: 15.00701904296875
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 15.00701904296875 ms
-                          - value: 15.00701904296875
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.0110139846801758 ms
-                    - value: 1.0110139846801758
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.0110139846801758 ms
-                          - value: 1.0110139846801758
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 2223.719000816345 ms
-                    - value: 2223.719000816345
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 2223.719000816345 ms
-                          - value: 2223.719000816345
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_flacky()"
-              ▿ tests: 2 elements
-                ▿ Test
-                  ▿ duration: 1.0019540786743164 ms
-                    - value: 1.0019540786743164
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Flacky failure message: result was 2.0"
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.0019540786743164 ms
-                          - value: 1.0019540786743164
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Flacky failure message: result was 2.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.3129243850708008 ms
-                    - value: 0.3129243850708008
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.3129243850708008 ms
-                          - value: 0.3129243850708008
-                          - unit: "ms"
-                      - message: Optional<String>.none
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.success
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_performance()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 267.13407039642334 ms
-                    - value: 267.13407039642334
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_performance()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_skip()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 40.708065032958984 ms
-                    - value: 40.708065032958984
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Test skipped - Skip message"
-                  - name: "test_skip()"
-                  - path: 0 elements
-                  ▿ skipMessage: Optional<String>
-                    - some: "Skip message"
-                  - status: Status.skipped
-            ▿ RepeatableTest
-              - name: "test_success()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.39589405059814453 ms
-                    - value: 0.39589405059814453
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_success()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_throwing()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 4.260063171386719 ms
-                    - value: 4.260063171386719
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 4.260063171386719 ms
-                          - value: 4.260063171386719
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.2710094451904297 ms
-                    - value: 1.2710094451904297
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.2710094451904297 ms
-                          - value: 1.2710094451904297
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.2449026107788086 ms
-                    - value: 1.2449026107788086
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.2449026107788086 ms
-                          - value: 1.2449026107788086
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_withAttachment()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.7349252700805664 ms
-                    - value: 0.7349252700805664
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withAttachment()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_withWarning()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.3190040588378906 ms
-                    - value: 0.3190040588378906
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withWarning()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
-          - coverage: 0.9325153374233128
-          - coveredLines: 152
-          - totalLines: 163
-      ▿ files: 2 members
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 23
+      ▿ files: 1 element
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
-              - coverage: 0.8507462686567164
-              - coveredLines: 57
-              - totalLines: 67
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 23
           - errors: 0 elements
-          - name: "SwiftTestingTests.swift"
-          ▿ warnings: 4 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExampleFramework.framework"
+          - name: "TextProcessor.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 98
+                    - some: 13
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 98
-              - message: "Some warning from ExampleSUITests"
+                  - startLine: 13
+              - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
@@ -1171,12 +1297,34 @@
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 98
+                    - some: 13
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 98
-              - message: "Some warning from ExampleSUITests"
+                  - startLine: 13
+              - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerWarning
+      - name: "XcodeprojExampleFramework.framework"
+      - suites: 0 elements
+    ▿ Module
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9325153374233128
+          - coveredLines: 152
+          - totalLines: 163
+      ▿ files: 2 elements
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.8507462686567164
+              - coveredLines: 57
+              - totalLines: 67
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExampleTests.xctest"
+          - name: "SwiftTestingTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1201,25 +1349,16 @@
                   - startLine: 75
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9895833333333334
-              - coveredLines: 95
-              - totalLines: 96
-          - errors: 0 elements
-          - name: "XCTestTests.swift"
-          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 102
+                    - some: 98
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 102
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
@@ -1228,12 +1367,25 @@
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 102
+                    - some: 98
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 102
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.9895833333333334
+              - coveredLines: 95
+              - totalLines: 96
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExampleTests.xctest"
+          - name: "XCTestTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1270,5 +1422,29 @@
                   - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"
-      - suites: 0 members
+      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
@@ -1,65 +1,249 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6703703703703704
-  ▿ modules: 4 members
-    ▿ Module
+  ▿ files: 6 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.4411764705882353
+          - coveredLines: 15
+          - totalLines: 34
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExample.app"
+      - name: "Calculator.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 36
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExample.app"
+      - name: "NumberHelper.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/NumberHelper.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 1.0
+          - coveredLines: 14
+          - totalLines: 14
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExample.app"
+      - name: "XcodeprojExampleApp.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.8507462686567164
+          - coveredLines: 57
+          - totalLines: 67
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExampleTests.xctest"
+      - name: "SwiftTestingTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
+      ▿ warnings: 4 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 25
+              ▿ endLine: Optional<Int>
+                - some: 72
+              ▿ startColumn: Optional<Int>
+                - some: 25
+              - startLine: 72
+          - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 32
+              ▿ endLine: Optional<Int>
+                - some: 75
+              ▿ startColumn: Optional<Int>
+                - some: 32
+              - startLine: 75
+          - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9895833333333334
+          - coveredLines: 95
+          - totalLines: 96
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExampleTests.xctest"
+      - name: "XCTestTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
+      ▿ warnings: 5 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 25
+              ▿ endLine: Optional<Int>
+                - some: 50
+              ▿ startColumn: Optional<Int>
+                - some: 25
+              - startLine: 50
+          - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 32
+              ▿ endLine: Optional<Int>
+                - some: 53
+              ▿ startColumn: Optional<Int>
+                - some: 32
+              - startLine: 53
+          - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 36
+              ▿ endLine: Optional<Int>
+                - some: 64
+              ▿ startColumn: Optional<Int>
+                - some: 36
+              - startLine: 64
+          - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.0
           - coveredLines: 0
           - totalLines: 23
-      ▿ files: 1 member
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 23
-          - errors: 0 elements
-          - name: "TextProcessor.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleFramework.framework"
-      - suites: 0 members
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExampleFramework.framework"
+      - name: "TextProcessor.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerWarning
+  ▿ modules: 3 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.34523809523809523
           - coveredLines: 29
           - totalLines: 84
-      ▿ files: 3 members
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
+      ▿ files: 3 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -67,7 +251,11 @@
               - coveredLines: 15
               - totalLines: 34
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExample.app"
           - name: "Calculator.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -96,97 +284,309 @@
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
-              - coverage: 1.0
-              - coveredLines: 14
-              - totalLines: 14
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 36
           - errors: 0 elements
-          - name: "XcodeprojExampleApp.swift"
-          - warnings: 0 elements
-      - name: "XcodeprojExample.app"
-      - suites: 0 members
-    ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.9325153374233128
-          - coveredLines: 152
-          - totalLines: 163
-      ▿ files: 2 members
-        ▿ File
-          - coverage: Optional<Coverage>.none
-          - errors: 0 elements
-          - name: "ExampleSUITests"
+          ▿ module: Optional<String>
+            - some: "XcodeprojExample.app"
+          - name: "NumberHelper.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
-              - coverage: 0.9895833333333334
-              - coveredLines: 95
-              - totalLines: 96
+              - coverage: 1.0
+              - coveredLines: 14
+              - totalLines: 14
           - errors: 0 elements
-          - name: "XCTestTests.swift"
-          ▿ warnings: 5 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 102
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 102
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 102
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 102
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 25
-                  ▿ endLine: Optional<Int>
-                    - some: 50
-                  ▿ startColumn: Optional<Int>
-                    - some: 25
-                  - startLine: 50
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 32
-                  ▿ endLine: Optional<Int>
-                    - some: 53
-                  ▿ startColumn: Optional<Int>
-                    - some: 32
-                  - startLine: 53
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 36
-                  ▿ endLine: Optional<Int>
-                    - some: 64
-                  ▿ startColumn: Optional<Int>
-                    - some: 36
-                  - startLine: 64
-              - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleTests"
-      ▿ suites: 2 members
+          ▿ module: Optional<String>
+            - some: "XcodeprojExample.app"
+          - name: "XcodeprojExampleApp.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
+          - warnings: 0 elements
+      - name: "XcodeprojExample.app"
+      ▿ suites: 2 elements
+        ▿ Suite
+          - name: "XCTestTests"
+          - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/XCTestTests"
+          ▿ repeatableTests: 11 members
+            ▿ RepeatableTest
+              - name: "test_async()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 13.139963150024414 ms
+                    - value: 13.139963150024414
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_async()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_asyncWithExpectation()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 11.280059814453125 ms
+                    - value: 11.280059814453125
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_asyncWithExpectation()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_expectedFailure()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 63.93897533416748 ms
+                    - value: 63.93897533416748
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Failure is expected"
+                  - name: "test_expectedFailure()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.expectedFailure
+            ▿ RepeatableTest
+              - name: "test_failure()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 0.9390115737915039 ms
+                    - value: 0.9390115737915039
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.9390115737915039 ms
+                          - value: 0.9390115737915039
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.8319616317749023 ms
+                    - value: 0.8319616317749023
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.8319616317749023 ms
+                          - value: 0.8319616317749023
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.8020401000976562 ms
+                    - value: 0.8020401000976562
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.8020401000976562 ms
+                          - value: 0.8020401000976562
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_flacky()"
+              ▿ tests: 2 elements
+                ▿ Test
+                  ▿ duration: 0.8020401000976562 ms
+                    - value: 0.8020401000976562
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Flacky failure message: result was 2.0"
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.8020401000976562 ms
+                          - value: 0.8020401000976562
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Flacky failure message: result was 2.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 3.0410289764404297 ms
+                    - value: 3.0410289764404297
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 3.0410289764404297 ms
+                          - value: 3.0410289764404297
+                          - unit: "ms"
+                      - message: Optional<String>.none
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.success
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_performance()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 258.4850788116455 ms
+                    - value: 258.4850788116455
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_performance()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_skip()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 1.9630193710327148 ms
+                    - value: 1.9630193710327148
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Test skipped - Skip message"
+                  - name: "test_skip()"
+                  - path: 0 elements
+                  ▿ skipMessage: Optional<String>
+                    - some: "Skip message"
+                  - status: Status.skipped
+            ▿ RepeatableTest
+              - name: "test_success()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.861048698425293 ms
+                    - value: 0.861048698425293
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_success()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_throwing()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 3.0019283294677734 ms
+                    - value: 3.0019283294677734
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 3.0019283294677734 ms
+                          - value: 3.0019283294677734
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 2.553105354309082 ms
+                    - value: 2.553105354309082
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 2.553105354309082 ms
+                          - value: 2.553105354309082
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 2.6280879974365234 ms
+                    - value: 2.6280879974365234
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 2.6280879974365234 ms
+                          - value: 2.6280879974365234
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_withAttachment()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 2.424001693725586 ms
+                    - value: 2.424001693725586
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withAttachment()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_withWarning()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.8809566497802734 ms
+                    - value: 0.8809566497802734
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withWarning()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
         ▿ Suite
           - name: "ExampleSUITests"
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/ExampleSUITests"
@@ -859,311 +1259,37 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-        ▿ Suite
-          - name: "XCTestTests"
-          - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/XCTestTests"
-          ▿ repeatableTests: 11 members
-            ▿ RepeatableTest
-              - name: "test_async()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 13.139963150024414 ms
-                    - value: 13.139963150024414
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_async()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_asyncWithExpectation()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 11.280059814453125 ms
-                    - value: 11.280059814453125
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_asyncWithExpectation()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_expectedFailure()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 63.93897533416748 ms
-                    - value: 63.93897533416748
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Failure is expected"
-                  - name: "test_expectedFailure()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.expectedFailure
-            ▿ RepeatableTest
-              - name: "test_failure()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 0.9390115737915039 ms
-                    - value: 0.9390115737915039
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.9390115737915039 ms
-                          - value: 0.9390115737915039
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.8319616317749023 ms
-                    - value: 0.8319616317749023
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.8319616317749023 ms
-                          - value: 0.8319616317749023
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.8020401000976562 ms
-                    - value: 0.8020401000976562
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.8020401000976562 ms
-                          - value: 0.8020401000976562
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_flacky()"
-              ▿ tests: 2 elements
-                ▿ Test
-                  ▿ duration: 0.8020401000976562 ms
-                    - value: 0.8020401000976562
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Flacky failure message: result was 2.0"
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.8020401000976562 ms
-                          - value: 0.8020401000976562
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Flacky failure message: result was 2.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 3.0410289764404297 ms
-                    - value: 3.0410289764404297
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 3.0410289764404297 ms
-                          - value: 3.0410289764404297
-                          - unit: "ms"
-                      - message: Optional<String>.none
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.success
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_performance()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 258.4850788116455 ms
-                    - value: 258.4850788116455
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_performance()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_skip()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 1.9630193710327148 ms
-                    - value: 1.9630193710327148
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Test skipped - Skip message"
-                  - name: "test_skip()"
-                  - path: 0 elements
-                  ▿ skipMessage: Optional<String>
-                    - some: "Skip message"
-                  - status: Status.skipped
-            ▿ RepeatableTest
-              - name: "test_success()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.861048698425293 ms
-                    - value: 0.861048698425293
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_success()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_throwing()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 3.0019283294677734 ms
-                    - value: 3.0019283294677734
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 3.0019283294677734 ms
-                          - value: 3.0019283294677734
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 2.553105354309082 ms
-                    - value: 2.553105354309082
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 2.553105354309082 ms
-                          - value: 2.553105354309082
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 2.6280879974365234 ms
-                    - value: 2.6280879974365234
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 2.6280879974365234 ms
-                          - value: 2.6280879974365234
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_withAttachment()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 2.424001693725586 ms
-                    - value: 2.424001693725586
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withAttachment()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_withWarning()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.8809566497802734 ms
-                    - value: 0.8809566497802734
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withWarning()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
-          - coverage: 0.9325153374233128
-          - coveredLines: 152
-          - totalLines: 163
-      ▿ files: 2 members
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 23
+      ▿ files: 1 element
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
-              - coverage: 0.8507462686567164
-              - coveredLines: 57
-              - totalLines: 67
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 23
           - errors: 0 elements
-          - name: "SwiftTestingTests.swift"
-          ▿ warnings: 4 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExampleFramework.framework"
+          - name: "TextProcessor.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 98
+                    - some: 13
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 98
-              - message: "Some warning from ExampleSUITests"
+                  - startLine: 13
+              - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
@@ -1171,12 +1297,34 @@
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 98
+                    - some: 13
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 98
-              - message: "Some warning from ExampleSUITests"
+                  - startLine: 13
+              - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerWarning
+      - name: "XcodeprojExampleFramework.framework"
+      - suites: 0 elements
+    ▿ Module
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9325153374233128
+          - coveredLines: 152
+          - totalLines: 163
+      ▿ files: 2 elements
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.8507462686567164
+              - coveredLines: 57
+              - totalLines: 67
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExampleTests.xctest"
+          - name: "SwiftTestingTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1201,25 +1349,16 @@
                   - startLine: 75
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9895833333333334
-              - coveredLines: 95
-              - totalLines: 96
-          - errors: 0 elements
-          - name: "XCTestTests.swift"
-          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 102
+                    - some: 98
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 102
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
@@ -1228,12 +1367,25 @@
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 102
+                    - some: 98
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 102
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.9895833333333334
+              - coveredLines: 95
+              - totalLines: 96
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExampleTests.xctest"
+          - name: "XCTestTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1270,5 +1422,29 @@
                   - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"
-      - suites: 0 members
+      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
@@ -1,65 +1,249 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6703703703703704
-  ▿ modules: 4 members
-    ▿ Module
+  ▿ files: 6 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.4411764705882353
+          - coveredLines: 15
+          - totalLines: 34
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExample.app"
+      - name: "Calculator.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 17
+              ▿ endLine: Optional<Int>
+                - some: 7
+              ▿ startColumn: Optional<Int>
+                - some: 17
+              - startLine: 7
+          - message: "Some warning from Calculator"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 36
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExample.app"
+      - name: "NumberHelper.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/NumberHelper.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 1.0
+          - coveredLines: 14
+          - totalLines: 14
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExample.app"
+      - name: "XcodeprojExampleApp.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
+      - warnings: 0 elements
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.8507462686567164
+          - coveredLines: 57
+          - totalLines: 67
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExampleTests.xctest"
+      - name: "SwiftTestingTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
+      ▿ warnings: 4 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 25
+              ▿ endLine: Optional<Int>
+                - some: 72
+              ▿ startColumn: Optional<Int>
+                - some: 25
+              - startLine: 72
+          - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 32
+              ▿ endLine: Optional<Int>
+                - some: 75
+              ▿ startColumn: Optional<Int>
+                - some: 32
+              - startLine: 75
+          - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 98
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 98
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9895833333333334
+          - coveredLines: 95
+          - totalLines: 96
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExampleTests.xctest"
+      - name: "XCTestTests.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
+      ▿ warnings: 5 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 25
+              ▿ endLine: Optional<Int>
+                - some: 50
+              ▿ startColumn: Optional<Int>
+                - some: 25
+              - startLine: 50
+          - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 32
+              ▿ endLine: Optional<Int>
+                - some: 53
+              ▿ startColumn: Optional<Int>
+                - some: 32
+              - startLine: 53
+          - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 36
+              ▿ endLine: Optional<Int>
+                - some: 64
+              ▿ startColumn: Optional<Int>
+                - some: 36
+              - startLine: 64
+          - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
+          - type: IssueType.swiftCompilerWarning
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 102
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 102
+          - message: "Some warning from ExampleSUITests"
+          - type: IssueType.swiftCompilerWarning
+    ▿ File
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.0
           - coveredLines: 0
           - totalLines: 23
-      ▿ files: 1 member
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 23
-          - errors: 0 elements
-          - name: "TextProcessor.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleFramework.framework"
-      - suites: 0 members
+      - errors: 0 elements
+      ▿ module: Optional<String>
+        - some: "XcodeprojExampleFramework.framework"
+      - name: "TextProcessor.swift"
+      ▿ path: Optional<String>
+        - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
+      ▿ warnings: 2 elements
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerError
+        ▿ Issue
+          ▿ location: Optional<Location>
+            ▿ some: Location
+              ▿ endColumn: Optional<Int>
+                - some: 9
+              ▿ endLine: Optional<Int>
+                - some: 13
+              ▿ startColumn: Optional<Int>
+                - some: 9
+              - startLine: 13
+          - message: "Some warning from StringUtils"
+          - type: IssueType.swiftCompilerWarning
+  ▿ modules: 3 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
           - coverage: 0.34523809523809523
           - coveredLines: 29
           - totalLines: 84
-      ▿ files: 3 members
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          - name: "NumberHelper.swift"
-          - warnings: 0 elements
+      ▿ files: 3 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
@@ -67,7 +251,11 @@
               - coveredLines: 15
               - totalLines: 34
           - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExample.app"
           - name: "Calculator.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
           ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
@@ -96,97 +284,309 @@
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
-              - coverage: 1.0
-              - coveredLines: 14
-              - totalLines: 14
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 36
           - errors: 0 elements
-          - name: "XcodeprojExampleApp.swift"
-          - warnings: 0 elements
-      - name: "XcodeprojExample.app"
-      - suites: 0 members
-    ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.9325153374233128
-          - coveredLines: 152
-          - totalLines: 163
-      ▿ files: 2 members
-        ▿ File
-          - coverage: Optional<Coverage>.none
-          - errors: 0 elements
-          - name: "ExampleSUITests"
+          ▿ module: Optional<String>
+            - some: "XcodeprojExample.app"
+          - name: "NumberHelper.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/NumberHelper.swift"
           - warnings: 0 elements
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
-              - coverage: 0.9895833333333334
-              - coveredLines: 95
-              - totalLines: 96
+              - coverage: 1.0
+              - coveredLines: 14
+              - totalLines: 14
           - errors: 0 elements
-          - name: "XCTestTests.swift"
-          ▿ warnings: 5 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 102
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 102
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 102
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 102
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 25
-                  ▿ endLine: Optional<Int>
-                    - some: 50
-                  ▿ startColumn: Optional<Int>
-                    - some: 25
-                  - startLine: 50
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 32
-                  ▿ endLine: Optional<Int>
-                    - some: 53
-                  ▿ startColumn: Optional<Int>
-                    - some: 32
-                  - startLine: 53
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 36
-                  ▿ endLine: Optional<Int>
-                    - some: 64
-                  ▿ startColumn: Optional<Int>
-                    - some: 36
-                  - startLine: 64
-              - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleTests"
-      ▿ suites: 2 members
+          ▿ module: Optional<String>
+            - some: "XcodeprojExample.app"
+          - name: "XcodeprojExampleApp.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
+          - warnings: 0 elements
+      - name: "XcodeprojExample.app"
+      ▿ suites: 2 elements
+        ▿ Suite
+          - name: "XCTestTests"
+          - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/XCTestTests"
+          ▿ repeatableTests: 11 members
+            ▿ RepeatableTest
+              - name: "test_async()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 14.130949974060059 ms
+                    - value: 14.130949974060059
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_async()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_asyncWithExpectation()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 12.129068374633789 ms
+                    - value: 12.129068374633789
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_asyncWithExpectation()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_expectedFailure()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 1198.7639665603638 ms
+                    - value: 1198.7639665603638
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Failure is expected"
+                  - name: "test_expectedFailure()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.expectedFailure
+            ▿ RepeatableTest
+              - name: "test_failure()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 3.0710697174072266 ms
+                    - value: 3.0710697174072266
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 3.0710697174072266 ms
+                          - value: 3.0710697174072266
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.9400844573974609 ms
+                    - value: 0.9400844573974609
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.9400844573974609 ms
+                          - value: 0.9400844573974609
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1137.6309394836426 ms
+                    - value: 1137.6309394836426
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "test_failure()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1137.6309394836426 ms
+                          - value: 1137.6309394836426
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Expected 5.0 but got 6.0"
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_flacky()"
+              ▿ tests: 2 elements
+                ▿ Test
+                  ▿ duration: 0.9429454803466797 ms
+                    - value: 0.9429454803466797
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Flacky failure message: result was 2.0"
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.9429454803466797 ms
+                          - value: 0.9429454803466797
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "Flacky failure message: result was 2.0"
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.3299713134765625 ms
+                    - value: 0.3299713134765625
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_flacky()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.3299713134765625 ms
+                          - value: 0.3299713134765625
+                          - unit: "ms"
+                      - message: Optional<String>.none
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.success
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_performance()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 254.35709953308105 ms
+                    - value: 254.35709953308105
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_performance()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_skip()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 11.239051818847656 ms
+                    - value: 11.239051818847656
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "Test skipped - Skip message"
+                  - name: "test_skip()"
+                  - path: 0 elements
+                  ▿ skipMessage: Optional<String>
+                    - some: "Skip message"
+                  - status: Status.skipped
+            ▿ RepeatableTest
+              - name: "test_success()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.4140138626098633 ms
+                    - value: 0.4140138626098633
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_success()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_throwing()"
+              ▿ tests: 3 elements
+                ▿ Test
+                  ▿ duration: 4.701972007751465 ms
+                    - value: 4.701972007751465
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 4.701972007751465 ms
+                          - value: 4.701972007751465
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                      - name: "First Run"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 0.9479522705078125 ms
+                    - value: 0.9479522705078125
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 0.9479522705078125 ms
+                          - value: 0.9479522705078125
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 1"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+                ▿ Test
+                  ▿ duration: 1.412034034729004 ms
+                    - value: 1.412034034729004
+                    - unit: "ms"
+                  ▿ failureMessage: Optional<String>
+                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                  - name: "test_throwing()"
+                  ▿ path: 1 element
+                    ▿ PathNode
+                      ▿ duration: Optional<Measurement<NSUnitDuration>>
+                        ▿ some: 1.412034034729004 ms
+                          - value: 1.412034034729004
+                          - unit: "ms"
+                      ▿ message: Optional<String>
+                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+                      - name: "Retry 2"
+                      ▿ result: Optional<Status>
+                        - some: Status.failure
+                      - type: NodeType.repetition
+                  - skipMessage: Optional<String>.none
+                  - status: Status.failure
+            ▿ RepeatableTest
+              - name: "test_withAttachment()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.986933708190918 ms
+                    - value: 0.986933708190918
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withAttachment()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
+            ▿ RepeatableTest
+              - name: "test_withWarning()"
+              ▿ tests: 1 element
+                ▿ Test
+                  ▿ duration: 0.3839731216430664 ms
+                    - value: 0.3839731216430664
+                    - unit: "ms"
+                  - failureMessage: Optional<String>.none
+                  - name: "test_withWarning()"
+                  - path: 0 elements
+                  - skipMessage: Optional<String>.none
+                  - status: Status.success
         ▿ Suite
           - name: "ExampleSUITests"
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/ExampleSUITests"
@@ -859,311 +1259,37 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-        ▿ Suite
-          - name: "XCTestTests"
-          - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/XCTestTests"
-          ▿ repeatableTests: 11 members
-            ▿ RepeatableTest
-              - name: "test_async()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 14.130949974060059 ms
-                    - value: 14.130949974060059
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_async()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_asyncWithExpectation()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 12.129068374633789 ms
-                    - value: 12.129068374633789
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_asyncWithExpectation()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_expectedFailure()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 1198.7639665603638 ms
-                    - value: 1198.7639665603638
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Failure is expected"
-                  - name: "test_expectedFailure()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.expectedFailure
-            ▿ RepeatableTest
-              - name: "test_failure()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 3.0710697174072266 ms
-                    - value: 3.0710697174072266
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 3.0710697174072266 ms
-                          - value: 3.0710697174072266
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.9400844573974609 ms
-                    - value: 0.9400844573974609
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.9400844573974609 ms
-                          - value: 0.9400844573974609
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1137.6309394836426 ms
-                    - value: 1137.6309394836426
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Expected 5.0 but got 6.0"
-                  - name: "test_failure()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1137.6309394836426 ms
-                          - value: 1137.6309394836426
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Expected 5.0 but got 6.0"
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_flacky()"
-              ▿ tests: 2 elements
-                ▿ Test
-                  ▿ duration: 0.9429454803466797 ms
-                    - value: 0.9429454803466797
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Flacky failure message: result was 2.0"
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.9429454803466797 ms
-                          - value: 0.9429454803466797
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "Flacky failure message: result was 2.0"
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.3299713134765625 ms
-                    - value: 0.3299713134765625
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_flacky()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.3299713134765625 ms
-                          - value: 0.3299713134765625
-                          - unit: "ms"
-                      - message: Optional<String>.none
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.success
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_performance()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 254.35709953308105 ms
-                    - value: 254.35709953308105
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_performance()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_skip()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 11.239051818847656 ms
-                    - value: 11.239051818847656
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "Test skipped - Skip message"
-                  - name: "test_skip()"
-                  - path: 0 elements
-                  ▿ skipMessage: Optional<String>
-                    - some: "Skip message"
-                  - status: Status.skipped
-            ▿ RepeatableTest
-              - name: "test_success()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.4140138626098633 ms
-                    - value: 0.4140138626098633
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_success()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_throwing()"
-              ▿ tests: 3 elements
-                ▿ Test
-                  ▿ duration: 4.701972007751465 ms
-                    - value: 4.701972007751465
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 4.701972007751465 ms
-                          - value: 4.701972007751465
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                      - name: "First Run"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 0.9479522705078125 ms
-                    - value: 0.9479522705078125
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 0.9479522705078125 ms
-                          - value: 0.9479522705078125
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 1"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-                ▿ Test
-                  ▿ duration: 1.412034034729004 ms
-                    - value: 1.412034034729004
-                    - unit: "ms"
-                  ▿ failureMessage: Optional<String>
-                    - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                  - name: "test_throwing()"
-                  ▿ path: 1 element
-                    ▿ PathNode
-                      ▿ duration: Optional<Measurement<NSUnitDuration>>
-                        ▿ some: 1.412034034729004 ms
-                          - value: 1.412034034729004
-                          - unit: "ms"
-                      ▿ message: Optional<String>
-                        - some: "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
-                      - name: "Retry 2"
-                      ▿ result: Optional<Status>
-                        - some: Status.failure
-                      - type: NodeType.repetition
-                  - skipMessage: Optional<String>.none
-                  - status: Status.failure
-            ▿ RepeatableTest
-              - name: "test_withAttachment()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.986933708190918 ms
-                    - value: 0.986933708190918
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withAttachment()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
-            ▿ RepeatableTest
-              - name: "test_withWarning()"
-              ▿ tests: 1 element
-                ▿ Test
-                  ▿ duration: 0.3839731216430664 ms
-                    - value: 0.3839731216430664
-                    - unit: "ms"
-                  - failureMessage: Optional<String>.none
-                  - name: "test_withWarning()"
-                  - path: 0 elements
-                  - skipMessage: Optional<String>.none
-                  - status: Status.success
     ▿ Module
       ▿ coverage: Optional<Coverage>
         ▿ some: Coverage
-          - coverage: 0.9325153374233128
-          - coveredLines: 152
-          - totalLines: 163
-      ▿ files: 2 members
+          - coverage: 0.0
+          - coveredLines: 0
+          - totalLines: 23
+      ▿ files: 1 element
         ▿ File
           ▿ coverage: Optional<Coverage>
             ▿ some: Coverage
-              - coverage: 0.8507462686567164
-              - coveredLines: 57
-              - totalLines: 67
+              - coverage: 0.0
+              - coveredLines: 0
+              - totalLines: 23
           - errors: 0 elements
-          - name: "SwiftTestingTests.swift"
-          ▿ warnings: 4 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExampleFramework.framework"
+          - name: "TextProcessor.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 98
+                    - some: 13
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 98
-              - message: "Some warning from ExampleSUITests"
+                  - startLine: 13
+              - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
@@ -1171,12 +1297,34 @@
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 98
+                    - some: 13
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 98
-              - message: "Some warning from ExampleSUITests"
+                  - startLine: 13
+              - message: "Some warning from StringUtils"
               - type: IssueType.swiftCompilerWarning
+      - name: "XcodeprojExampleFramework.framework"
+      - suites: 0 elements
+    ▿ Module
+      ▿ coverage: Optional<Coverage>
+        ▿ some: Coverage
+          - coverage: 0.9325153374233128
+          - coveredLines: 152
+          - totalLines: 163
+      ▿ files: 2 elements
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.8507462686567164
+              - coveredLines: 57
+              - totalLines: 67
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExampleTests.xctest"
+          - name: "SwiftTestingTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1201,25 +1349,16 @@
                   - startLine: 75
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9895833333333334
-              - coveredLines: 95
-              - totalLines: 96
-          - errors: 0 elements
-          - name: "XCTestTests.swift"
-          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 102
+                    - some: 98
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 102
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerError
             ▿ Issue
@@ -1228,12 +1367,25 @@
                   ▿ endColumn: Optional<Int>
                     - some: 9
                   ▿ endLine: Optional<Int>
-                    - some: 102
+                    - some: 98
                   ▿ startColumn: Optional<Int>
                     - some: 9
-                  - startLine: 102
+                  - startLine: 98
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
+        ▿ File
+          ▿ coverage: Optional<Coverage>
+            ▿ some: Coverage
+              - coverage: 0.9895833333333334
+              - coveredLines: 95
+              - totalLines: 96
+          - errors: 0 elements
+          ▿ module: Optional<String>
+            - some: "XcodeprojExampleTests.xctest"
+          - name: "XCTestTests.swift"
+          ▿ path: Optional<String>
+            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -1270,5 +1422,29 @@
                   - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerError
+            ▿ Issue
+              ▿ location: Optional<Location>
+                ▿ some: Location
+                  ▿ endColumn: Optional<Int>
+                    - some: 9
+                  ▿ endLine: Optional<Int>
+                    - some: 102
+                  ▿ startColumn: Optional<Int>
+                    - some: 9
+                  - startLine: 102
+              - message: "Some warning from ExampleSUITests"
+              - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"
-      - suites: 0 members
+      - suites: 0 elements


### PR DESCRIPTION
## Summary

Resolves #168. The `4.x` model treated `Module` as the container, seeding `Module.files` from coverage. Files in test-less targets (which coverage never sees) and files with build issues that have no `producingTarget` were silently dropped — confirmed on `Xcworkspace-26.3-iOS.xcresult`, where 13 raw warnings collapse to 4 in `Report.warnings`. Flip the model: `Report.files` becomes the primary index, `Report.modules` becomes a projection over it.

## Key Changes

- **`Report.files: [File]`** — primary. Every file the bundle has any signal about (coverage, warnings, errors) appears here exactly once.
- **`Report.modules: [Module]`** — projection grouping files by target name. Files with `File.module == nil` (test-less targets, project-level issues) live in `files` only — they no longer disappear.
- **`Report.File`** gains `path: String?` (absolute path when coverage or `sourceURL` provided one) and `module: String?` (target name when known). Identity is `path ?? name`.
- **Collections**: `Set<Module>` / `Set<File>` → `[Module]` / `[File]`. Suites stay as `Set` on `Suite` for the existing hash contract.
- **Aliasing** (test bundle `FooTests` → coverage target `Foo`) sorts candidates so the chosen alias is deterministic when multiple targets satisfy the predicate.
- **Renames**: `Report.Module.File` → `Report.File`, `Report.Module.File.Issue` → `Report.File.Issue`, `Report.Module.File.Coverage` → `Report.File.Coverage`.
- **Snapshots** re-recorded.
- **New unit tests** on `File` identity (hash by `path ?? name`; same-path-different-module collide; nil-path falls back to name).

## Open questions from the issue, decided

- **`Module.files` copy or reference** — kept as `[File]` (copies). On large reports this is still tractable; we can revisit if memory bites.
- **File identity** — `path ?? name`. Same basename, different paths = distinct files.
- **Suites placement** — stay on `Module` (test results always know the target).
- **Analyzer warnings** — deferred. None of the existing fixtures contain `analyzerWarnings[]`; can be added symmetrically when there's a real signal.
- **Errors without `sourceURL`** — still dropped, same behavior as warnings (see #165). A future `Report.unboundIssues` bucket can be a follow-up if it bites.

## Breaking change

`5.0.0`. Public API surface:

- `Report.modules` is now `[Module]` (was `Set<Module>`), and is a projection — not every file appears here.
- `Report.files` is new — the source of truth.
- `Module.files` is a subset (files where `File.module == module.name`).
- `Issue.IssueType.buildWarning` is gone (renamed `.swiftCompilerWarning` in #159).
- `Issue.location` and `Issue.IssueType.unknown(_)` are present (from #159/#160).
- Counts grow because dedup was dropped in #161 and warnings on test-less files no longer disappear.

## Additional Changes

_None._