### PR TITLE
Support root-level @Test and nested @Suite (Swift Testing)

### DIFF
--- a/Sources/PeekieSDK/Formatters/JsonFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/JsonFormatter.swift
@@ -96,8 +96,16 @@ private struct JSONModule: Encodable {
         files = module.files
             .sorted { $0.name < $1.name }
             .map { JSONFile(from: $0) }
-        suites = module.suites
+        rootLevelTests = module.rootLevelTests
+            .filtered(testResults: include)
             .sorted { $0.name < $1.name }
+            .flatMap { repeatableTest in
+                repeatableTest.mergedTests(filterDevice: includeDeviceDetails == false)
+                    .filter { include.contains($0.status) }
+                    .map { JSONTest(from: $0) }
+            }
+        suites = module.suites
+            .sorted { $0.fullPath < $1.fullPath }
             .map {
                 JSONSuite(
                     from: $0,
@@ -112,6 +120,7 @@ private struct JSONModule: Encodable {
     let coverage: JSONCoverage?
     let files: [JSONFile]
     let name: String
+    let rootLevelTests: [JSONTest]
     let suites: [JSONSuite]
 }
 
@@ -188,6 +197,7 @@ private struct JSONSuite: Encodable {
         includeDeviceDetails: Bool
     ) {
         name = suite.name
+        fullPath = suite.fullPath
         tests = suite.repeatableTests
             .filtered(testResults: include)
             .sorted { $0.name < $1.name }
@@ -196,11 +206,21 @@ private struct JSONSuite: Encodable {
                     .filter { include.contains($0.status) }
                     .map { JSONTest(from: $0) }
             }
+        nestedSuites = suite.nestedSuites
+            .map {
+                Self(
+                    from: $0,
+                    include: include,
+                    includeDeviceDetails: includeDeviceDetails
+                )
+            }
     }
 
     // MARK: Internal
 
+    let fullPath: String
     let name: String
+    let nestedSuites: [Self]
     let tests: [JSONTest]
 }
 

--- a/Sources/PeekieSDK/Formatters/ListFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/ListFormatter.swift
@@ -8,12 +8,17 @@ import Logging
 /// This formatter produces plain text output with test statuses represented by emoji icons.
 /// Ideal for terminal output and CI/CD logs.
 ///
-/// Example output:
+/// Example output (`.bySuite`):
 /// ```
-/// FileA.swift
-/// ✅ test_success()
-/// ❌ test_failure() (Failure message)
-/// ⏭️ test_skip() (Skip message)
+/// ExamplesTests / (no suite)
+/// ✅ rootLevelSuccess()
+/// ❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+///
+/// ExamplesTests / OuterSuite
+/// ✅ outerSuccess()
+///
+/// ExamplesTests / OuterSuite / InnerSuite
+/// ✅ innerSuccess()
 /// ```
 public final class ListFormatter {
     // MARK: Lifecycle
@@ -22,6 +27,21 @@ public final class ListFormatter {
     public init() {}
 
     // MARK: Public
+
+    /// Controls how tests are grouped in the formatted output.
+    public enum Grouping {
+        /// Each test is printed on its own line with the full module/suite path
+        /// prefix, e.g. `"✅ ExamplesTests / OuterSuite / innerSuccess()"`. Lines
+        /// are sorted lexicographically by qualified name. Useful when piping
+        /// into `grep` or producing flat reports.
+        case fullyQualified
+
+        /// Tests are grouped under section headers of the form
+        /// `"<Module> / <Suite-path>"` (or `"<Module> / (no suite)"` for
+        /// root-level `@Test`s). This is the closest match to the historical
+        /// per-suite layout.
+        case bySuite
+    }
 
     /// Formats a given report based on specified criteria.
     ///
@@ -34,16 +54,16 @@ public final class ListFormatter {
     /// specifies which test statuses to include in the formatted report.
     ///   - includeDeviceDetails: If true, device information is included in test names. Defaults to
     /// false.
+    ///   - grouping: Layout strategy — `.bySuite` (default, with section headers) or
+    /// `.fullyQualified` (one fully qualified line per test).
     ///
     /// - Returns: A formatted string representation of the report based on the specified criteria.
-    ///
-    /// - Throws: This method may throw an error if the formatting fails for any reason, such as an
-    /// issue with the report model.
     public func format(
         _ report: Report,
         include: [Report.Module.Suite.RepeatableTest.Test.Status] = Report.Module
             .Suite.RepeatableTest.Test.Status.allCases,
-        includeDeviceDetails: Bool = false
+        includeDeviceDetails: Bool = false,
+        grouping: Grouping = .bySuite
     )
         -> String
     {
@@ -53,70 +73,160 @@ public final class ListFormatter {
                 "modulesCount": "\(report.modules.count)",
                 "includeStatuses": "\(include.map(\.rawValue).joined(separator: ","))",
                 "includeDeviceDetails": "\(includeDeviceDetails)",
+                "grouping": "\(grouping)",
             ]
         )
 
-        let files = report.modules
-            .flatMap { Array($0.suites) }
-            .sorted { $0.name < $1.name }
+        let sections = collectSections(
+            report: report,
+            include: include,
+            includeDeviceDetails: includeDeviceDetails
+        )
 
-        let filesReports = files.compactMap { file in
-            file.report(testResults: include, includeDeviceDetails: includeDeviceDetails)
-        }
+        let output: String =
+            switch grouping {
+            case .bySuite:
+                renderBySuite(sections: sections)
+            case .fullyQualified:
+                renderFullyQualified(sections: sections)
+            }
 
         logger.debug(
             "Formatting completed",
             metadata: [
-                "filesCount": "\(files.count)",
-                "filesWithResults": "\(filesReports.count)",
+                "sectionsCount": "\(sections.count)",
             ]
         )
 
-        return filesReports.joined(separator: "\n\n")
+        return output
     }
 
     // MARK: Private
 
-    private let logger = Logger(label: "com.peekie.formatter")
-}
+    /// One emit-ready section: the header path (`"<Module> / <Suite-path>"` or
+    /// `"<Module> / (no suite)"`), the qualifying prefix used in `.fullyQualified`
+    /// mode (same as header but without the `(no suite)` placeholder), and the
+    /// already-merged tests in sorted order.
+    private struct Section {
+        let header: String
+        let qualifiedPrefix: String
+        let tests: [Report.Module.Suite.RepeatableTest.Test]
+    }
 
-extension Report.Module.Suite {
-    func report(
-        testResults: [Report.Module.Suite.RepeatableTest.Test.Status],
+    private let logger = Logger(label: "com.peekie.formatter")
+
+    private func collectSections(
+        report: Report,
+        include: [Report.Module.Suite.RepeatableTest.Test.Status],
         includeDeviceDetails: Bool
     )
-        -> String?
+        -> [Section]
     {
-        let tests = repeatableTests.filtered(testResults: testResults).sorted { $0.name < $1.name }
+        var sections = [Section]()
+        for module in report.modules.sorted(by: { $0.name < $1.name }) {
+            // Root-level @Tests first (so the bundle's loose tests stay above the
+            // suite hierarchy in the human-readable view).
+            let rootTests = mergedTests(
+                from: module.rootLevelTests,
+                include: include,
+                includeDeviceDetails: includeDeviceDetails
+            )
+            if rootTests.isEmpty == false {
+                sections.append(.init(
+                    header: "\(module.name) / (no suite)",
+                    qualifiedPrefix: module.name,
+                    tests: rootTests
+                ))
+            }
 
-        guard tests.isEmpty == false else {
-            return nil
+            let suiteSections = module.suites
+                .flatMap { collectSuiteSections(
+                    suite: $0,
+                    moduleName: module.name,
+                    include: include,
+                    includeDeviceDetails: includeDeviceDetails
+                ) }
+                .sorted { $0.header < $1.header }
+            sections.append(contentsOf: suiteSections)
         }
+        return sections
+    }
 
-        var rows = [String]()
-        for repeatableTest in tests.sorted(by: { $0.name < $1.name }) {
-            // Use merged tests which already handle repetitions and optionally devices
-            let mergedTests = repeatableTest
+    private func collectSuiteSections(
+        suite: Report.Module.Suite,
+        moduleName: String,
+        include: [Report.Module.Suite.RepeatableTest.Test.Status],
+        includeDeviceDetails: Bool
+    )
+        -> [Section]
+    {
+        var sections = [Section]()
+        let tests = mergedTests(
+            from: suite.repeatableTests,
+            include: include,
+            includeDeviceDetails: includeDeviceDetails
+        )
+        if tests.isEmpty == false {
+            let prefix = "\(moduleName) / \(suite.fullPath)"
+            sections.append(.init(header: prefix, qualifiedPrefix: prefix, tests: tests))
+        }
+        for nested in suite.nestedSuites {
+            sections.append(contentsOf: collectSuiteSections(
+                suite: nested,
+                moduleName: moduleName,
+                include: include,
+                includeDeviceDetails: includeDeviceDetails
+            ))
+        }
+        return sections
+    }
+
+    private func mergedTests(
+        from repeatableTests: Set<Report.Module.Suite.RepeatableTest>,
+        include: [Report.Module.Suite.RepeatableTest.Test.Status],
+        includeDeviceDetails: Bool
+    )
+        -> [Report.Module.Suite.RepeatableTest.Test]
+    {
+        let filtered = repeatableTests
+            .filtered(testResults: include)
+            .sorted { $0.name < $1.name }
+
+        var merged = [Report.Module.Suite.RepeatableTest.Test]()
+        for repeatable in filtered {
+            let tests = repeatable
                 .mergedTests(filterDevice: includeDeviceDetails == false)
-                .filter { testResults.contains($0.status) }
+                .filter { include.contains($0.status) }
+            merged.append(contentsOf: tests)
+        }
+        return merged.sorted { $0.name < $1.name }
+    }
 
-            // Output each merged test separately
-            for test in mergedTests {
-                rows.append(test.report())
+    private func renderBySuite(sections: [Section]) -> String {
+        sections.map { section in
+            let rows = [section.header] + section.tests.map { $0.report() }
+            return rows.joined(separator: "\n")
+        }
+        .joined(separator: "\n\n")
+    }
+
+    private func renderFullyQualified(sections: [Section]) -> String {
+        var lines = [String]()
+        for section in sections {
+            for test in section.tests {
+                let qualifiedName = "\(section.qualifiedPrefix) / \(test.name)"
+                lines.append(test.report(name: qualifiedName))
             }
         }
-
-        rows.insert(name, at: 0)
-
-        return rows.joined(separator: "\n")
+        return lines.sorted().joined(separator: "\n")
     }
 }
 
 private extension Report.Module.Suite.RepeatableTest.Test {
-    func report() -> String {
+    func report(name overrideName: String? = nil) -> String {
         [
             status.icon,
-            name,
+            overrideName ?? name,
             message.map { "(\($0))" },
         ]
         .compactMap(\.self)

--- a/Sources/PeekieSDK/Formatters/SonarFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/SonarFormatter.swift
@@ -38,20 +38,35 @@ public final class SonarFormatter {
 
     // MARK: Private
 
+    /// Flatten a suite tree into all suites (root + nested) so each maps to its
+    /// own source file in the SonarQube XML output.
+    private static func flatten(_ suite: Report.Module.Suite) -> [Report.Module.Suite] {
+        [suite] + suite.nestedSuites.flatMap { flatten($0) }
+    }
+
     private func collectFiles(report: Report, fsIndex: FSIndex) -> [XMLFile] {
         var filesByPath = [String: [TestCase]]()
         var pathsByNode = [String: String]()
 
-        for suite in report.modules.flatMap(\.suites).sorted(by: { $0.name < $1.name }) {
-            guard suite.repeatableTests.isEmpty == false else {
-                continue
-            }
-            guard let path = resolvePath(for: suite, fsIndex: fsIndex, cache: &pathsByNode) else {
-                continue
-            }
+        for module in report.modules.sorted(by: { $0.name < $1.name }) {
+            // Root-level @Tests: no enclosing suite means no filesystem anchor —
+            // SonarQube needs a file path per <file> element, so we can't surface
+            // these tests in the XML output. They still appear in the List/JSON
+            // formatters which don't require path resolution.
 
-            let testCases = TestCase.cases(from: suite)
-            filesByPath[path, default: []].append(contentsOf: testCases)
+            let flatSuites = module.suites.flatMap { Self.flatten($0) }
+            for suite in flatSuites.sorted(by: { $0.fullPath < $1.fullPath }) {
+                guard suite.repeatableTests.isEmpty == false else {
+                    continue
+                }
+                guard let path = resolvePath(for: suite, fsIndex: fsIndex, cache: &pathsByNode)
+                else {
+                    continue
+                }
+
+                let testCases = TestCase.cases(from: suite)
+                filesByPath[path, default: []].append(contentsOf: testCases)
+            }
         }
 
         return filesByPath
@@ -200,9 +215,9 @@ private struct Failure: Encodable, DynamicNodeEncoding {
 }
 
 extension TestCase {
-    init(_ test: Report.Module.Suite.RepeatableTest.Test) {
+    init(_ test: Report.Module.Suite.RepeatableTest.Test, qualifiedName: String? = nil) {
         self.init(
-            name: test.name,
+            name: qualifiedName ?? test.name,
             duration: Int(test.duration.converted(to: .milliseconds).value),
             skipped: test.status == .skipped ? test.message.map { .init(message: $0) } : nil,
             failure: test.status == .failure ? test.message.map { .init(message: $0) } : nil
@@ -211,16 +226,19 @@ extension TestCase {
 }
 
 private extension TestCase {
-    static func cases(from file: Report.Module.Suite) -> [Self] {
+    static func cases(from suite: Report.Module.Suite) -> [Self] {
         var testCases = [Self]()
 
-        for repeatableTest in file.repeatableTests.sorted(by: { $0.name < $1.name }) {
+        for repeatableTest in suite.repeatableTests.sorted(by: { $0.name < $1.name }) {
             // Use merged tests which already handle repetitions and optionally devices
             let mergedTests = repeatableTest.mergedTests(filterDevice: false)
 
-            // Output each merged test separately
+            // Qualify the test name with the suite's full path so nested suites
+            // can share a source file without collisions (XMLEncoder handles
+            // special-character escaping on attribute values).
             for test in mergedTests {
-                testCases.append(Self(test))
+                let qualifiedName = "\(suite.fullPath) / \(test.name)"
+                testCases.append(Self(test, qualifiedName: qualifiedName))
             }
         }
 

--- a/Sources/PeekieSDK/Models/Report+Convenience+Suites.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience+Suites.swift
@@ -3,15 +3,24 @@ import Foundation
 extension Report {
     // MARK: - Suite parsing
 
-    /// Walks `testResultsDTO` and produces a `[testBundleName: [Suite]]` mapping. The
-    /// bundle name comes straight from the unit test bundle node — aliasing to a
-    /// coverage-target name (e.g. `PeekieTests` → `Peekie`) happens at the call site.
+    /// Result of walking one `Unit test bundle` node: any `@Test`s declared at the
+    /// bundle root (no enclosing `@Suite`), plus the top-level suites and their
+    /// nested-suite trees.
+    struct BundleTestNodes {
+        var rootLevelTests: Set<Module.Suite.RepeatableTest>
+        var suites: [Module.Suite]
+    }
+
+    /// Walks `testResultsDTO` and produces a `[testBundleName: BundleTestNodes]`
+    /// mapping. The bundle name comes straight from the unit test bundle node —
+    /// aliasing to a coverage-target name (e.g. `PeekieTests` → `Peekie`) happens
+    /// at the call site.
     static func buildSuites(
         from testResultsDTO: TestResultsDTO
     )
-        -> [String: [Module.Suite]]
+        -> [String: BundleTestNodes]
     {
-        var byBundle = [String: [Module.Suite]]()
+        var byBundle = [String: BundleTestNodes]()
 
         for rootNode in testResultsDTO.testNodes where rootNode.nodeType == .testPlan {
             guard let unitTestBundles = rootNode.children else {
@@ -20,57 +29,109 @@ extension Report {
 
             for testNode in unitTestBundles where testNode.nodeType == .unitTestBundle {
                 let bundleName = testNode.name
+                let bundleChildren = (testNode.children ?? []).filter { $0.isMetadata == false }
+
+                var rootLevelTests = Set<Module.Suite.RepeatableTest>()
                 var suites = [Module.Suite]()
-                for testSuite in testNode.children ?? [] where testSuite.nodeType == .testSuite {
-                    guard let nodeIdentifierURL = testSuite.nodeIdentifierURL else {
+
+                for child in bundleChildren {
+                    switch child.nodeType {
+                    case .testCase:
+                        // Root-level @Test function — no enclosing @Suite.
+                        rootLevelTests.insert(buildRepeatableTest(from: child))
+
+                    case .testSuite:
+                        suites.append(buildSuite(from: child, parentPath: nil))
+
+                    default:
                         continue
                     }
-
-                    let suite = buildSuite(
-                        from: testSuite,
-                        nodeIdentifierURL: nodeIdentifierURL
-                    )
-                    suites.append(suite)
                 }
-                byBundle[bundleName, default: []].append(contentsOf: suites)
+
+                let existing = byBundle[bundleName] ?? BundleTestNodes(
+                    rootLevelTests: [],
+                    suites: []
+                )
+                byBundle[bundleName] = BundleTestNodes(
+                    rootLevelTests: existing.rootLevelTests.union(rootLevelTests),
+                    suites: existing.suites + suites
+                )
             }
         }
 
         return byBundle
     }
 
+    /// Recursively builds a `Suite` from a `Test Suite` node. Walks both nested
+    /// `Test Suite` children (becoming `nestedSuites`) and `Test Case` children
+    /// (becoming `repeatableTests`). `parentPath` is the `" / "`-joined chain of
+    /// ancestor suite names from the bundle root; pass `nil` for top-level suites.
     private static func buildSuite(
         from testSuite: TestResultsDTO.TestNode,
-        nodeIdentifierURL: String
+        parentPath: String?
     )
         -> Module.Suite
     {
+        let fullPath = parentPath.map { "\($0) / \(testSuite.name)" } ?? testSuite.name
+
+        // Edge case: nested `Test Suite` nodes can legitimately carry a `null`
+        // `nodeIdentifierURL` in some xcresult outputs. We synthesize one from the
+        // parent's URL when available; otherwise fall back to a synthetic
+        // `test://` URL keyed on `fullPath` so the suite is still addressable
+        // downstream (e.g. for SonarFormatter caching) without dropping it.
+        let nodeIdentifierURL = testSuite.nodeIdentifierURL
+            ?? "test://com.apple.xcode/_synthesized/\(fullPath)"
+
         var repeatableTests = Set<Module.Suite.RepeatableTest>()
-        let filteredCases = (testSuite.children ?? []).filter { $0.isMetadata == false }
-        for testCase in filteredCases where testCase.nodeType == .testCase {
-            var repeatable = Module.Suite.RepeatableTest(name: testCase.name, tests: [])
+        var nestedSuites = [Module.Suite]()
 
-            let filteredChildren = (testCase.children ?? []).filter { $0.isMetadata == false }
-            for child in filteredChildren {
-                processTestNode(
-                    child,
-                    path: [],
-                    testCase: testCase,
-                    into: &repeatable
-                )
-            }
+        let filteredChildren = (testSuite.children ?? []).filter { $0.isMetadata == false }
+        for child in filteredChildren {
+            switch child.nodeType {
+            case .testCase:
+                repeatableTests.insert(buildRepeatableTest(from: child))
 
-            if repeatable.tests.isEmpty {
-                repeatable.tests.append(.init(from: testCase))
+            case .testSuite:
+                nestedSuites.append(buildSuite(from: child, parentPath: fullPath))
+
+            default:
+                continue
             }
-            repeatableTests.insert(repeatable)
         }
 
         return Module.Suite(
             name: testSuite.name,
             nodeIdentifierURL: nodeIdentifierURL,
-            repeatableTests: repeatableTests
+            fullPath: fullPath,
+            repeatableTests: repeatableTests,
+            nestedSuites: nestedSuites
         )
+    }
+
+    /// Converts a `Test Case` node into a `RepeatableTest`. Used both by top-level
+    /// bundle walking (root-level `@Test` cases) and by suite walking (cases inside
+    /// `@Suite` types and `XCTestCase` subclasses).
+    private static func buildRepeatableTest(
+        from testCase: TestResultsDTO.TestNode
+    )
+        -> Module.Suite.RepeatableTest
+    {
+        var repeatable = Module.Suite.RepeatableTest(name: testCase.name, tests: [])
+
+        let filteredChildren = (testCase.children ?? []).filter { $0.isMetadata == false }
+        for child in filteredChildren {
+            processTestNode(
+                child,
+                path: [],
+                testCase: testCase,
+                into: &repeatable
+            )
+        }
+
+        if repeatable.tests.isEmpty {
+            repeatable.tests.append(.init(from: testCase))
+        }
+        return repeatable
     }
 
     private static func processTestNode(
@@ -215,7 +276,7 @@ extension Report {
 
     static func buildModules(
         files: [File],
-        suitesByModule: [String: [Module.Suite]],
+        testNodesByModule: [String: BundleTestNodes],
         coverageReportDTO: CoverageReportDTO?
     )
         -> [Module]
@@ -224,32 +285,54 @@ extension Report {
         if let coverageReportDTO {
             moduleNames.formUnion(coverageReportDTO.targets.map(\.name))
         }
-        moduleNames.formUnion(suitesByModule.keys)
+        moduleNames.formUnion(testNodesByModule.keys)
 
         return moduleNames.sorted().map { name in
-            let moduleFiles = files.filter { $0.module == name }
-
-            let moduleCoverage: Coverage? =
-                if let target = coverageReportDTO?.targets
-                    .first(where: { $0.name == name }),
-                    target.executableLines > 0
-                {
-                    Coverage(
-                        coveredLines: target.coveredLines,
-                        totalLines: target.executableLines,
-                        coverage: target.lineCoverage
-                    )
-                } else {
-                    nil
-                }
-
-            return Module(
+            buildModule(
                 name: name,
-                files: moduleFiles,
-                coverage: moduleCoverage,
-                suites: suitesByModule[name] ?? []
+                files: files,
+                testNodes: testNodesByModule[name],
+                coverageReportDTO: coverageReportDTO
             )
         }
+    }
+
+    private static func buildModule(
+        name: String,
+        files: [File],
+        testNodes: BundleTestNodes?,
+        coverageReportDTO: CoverageReportDTO?
+    )
+        -> Module
+    {
+        let moduleFiles = files.filter { $0.module == name }
+        let moduleCoverage = moduleCoverage(for: name, coverageReportDTO: coverageReportDTO)
+        return Module(
+            name: name,
+            files: moduleFiles,
+            coverage: moduleCoverage,
+            rootLevelTests: testNodes?.rootLevelTests ?? [],
+            suites: testNodes?.suites ?? []
+        )
+    }
+
+    private static func moduleCoverage(
+        for name: String,
+        coverageReportDTO: CoverageReportDTO?
+    )
+        -> Coverage?
+    {
+        guard let target = coverageReportDTO?.targets.first(where: { $0.name == name }),
+              target.executableLines > 0
+        else {
+            return nil
+        }
+
+        return Coverage(
+            coveredLines: target.coveredLines,
+            totalLines: target.executableLines,
+            coverage: target.lineCoverage
+        )
     }
 
     // MARK: - Total coverage

--- a/Sources/PeekieSDK/Models/Report+Convenience.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience.swift
@@ -42,7 +42,7 @@ extension Report {
             errorsByFileName: errorsByFileName
         )
 
-        let suitesByModule = Self.suitesByCanonicalModule(
+        let testNodesByModule = Self.testNodesByCanonicalModule(
             testResultsDTO: testResultsDTO,
             coverageReportDTO: coverageReportDTO
         )
@@ -50,7 +50,7 @@ extension Report {
         self.files = files
         modules = Self.buildModules(
             files: files,
-            suitesByModule: suitesByModule,
+            testNodesByModule: testNodesByModule,
             coverageReportDTO: coverageReportDTO
         )
         coverage = Self.computeTotalCoverage(
@@ -76,25 +76,30 @@ extension Report {
         return (warnings, errors)
     }
 
-    /// Build suites grouped by their test bundle name; alias test-bundle names to
-    /// canonical coverage-target names so they project onto the same Module.
-    private static func suitesByCanonicalModule(
+    /// Build bundle test nodes (root-level tests + top-level suite trees) grouped
+    /// by their test bundle name; alias test-bundle names to canonical
+    /// coverage-target names so they project onto the same Module.
+    private static func testNodesByCanonicalModule(
         testResultsDTO: TestResultsDTO?,
         coverageReportDTO: CoverageReportDTO?
     )
-        -> [String: [Module.Suite]]
+        -> [String: BundleTestNodes]
     {
-        let suitesByBundle: [String: [Module.Suite]] =
+        let nodesByBundle: [String: BundleTestNodes] =
             testResultsDTO.map(buildSuites(from:)) ?? [:]
         let coverageTargetNames = Set(coverageReportDTO?.targets.map(\.name) ?? [])
         let aliasing = aliasTestBundlesToCoverageTargets(
-            testBundleNames: Set(suitesByBundle.keys),
+            testBundleNames: Set(nodesByBundle.keys),
             coverageTargetNames: coverageTargetNames
         )
-        var result = [String: [Module.Suite]]()
-        for (bundle, suites) in suitesByBundle {
+        var result = [String: BundleTestNodes]()
+        for (bundle, nodes) in nodesByBundle {
             let canonical = aliasing[bundle] ?? bundle
-            result[canonical, default: []].append(contentsOf: suites)
+            let existing = result[canonical] ?? BundleTestNodes(rootLevelTests: [], suites: [])
+            result[canonical] = BundleTestNodes(
+                rootLevelTests: existing.rootLevelTests.union(nodes.rootLevelTests),
+                suites: existing.suites + nodes.suites
+            )
         }
         return result
     }

--- a/Sources/PeekieSDK/Models/Report.swift
+++ b/Sources/PeekieSDK/Models/Report.swift
@@ -123,11 +123,13 @@ public extension Report {
             name: String,
             files: [File] = [],
             coverage: Coverage? = nil,
+            rootLevelTests: Set<Suite.RepeatableTest> = [],
             suites: [Suite] = []
         ) {
             self.name = name
             self.files = files
             self.coverage = coverage
+            self.rootLevelTests = rootLevelTests
             self.suites = suites
         }
 
@@ -142,7 +144,15 @@ public extension Report {
         /// Target-level coverage when xcresult reported one.
         public let coverage: Coverage?
 
-        /// Test suites this target ran.
+        /// Swift Testing `@Test` functions declared at the bundle root, i.e. outside
+        /// any `@Suite` type. These appear in xcresult JSON as `Test Case` nodes
+        /// directly under the `Unit test bundle` node. Empty for legacy `XCTest`-only
+        /// bundles, where every test is wrapped in an `XCTestCase` subclass that
+        /// surfaces as a `Test Suite` node.
+        public let rootLevelTests: Set<Suite.RepeatableTest>
+
+        /// Top-level test suites this target ran. Nested suites live inside their
+        /// parents via `Suite.nestedSuites` — only the outermost suites appear here.
         public let suites: [Suite]
 
         /// All warnings from all files in this module.
@@ -328,17 +338,28 @@ public extension Report.Module {
         public init(
             name: String,
             nodeIdentifierURL: String,
-            repeatableTests: Set<RepeatableTest> = []
+            fullPath: String? = nil,
+            repeatableTests: Set<RepeatableTest> = [],
+            nestedSuites: [Self] = []
         ) {
             self.name = name
+            self.fullPath = fullPath ?? name
             self.nodeIdentifierURL = nodeIdentifierURL
             self.repeatableTests = repeatableTests
+            self.nestedSuites = nestedSuites
         }
 
         // MARK: Public
 
-        /// Name of the test suite (e.g., "ReportTests")
+        /// Short name of the test suite (e.g., "InnerSuite")
         public let name: String
+
+        /// Fully qualified suite path joined by `" / "` from the outermost suite to
+        /// `self`. For top-level suites this equals `name`; for nested suites it is
+        /// e.g. `"OuterSuite / InnerSuite / DeeplyNestedSuite"`. Used for
+        /// human-facing identification and as the equality / hash key, so two
+        /// suites named `InnerSuite` under different parents stay distinct.
+        public let fullPath: String
 
         /// URL identifier from the test node in xcresult JSON.
         /// Examples:
@@ -348,15 +369,21 @@ public extension Report.Module {
         /// Format: `test://com.apple.xcode/<Module>/<Bundle>/<Suite>/<TestCase>`
         public let nodeIdentifierURL: String
 
-        /// Set of repeatable tests in this suite
+        /// Set of repeatable tests directly inside this suite (excluding tests of
+        /// any nested `@Suite`-typed child).
         public internal(set) var repeatableTests: Set<RepeatableTest>
 
+        /// Suites declared inside this suite (nested `@Suite` types). Order matches
+        /// the order returned by `xcresulttool`; in practice this is declaration
+        /// order from the source file. Empty when this suite has no nested suites.
+        public let nestedSuites: [Self]
+
         public static func ==(lhs: Self, rhs: Self) -> Bool {
-            lhs.name == rhs.name
+            lhs.fullPath == rhs.fullPath
         }
 
         public func hash(into hasher: inout Hasher) {
-            hasher.combine(name)
+            hasher.combine(fullPath)
         }
     }
 }

--- a/Sources/PeekieTestHelpers/Report+TestHelpers.swift
+++ b/Sources/PeekieTestHelpers/Report+TestHelpers.swift
@@ -42,11 +42,18 @@ public extension Report.Module {
         name: String = "",
         files: [Report.File] = [],
         coverage: Report.Coverage? = nil,
+        rootLevelTests: Set<Suite.RepeatableTest> = [],
         suites: [Suite] = []
     )
         -> Self
     {
-        .init(name: name, files: files, coverage: coverage, suites: suites)
+        .init(
+            name: name,
+            files: files,
+            coverage: coverage,
+            rootLevelTests: rootLevelTests,
+            suites: suites
+        )
     }
 }
 
@@ -92,14 +99,18 @@ public extension Report.Module.Suite {
     static func testMake(
         name: String = "",
         nodeIdentifierURL: String = "",
-        repeatableTests: Set<RepeatableTest> = []
+        fullPath: String? = nil,
+        repeatableTests: Set<RepeatableTest> = [],
+        nestedSuites: [Self] = []
     )
         -> Self
     {
         .init(
             name: name,
             nodeIdentifierURL: nodeIdentifierURL,
-            repeatableTests: repeatableTests
+            fullPath: fullPath,
+            repeatableTests: repeatableTests,
+            nestedSuites: nestedSuites
         )
     }
 }

--- a/Tests/PeekieTests/SonarFormatterSnapshotTests.swift
+++ b/Tests/PeekieTests/SonarFormatterSnapshotTests.swift
@@ -43,6 +43,10 @@ struct SonarFormatterSnapshotTests {
 
     // MARK: Private
 
+    private static func flattenSuites(_ suite: Report.Module.Suite) -> [Report.Module.Suite] {
+        [suite] + suite.nestedSuites.flatMap { flattenSuites($0) }
+    }
+
     // MARK: - Helpers
 
     private func createTestDirectory(for report: Report, slug: String) throws -> URL {
@@ -57,10 +61,15 @@ struct SonarFormatterSnapshotTests {
         try FileManager.default.createDirectory(at: testDir, withIntermediateDirectories: true)
 
         // Generate mock Swift test files based on test suite names from the report
-        // Only include files that have tests (skip coverage-only files)
+        // Only include files that have tests (skip coverage-only files). Walk
+        // the full suite tree so nested suites (e.g. `InnerSuite` inside
+        // `OuterSuite`) also get a backing file for path resolution.
         let testSuites = Set(
             report.modules.flatMap {
-                $0.suites.filter { $0.repeatableTests.isEmpty == false }.map(\.name)
+                $0.suites
+                    .flatMap { Self.flattenSuites($0) }
+                    .filter { $0.repeatableTests.isEmpty == false }
+                    .map(\.name)
             }
         )
 

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
@@ -11,6 +11,9 @@
 
       ],
       "name" : "Calculator",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -330,9 +333,61 @@
         }
       ],
       "name" : "ExamplesTests",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 5.936861038208008,
+          "name" : "2 + 3 = 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 6.15382194519043,
+          "name" : "array[0] is nil?",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 6.681203842163086,
+          "name" : "divide(10, 2) \/ returns 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 6.836891174316406,
+          "name" : "root level with spaces in name",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 39.57366943359375,
+          "name" : "rootLevelAsync()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 9.5062255859375,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        },
+        {
+          "durationMs" : 11.216163635253906,
+          "name" : "rootLevelSuccess()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 12.542247772216797,
+          "name" : "success 🎯",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 12.524127960205078,
+          "name" : "сложение работает",
+          "status" : "success"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 37.470102310180664,
@@ -393,7 +448,49 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 2.3550987243652344,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    },
+                    {
+                      "durationMs" : 2.6962757110595703,
+                      "name" : "deeplyNestedSuccess()",
+                      "status" : "success"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 4.83393669128418,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                },
+                {
+                  "durationMs" : 5.117893218994141,
+                  "name" : "innerSuccess()",
+                  "status" : "success"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 4.732370376586914,
@@ -414,7 +511,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 13.998031616210938,
@@ -485,6 +586,9 @@
 
       ],
       "name" : "StringUtils",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
@@ -11,6 +11,9 @@
 
       ],
       "name" : "Calculator",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -330,9 +333,61 @@
         }
       ],
       "name" : "ExamplesTests",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 20.65587043762207,
+          "name" : "2 + 3 = 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 20.390987396240234,
+          "name" : "array[0] is nil?",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 35.5830192565918,
+          "name" : "divide(10, 2) \/ returns 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 20.6758975982666,
+          "name" : "root level with spaces in name",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 44.93212699890137,
+          "name" : "rootLevelAsync()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 20.82514762878418,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        },
+        {
+          "durationMs" : 19.83499526977539,
+          "name" : "rootLevelSuccess()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 19.835233688354492,
+          "name" : "success 🎯",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 19.975900650024414,
+          "name" : "сложение работает",
+          "status" : "success"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 56.4117431640625,
@@ -393,7 +448,49 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 30.48539161682129,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    },
+                    {
+                      "durationMs" : 30.13896942138672,
+                      "name" : "deeplyNestedSuccess()",
+                      "status" : "success"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 30.64703941345215,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                },
+                {
+                  "durationMs" : 30.672073364257812,
+                  "name" : "innerSuccess()",
+                  "status" : "success"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 30.54666519165039,
@@ -414,7 +511,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 13.459086418151855,
@@ -485,6 +586,9 @@
 
       ],
       "name" : "StringUtils",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
@@ -11,6 +11,9 @@
 
       ],
       "name" : "Calculator",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -330,9 +333,61 @@
         }
       ],
       "name" : "ExamplesTests",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 7.622003555297852,
+          "name" : "2 + 3 = 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 9.020805358886719,
+          "name" : "array[0] is nil?",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 7.498979568481445,
+          "name" : "divide(10, 2) \/ returns 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 8.006095886230469,
+          "name" : "root level with spaces in name",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 46.43607139587402,
+          "name" : "rootLevelAsync()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 14.945030212402344,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        },
+        {
+          "durationMs" : 7.730960845947266,
+          "name" : "rootLevelSuccess()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 8.772850036621094,
+          "name" : "success 🎯",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 8.159160614013672,
+          "name" : "сложение работает",
+          "status" : "success"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 39.85905647277832,
@@ -393,7 +448,49 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 8.289098739624023,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    },
+                    {
+                      "durationMs" : 1.172780990600586,
+                      "name" : "deeplyNestedSuccess()",
+                      "status" : "success"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 9.839773178100586,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                },
+                {
+                  "durationMs" : 9.549140930175781,
+                  "name" : "innerSuccess()",
+                  "status" : "success"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 7.92694091796875,
@@ -414,7 +511,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 12.018918991088867,
@@ -485,6 +586,9 @@
 
       ],
       "name" : "StringUtils",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
@@ -11,6 +11,9 @@
 
       ],
       "name" : "Calculator",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -330,9 +333,61 @@
         }
       ],
       "name" : "ExamplesTests",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 13.487815856933594,
+          "name" : "2 + 3 = 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 12.493371963500977,
+          "name" : "array[0] is nil?",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 11.94906234741211,
+          "name" : "divide(10, 2) \/ returns 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 11.800050735473633,
+          "name" : "root level with spaces in name",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 34.48796272277832,
+          "name" : "rootLevelAsync()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 10.576248168945312,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        },
+        {
+          "durationMs" : 16.137361526489258,
+          "name" : "rootLevelSuccess()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 16.204833984375,
+          "name" : "success 🎯",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 6.053686141967773,
+          "name" : "сложение работает",
+          "status" : "success"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 38.59519958496094,
@@ -393,7 +448,49 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 5.721092224121094,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    },
+                    {
+                      "durationMs" : 4.171848297119141,
+                      "name" : "deeplyNestedSuccess()",
+                      "status" : "success"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 11.559009552001953,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                },
+                {
+                  "durationMs" : 13.177633285522461,
+                  "name" : "innerSuccess()",
+                  "status" : "success"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 12.932777404785156,
@@ -414,7 +511,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 12.495994567871094,
@@ -485,6 +586,9 @@
 
       ],
       "name" : "StringUtils",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
@@ -11,6 +11,9 @@
 
       ],
       "name" : "Calculator",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -330,9 +333,61 @@
         }
       ],
       "name" : "ExamplesTests",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 24.835824966430664,
+          "name" : "2 + 3 = 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 23.153066635131836,
+          "name" : "array[0] is nil?",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 24.006128311157227,
+          "name" : "divide(10, 2) \/ returns 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 15.278100967407227,
+          "name" : "root level with spaces in name",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 54.04496192932129,
+          "name" : "rootLevelAsync()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 25.02584457397461,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        },
+        {
+          "durationMs" : 23.235321044921875,
+          "name" : "rootLevelSuccess()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 26.024818420410156,
+          "name" : "success 🎯",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 13.484954833984375,
+          "name" : "сложение работает",
+          "status" : "success"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 47.50776290893555,
@@ -393,7 +448,49 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 3.5970211029052734,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    },
+                    {
+                      "durationMs" : 4.230976104736328,
+                      "name" : "deeplyNestedSuccess()",
+                      "status" : "success"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 7.421016693115234,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                },
+                {
+                  "durationMs" : 8.491992950439453,
+                  "name" : "innerSuccess()",
+                  "status" : "success"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 10.597944259643555,
@@ -414,7 +511,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 13.314962387084961,
@@ -485,6 +586,9 @@
 
       ],
       "name" : "StringUtils",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
@@ -52,9 +52,61 @@
         }
       ],
       "name" : "XcodeprojExample.app",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 147.8731632232666,
+          "name" : "2 + 3 = 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 151.1080265045166,
+          "name" : "array[0] is nil?",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 150.55441856384277,
+          "name" : "divide(10, 2) \/ returns 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 148.26488494873047,
+          "name" : "root level with spaces in name",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 194.92292404174805,
+          "name" : "rootLevelAsync()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 134.35077667236328,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        },
+        {
+          "durationMs" : 150.6330966949463,
+          "name" : "rootLevelSuccess()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 147.89104461669922,
+          "name" : "success 🎯",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 149.37901496887207,
+          "name" : "сложение работает",
+          "status" : "success"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 187.75701522827148,
@@ -115,7 +167,49 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 17.81916618347168,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    },
+                    {
+                      "durationMs" : 12.443780899047852,
+                      "name" : "deeplyNestedSuccess()",
+                      "status" : "success"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 18.955707550048828,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                },
+                {
+                  "durationMs" : 2.6149749755859375,
+                  "name" : "innerSuccess()",
+                  "status" : "success"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 133.53776931762695,
@@ -136,7 +230,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 12.345075607299805,
@@ -337,6 +435,9 @@
         }
       ],
       "name" : "XcodeprojExampleFramework.framework",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -486,6 +587,9 @@
         }
       ],
       "name" : "XcodeprojExampleTests.xctest",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
@@ -52,9 +52,61 @@
         }
       ],
       "name" : "XcodeprojExample.app",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 1.7011165618896484,
+          "name" : "2 + 3 = 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 2.4039745330810547,
+          "name" : "array[0] is nil?",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 2.484560012817383,
+          "name" : "divide(10, 2) \/ returns 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 2.542734146118164,
+          "name" : "root level with spaces in name",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 34.63625907897949,
+          "name" : "rootLevelAsync()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 1.6782283782958984,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        },
+        {
+          "durationMs" : 2.6369094848632812,
+          "name" : "rootLevelSuccess()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 2.935171127319336,
+          "name" : "success 🎯",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 2.5870800018310547,
+          "name" : "сложение работает",
+          "status" : "success"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 33.849239349365234,
@@ -115,7 +167,49 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 1.3551712036132812,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    },
+                    {
+                      "durationMs" : 1.4379024505615234,
+                      "name" : "deeplyNestedSuccess()",
+                      "status" : "success"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 2.122163772583008,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                },
+                {
+                  "durationMs" : 2.2077560424804688,
+                  "name" : "innerSuccess()",
+                  "status" : "success"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 2.832651138305664,
@@ -136,7 +230,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 12.11702823638916,
@@ -337,6 +435,9 @@
         }
       ],
       "name" : "XcodeprojExampleFramework.framework",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -486,6 +587,9 @@
         }
       ],
       "name" : "XcodeprojExampleTests.xctest",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
@@ -52,9 +52,61 @@
         }
       ],
       "name" : "XcodeprojExample.app",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 19.630908966064453,
+          "name" : "2 + 3 = 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 70.4951286315918,
+          "name" : "array[0] is nil?",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 22.92919158935547,
+          "name" : "divide(10, 2) \/ returns 5",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 70.92022895812988,
+          "name" : "root level with spaces in name",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 102.27608680725098,
+          "name" : "rootLevelAsync()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 81.07686042785645,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        },
+        {
+          "durationMs" : 71.48408889770508,
+          "name" : "rootLevelSuccess()",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 72.00813293457031,
+          "name" : "success 🎯",
+          "status" : "success"
+        },
+        {
+          "durationMs" : 71.929931640625,
+          "name" : "сложение работает",
+          "status" : "success"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 94.70796585083008,
@@ -115,7 +167,49 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 8.196353912353516,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    },
+                    {
+                      "durationMs" : 4.525661468505859,
+                      "name" : "deeplyNestedSuccess()",
+                      "status" : "success"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 67.53802299499512,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                },
+                {
+                  "durationMs" : 61.01274490356445,
+                  "name" : "innerSuccess()",
+                  "status" : "success"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 62.69407272338867,
@@ -136,7 +230,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 14.802932739257812,
@@ -337,6 +435,9 @@
         }
       ],
       "name" : "XcodeprojExampleFramework.framework",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -486,6 +587,9 @@
         }
       ],
       "name" : "XcodeprojExampleTests.xctest",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
@@ -11,6 +11,9 @@
 
       ],
       "name" : "Calculator",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -330,9 +333,21 @@
         }
       ],
       "name" : "ExamplesTests",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 9.5062255859375,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 18.467187881469727,
@@ -349,7 +364,39 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 2.3550987243652344,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 4.83393669128418,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 8.777856826782227,
@@ -360,7 +407,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 20.39492130279541,
@@ -383,6 +434,9 @@
 
       ],
       "name" : "StringUtils",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
@@ -11,6 +11,9 @@
 
       ],
       "name" : "Calculator",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -330,9 +333,21 @@
         }
       ],
       "name" : "ExamplesTests",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 20.82514762878418,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 35.575151443481445,
@@ -349,7 +364,39 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 30.48539161682129,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 30.64703941345215,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 45.76516151428223,
@@ -360,7 +407,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 2.6619434356689453,
@@ -383,6 +434,9 @@
 
       ],
       "name" : "StringUtils",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
@@ -11,6 +11,9 @@
 
       ],
       "name" : "Calculator",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -330,9 +333,21 @@
         }
       ],
       "name" : "ExamplesTests",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 14.945030212402344,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 9.336233139038086,
@@ -349,7 +364,39 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 8.289098739624023,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 9.839773178100586,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 10.738849639892578,
@@ -360,7 +407,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 5.89299201965332,
@@ -383,6 +434,9 @@
 
       ],
       "name" : "StringUtils",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
@@ -11,6 +11,9 @@
 
       ],
       "name" : "Calculator",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -330,9 +333,21 @@
         }
       ],
       "name" : "ExamplesTests",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 10.576248168945312,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 7.595062255859375,
@@ -349,7 +364,39 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 5.721092224121094,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 11.559009552001953,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 9.44972038269043,
@@ -360,7 +407,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 4.215121269226074,
@@ -383,6 +434,9 @@
 
       ],
       "name" : "StringUtils",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
@@ -11,6 +11,9 @@
 
       ],
       "name" : "Calculator",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -330,9 +333,21 @@
         }
       ],
       "name" : "ExamplesTests",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 25.02584457397461,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 18.293142318725586,
@@ -349,7 +364,39 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 3.5970211029052734,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 7.421016693115234,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 20.42412757873535,
@@ -360,7 +407,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 8.102893829345703,
@@ -383,6 +434,9 @@
 
       ],
       "name" : "StringUtils",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
@@ -52,9 +52,21 @@
         }
       ],
       "name" : "XcodeprojExample.app",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 134.35077667236328,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 134.09423828125,
@@ -71,7 +83,39 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 17.81916618347168,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 18.955707550048828,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 132.3409080505371,
@@ -82,7 +126,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 1544.7980165481567,
@@ -235,6 +283,9 @@
         }
       ],
       "name" : "XcodeprojExampleFramework.framework",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -384,6 +435,9 @@
         }
       ],
       "name" : "XcodeprojExampleTests.xctest",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
@@ -52,9 +52,21 @@
         }
       ],
       "name" : "XcodeprojExample.app",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 1.6782283782958984,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 2.2950172424316406,
@@ -71,7 +83,39 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 1.3551712036132812,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 2.122163772583008,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 2.2840499877929688,
@@ -82,7 +126,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 2.6750564575195312,
@@ -235,6 +283,9 @@
         }
       ],
       "name" : "XcodeprojExampleFramework.framework",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -384,6 +435,9 @@
         }
       ],
       "name" : "XcodeprojExampleTests.xctest",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
@@ -52,9 +52,21 @@
         }
       ],
       "name" : "XcodeprojExample.app",
+      "rootLevelTests" : [
+        {
+          "durationMs" : 81.07686042785645,
+          "message" : "Expected 5.0 but got 6.0",
+          "name" : "rootLevelFailure()",
+          "status" : "failure"
+        }
+      ],
       "suites" : [
         {
+          "fullPath" : "ExampleSUITests",
           "name" : "ExampleSUITests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 68.94230842590332,
@@ -71,7 +83,39 @@
           ]
         },
         {
+          "fullPath" : "OuterSuite",
           "name" : "OuterSuite",
+          "nestedSuites" : [
+            {
+              "fullPath" : "OuterSuite \/ InnerSuite",
+              "name" : "InnerSuite",
+              "nestedSuites" : [
+                {
+                  "fullPath" : "OuterSuite \/ InnerSuite \/ DeeplyNestedSuite",
+                  "name" : "DeeplyNestedSuite",
+                  "nestedSuites" : [
+
+                  ],
+                  "tests" : [
+                    {
+                      "durationMs" : 8.196353912353516,
+                      "message" : "Deeply nested failure: result was 0.0",
+                      "name" : "deeplyNestedFailure()",
+                      "status" : "failure"
+                    }
+                  ]
+                }
+              ],
+              "tests" : [
+                {
+                  "durationMs" : 67.53802299499512,
+                  "message" : "Inner suite failure: result was 12.0",
+                  "name" : "innerFailure()",
+                  "status" : "failure"
+                }
+              ]
+            }
+          ],
           "tests" : [
             {
               "durationMs" : 66.36381149291992,
@@ -82,7 +126,11 @@
           ]
         },
         {
+          "fullPath" : "XCTestTests",
           "name" : "XCTestTests",
+          "nestedSuites" : [
+
+          ],
           "tests" : [
             {
               "durationMs" : 1373.3559846878052,
@@ -235,6 +283,9 @@
         }
       ],
       "name" : "XcodeprojExampleFramework.framework",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]
@@ -384,6 +435,9 @@
         }
       ],
       "name" : "XcodeprojExampleTests.xctest",
+      "rootLevelTests" : [
+
+      ],
       "suites" : [
 
       ]

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.SPM-iOS_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.SPM-iOS_all.txt
@@ -1,4 +1,15 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+ExamplesTests / ExampleSUITests
 ✅ async()
 ⏭️ disabled() (Test skipped: Disabled reason)
 🤡 expectedFailure() (Failure is expected)
@@ -10,12 +21,20 @@ ExampleSUITests
 ❌ throwing() (Calculator.swift:26: Caught error: .divisionByZero)
 ✅ withAttachment()
 
-OuterSuite
+ExamplesTests / OuterSuite
 ✅ outer with spaces in name
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 ✅ outerSuccess()
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+✅ innerSuccess()
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+✅ deeplyNestedSuccess()
+
+ExamplesTests / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 🤡 test_expectedFailure() (Failure is expected)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.SPM-macOS_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.SPM-macOS_all.txt
@@ -1,4 +1,15 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+ExamplesTests / ExampleSUITests
 ✅ async()
 ⏭️ disabled() (Test skipped: Disabled reason)
 🤡 expectedFailure() (Failure is expected)
@@ -10,12 +21,20 @@ ExampleSUITests
 ❌ throwing() (Calculator.swift:26: Caught error: .divisionByZero)
 ✅ withAttachment()
 
-OuterSuite
+ExamplesTests / OuterSuite
 ✅ outer with spaces in name
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 ✅ outerSuccess()
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+✅ innerSuccess()
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+✅ deeplyNestedSuccess()
+
+ExamplesTests / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 🤡 test_expectedFailure() (Failure is expected)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.SPM-tvOS_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.SPM-tvOS_all.txt
@@ -1,4 +1,15 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+ExamplesTests / ExampleSUITests
 ✅ async()
 ⏭️ disabled() (Test skipped: Disabled reason)
 🤡 expectedFailure() (Failure is expected)
@@ -10,12 +21,20 @@ ExampleSUITests
 ❌ throwing() (Calculator.swift:26: Caught error: .divisionByZero)
 ✅ withAttachment()
 
-OuterSuite
+ExamplesTests / OuterSuite
 ✅ outer with spaces in name
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 ✅ outerSuccess()
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+✅ innerSuccess()
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+✅ deeplyNestedSuccess()
+
+ExamplesTests / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 🤡 test_expectedFailure() (Failure is expected)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.SPM-visionOS_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.SPM-visionOS_all.txt
@@ -1,4 +1,15 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+ExamplesTests / ExampleSUITests
 ✅ async()
 ⏭️ disabled() (Test skipped: Disabled reason)
 🤡 expectedFailure() (Failure is expected)
@@ -10,12 +21,20 @@ ExampleSUITests
 ❌ throwing() (Calculator.swift:26: Caught error: .divisionByZero)
 ✅ withAttachment()
 
-OuterSuite
+ExamplesTests / OuterSuite
 ✅ outer with spaces in name
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 ✅ outerSuccess()
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+✅ innerSuccess()
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+✅ deeplyNestedSuccess()
+
+ExamplesTests / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 🤡 test_expectedFailure() (Failure is expected)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.SPM-watchOS_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.SPM-watchOS_all.txt
@@ -1,4 +1,15 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+ExamplesTests / ExampleSUITests
 ✅ async()
 ⏭️ disabled() (Test skipped: Disabled reason)
 🤡 expectedFailure() (Failure is expected)
@@ -10,12 +21,20 @@ ExampleSUITests
 ❌ throwing() (Calculator.swift:26: Caught error: .divisionByZero)
 ✅ withAttachment()
 
-OuterSuite
+ExamplesTests / OuterSuite
 ✅ outer with spaces in name
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 ✅ outerSuccess()
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+✅ innerSuccess()
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+✅ deeplyNestedSuccess()
+
+ExamplesTests / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 🤡 test_expectedFailure() (Failure is expected)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.Xcworkspace-iOS_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.Xcworkspace-iOS_all.txt
@@ -1,4 +1,15 @@
-ExampleSUITests
+XcodeprojExample.app / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+XcodeprojExample.app / ExampleSUITests
 ✅ async()
 ⏭️ disabled() (Test skipped: Disabled reason)
 🤡 expectedFailure() (Failure is expected)
@@ -10,12 +21,20 @@ ExampleSUITests
 ❌ throwing() (SwiftTestingTests.swift:85: Caught error: .divisionByZero)
 ✅ withAttachment()
 
-OuterSuite
+XcodeprojExample.app / OuterSuite
 ✅ outer with spaces in name
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 ✅ outerSuccess()
 
-XCTestTests
+XcodeprojExample.app / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+✅ innerSuccess()
+
+XcodeprojExample.app / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+✅ deeplyNestedSuccess()
+
+XcodeprojExample.app / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 🤡 test_expectedFailure() (Failure is expected)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.Xcworkspace-macOS_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.Xcworkspace-macOS_all.txt
@@ -1,4 +1,15 @@
-ExampleSUITests
+XcodeprojExample.app / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+XcodeprojExample.app / ExampleSUITests
 ✅ async()
 ⏭️ disabled() (Test skipped: Disabled reason)
 🤡 expectedFailure() (Failure is expected)
@@ -10,12 +21,20 @@ ExampleSUITests
 ❌ throwing() (SwiftTestingTests.swift:85: Caught error: .divisionByZero)
 ✅ withAttachment()
 
-OuterSuite
+XcodeprojExample.app / OuterSuite
 ✅ outer with spaces in name
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 ✅ outerSuccess()
 
-XCTestTests
+XcodeprojExample.app / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+✅ innerSuccess()
+
+XcodeprojExample.app / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+✅ deeplyNestedSuccess()
+
+XcodeprojExample.app / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 🤡 test_expectedFailure() (Failure is expected)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.Xcworkspace-visionOS_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_allStatuses-_.Xcworkspace-visionOS_all.txt
@@ -1,4 +1,15 @@
-ExampleSUITests
+XcodeprojExample.app / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+XcodeprojExample.app / ExampleSUITests
 ✅ async()
 ⏭️ disabled() (Test skipped: Disabled reason)
 🤡 expectedFailure() (Failure is expected)
@@ -10,12 +21,20 @@ ExampleSUITests
 ❌ throwing() (SwiftTestingTests.swift:85: Caught error: .divisionByZero)
 ✅ withAttachment()
 
-OuterSuite
+XcodeprojExample.app / OuterSuite
 ✅ outer with spaces in name
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 ✅ outerSuccess()
 
-XCTestTests
+XcodeprojExample.app / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+✅ innerSuccess()
+
+XcodeprojExample.app / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+✅ deeplyNestedSuccess()
+
+XcodeprojExample.app / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 🤡 test_expectedFailure() (Failure is expected)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.SPM-iOS_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.SPM-iOS_failure.txt
@@ -1,10 +1,19 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+
+ExamplesTests / ExampleSUITests
 ❌ failure() (Expected 5.0 but got 6.0)
 ❌ throwing() (Calculator.swift:26: Caught error: .divisionByZero)
 
-OuterSuite
+ExamplesTests / OuterSuite
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+
+ExamplesTests / XCTestTests
 ❌ test_failure() (Expected 5.0 but got 6.0)
 ❌ test_throwing() (Calculator.swift:26: failed: caught error: "divisionByZero")

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.SPM-macOS_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.SPM-macOS_failure.txt
@@ -1,10 +1,19 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+
+ExamplesTests / ExampleSUITests
 ❌ failure() (Expected 5.0 but got 6.0)
 ❌ throwing() (Calculator.swift:26: Caught error: .divisionByZero)
 
-OuterSuite
+ExamplesTests / OuterSuite
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+
+ExamplesTests / XCTestTests
 ❌ test_failure() (Expected 5.0 but got 6.0)
 ❌ test_throwing() (Calculator.swift:26: failed: caught error: "divisionByZero")

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.SPM-tvOS_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.SPM-tvOS_failure.txt
@@ -1,10 +1,19 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+
+ExamplesTests / ExampleSUITests
 ❌ failure() (Expected 5.0 but got 6.0)
 ❌ throwing() (Calculator.swift:26: Caught error: .divisionByZero)
 
-OuterSuite
+ExamplesTests / OuterSuite
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+
+ExamplesTests / XCTestTests
 ❌ test_failure() (Expected 5.0 but got 6.0)
 ❌ test_throwing() (Calculator.swift:26: failed: caught error: "divisionByZero")

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.SPM-visionOS_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.SPM-visionOS_failure.txt
@@ -1,10 +1,19 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+
+ExamplesTests / ExampleSUITests
 ❌ failure() (Expected 5.0 but got 6.0)
 ❌ throwing() (Calculator.swift:26: Caught error: .divisionByZero)
 
-OuterSuite
+ExamplesTests / OuterSuite
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+
+ExamplesTests / XCTestTests
 ❌ test_failure() (Expected 5.0 but got 6.0)
 ❌ test_throwing() (Calculator.swift:26: failed: caught error: "divisionByZero")

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.SPM-watchOS_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.SPM-watchOS_failure.txt
@@ -1,10 +1,19 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+
+ExamplesTests / ExampleSUITests
 ❌ failure() (Expected 5.0 but got 6.0)
 ❌ throwing() (Calculator.swift:26: Caught error: .divisionByZero)
 
-OuterSuite
+ExamplesTests / OuterSuite
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+
+ExamplesTests / XCTestTests
 ❌ test_failure() (Expected 5.0 but got 6.0)
 ❌ test_throwing() (Calculator.swift:26: failed: caught error: "divisionByZero")

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.Xcworkspace-iOS_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.Xcworkspace-iOS_failure.txt
@@ -1,10 +1,19 @@
-ExampleSUITests
+XcodeprojExample.app / (no suite)
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+
+XcodeprojExample.app / ExampleSUITests
 ❌ failure() (Expected 5.0 but got 6.0)
 ❌ throwing() (SwiftTestingTests.swift:85: Caught error: .divisionByZero)
 
-OuterSuite
+XcodeprojExample.app / OuterSuite
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 
-XCTestTests
+XcodeprojExample.app / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+
+XcodeprojExample.app / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+
+XcodeprojExample.app / XCTestTests
 ❌ test_failure() (Expected 5.0 but got 6.0)
 ❌ test_throwing() (XCTestTests.swift:77: failed: caught error: "divisionByZero")

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.Xcworkspace-macOS_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.Xcworkspace-macOS_failure.txt
@@ -1,10 +1,19 @@
-ExampleSUITests
+XcodeprojExample.app / (no suite)
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+
+XcodeprojExample.app / ExampleSUITests
 ❌ failure() (Expected 5.0 but got 6.0)
 ❌ throwing() (SwiftTestingTests.swift:85: Caught error: .divisionByZero)
 
-OuterSuite
+XcodeprojExample.app / OuterSuite
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 
-XCTestTests
+XcodeprojExample.app / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+
+XcodeprojExample.app / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+
+XcodeprojExample.app / XCTestTests
 ❌ test_failure() (Expected 5.0 but got 6.0)
 ❌ test_throwing() (XCTestTests.swift:77: failed: caught error: "divisionByZero")

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.Xcworkspace-visionOS_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_failureOnly-_.Xcworkspace-visionOS_failure.txt
@@ -1,10 +1,19 @@
-ExampleSUITests
+XcodeprojExample.app / (no suite)
+❌ rootLevelFailure() (Expected 5.0 but got 6.0)
+
+XcodeprojExample.app / ExampleSUITests
 ❌ failure() (Expected 5.0 but got 6.0)
 ❌ throwing() (SwiftTestingTests.swift:85: Caught error: .divisionByZero)
 
-OuterSuite
+XcodeprojExample.app / OuterSuite
 ❌ outerFailure() (Outer suite failure: result was 200.0)
 
-XCTestTests
+XcodeprojExample.app / OuterSuite / InnerSuite
+❌ innerFailure() (Inner suite failure: result was 12.0)
+
+XcodeprojExample.app / OuterSuite / InnerSuite / DeeplyNestedSuite
+❌ deeplyNestedFailure() (Deeply nested failure: result was 0.0)
+
+XcodeprojExample.app / XCTestTests
 ❌ test_failure() (Expected 5.0 but got 6.0)
 ❌ test_throwing() (XCTestTests.swift:77: failed: caught error: "divisionByZero")

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.SPM-iOS_skipped.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.SPM-iOS_skipped.txt
@@ -1,5 +1,5 @@
-ExampleSUITests
+ExamplesTests / ExampleSUITests
 ⏭️ disabled() (Test skipped: Disabled reason)
 
-XCTestTests
+ExamplesTests / XCTestTests
 ⏭️ test_skip() (Skip message)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.SPM-macOS_skipped.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.SPM-macOS_skipped.txt
@@ -1,5 +1,5 @@
-ExampleSUITests
+ExamplesTests / ExampleSUITests
 ⏭️ disabled() (Test skipped: Disabled reason)
 
-XCTestTests
+ExamplesTests / XCTestTests
 ⏭️ test_skip() (Skip message)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.SPM-tvOS_skipped.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.SPM-tvOS_skipped.txt
@@ -1,5 +1,5 @@
-ExampleSUITests
+ExamplesTests / ExampleSUITests
 ⏭️ disabled() (Test skipped: Disabled reason)
 
-XCTestTests
+ExamplesTests / XCTestTests
 ⏭️ test_skip() (Skip message)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.SPM-visionOS_skipped.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.SPM-visionOS_skipped.txt
@@ -1,5 +1,5 @@
-ExampleSUITests
+ExamplesTests / ExampleSUITests
 ⏭️ disabled() (Test skipped: Disabled reason)
 
-XCTestTests
+ExamplesTests / XCTestTests
 ⏭️ test_skip() (Skip message)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.SPM-watchOS_skipped.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.SPM-watchOS_skipped.txt
@@ -1,5 +1,5 @@
-ExampleSUITests
+ExamplesTests / ExampleSUITests
 ⏭️ disabled() (Test skipped: Disabled reason)
 
-XCTestTests
+ExamplesTests / XCTestTests
 ⏭️ test_skip() (Skip message)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.Xcworkspace-iOS_skipped.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.Xcworkspace-iOS_skipped.txt
@@ -1,5 +1,5 @@
-ExampleSUITests
+XcodeprojExample.app / ExampleSUITests
 ⏭️ disabled() (Test skipped: Disabled reason)
 
-XCTestTests
+XcodeprojExample.app / XCTestTests
 ⏭️ test_skip() (Skip message)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.Xcworkspace-macOS_skipped.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.Xcworkspace-macOS_skipped.txt
@@ -1,5 +1,5 @@
-ExampleSUITests
+XcodeprojExample.app / ExampleSUITests
 ⏭️ disabled() (Test skipped: Disabled reason)
 
-XCTestTests
+XcodeprojExample.app / XCTestTests
 ⏭️ test_skip() (Skip message)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.Xcworkspace-visionOS_skipped.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_skippedOnly-_.Xcworkspace-visionOS_skipped.txt
@@ -1,5 +1,5 @@
-ExampleSUITests
+XcodeprojExample.app / ExampleSUITests
 ⏭️ disabled() (Test skipped: Disabled reason)
 
-XCTestTests
+XcodeprojExample.app / XCTestTests
 ⏭️ test_skip() (Skip message)

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.SPM-iOS_success.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.SPM-iOS_success.txt
@@ -1,13 +1,29 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+ExamplesTests / ExampleSUITests
 ✅ async()
 ✅ success()
 ✅ withAttachment()
 
-OuterSuite
+ExamplesTests / OuterSuite
 ✅ outer with spaces in name
 ✅ outerSuccess()
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+✅ innerSuccess()
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+✅ deeplyNestedSuccess()
+
+ExamplesTests / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 ✅ test_performance()

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.SPM-macOS_success.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.SPM-macOS_success.txt
@@ -1,13 +1,29 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+ExamplesTests / ExampleSUITests
 ✅ async()
 ✅ success()
 ✅ withAttachment()
 
-OuterSuite
+ExamplesTests / OuterSuite
 ✅ outer with spaces in name
 ✅ outerSuccess()
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+✅ innerSuccess()
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+✅ deeplyNestedSuccess()
+
+ExamplesTests / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 ✅ test_performance()

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.SPM-tvOS_success.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.SPM-tvOS_success.txt
@@ -1,13 +1,29 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+ExamplesTests / ExampleSUITests
 ✅ async()
 ✅ success()
 ✅ withAttachment()
 
-OuterSuite
+ExamplesTests / OuterSuite
 ✅ outer with spaces in name
 ✅ outerSuccess()
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+✅ innerSuccess()
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+✅ deeplyNestedSuccess()
+
+ExamplesTests / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 ✅ test_performance()

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.SPM-visionOS_success.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.SPM-visionOS_success.txt
@@ -1,13 +1,29 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+ExamplesTests / ExampleSUITests
 ✅ async()
 ✅ success()
 ✅ withAttachment()
 
-OuterSuite
+ExamplesTests / OuterSuite
 ✅ outer with spaces in name
 ✅ outerSuccess()
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+✅ innerSuccess()
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+✅ deeplyNestedSuccess()
+
+ExamplesTests / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 ✅ test_performance()

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.SPM-watchOS_success.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.SPM-watchOS_success.txt
@@ -1,13 +1,29 @@
-ExampleSUITests
+ExamplesTests / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+ExamplesTests / ExampleSUITests
 ✅ async()
 ✅ success()
 ✅ withAttachment()
 
-OuterSuite
+ExamplesTests / OuterSuite
 ✅ outer with spaces in name
 ✅ outerSuccess()
 
-XCTestTests
+ExamplesTests / OuterSuite / InnerSuite
+✅ innerSuccess()
+
+ExamplesTests / OuterSuite / InnerSuite / DeeplyNestedSuite
+✅ deeplyNestedSuccess()
+
+ExamplesTests / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 ✅ test_performance()

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.Xcworkspace-iOS_success.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.Xcworkspace-iOS_success.txt
@@ -1,13 +1,29 @@
-ExampleSUITests
+XcodeprojExample.app / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+XcodeprojExample.app / ExampleSUITests
 ✅ async()
 ✅ success()
 ✅ withAttachment()
 
-OuterSuite
+XcodeprojExample.app / OuterSuite
 ✅ outer with spaces in name
 ✅ outerSuccess()
 
-XCTestTests
+XcodeprojExample.app / OuterSuite / InnerSuite
+✅ innerSuccess()
+
+XcodeprojExample.app / OuterSuite / InnerSuite / DeeplyNestedSuite
+✅ deeplyNestedSuccess()
+
+XcodeprojExample.app / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 ✅ test_performance()

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.Xcworkspace-macOS_success.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.Xcworkspace-macOS_success.txt
@@ -1,13 +1,29 @@
-ExampleSUITests
+XcodeprojExample.app / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+XcodeprojExample.app / ExampleSUITests
 ✅ async()
 ✅ success()
 ✅ withAttachment()
 
-OuterSuite
+XcodeprojExample.app / OuterSuite
 ✅ outer with spaces in name
 ✅ outerSuccess()
 
-XCTestTests
+XcodeprojExample.app / OuterSuite / InnerSuite
+✅ innerSuccess()
+
+XcodeprojExample.app / OuterSuite / InnerSuite / DeeplyNestedSuite
+✅ deeplyNestedSuccess()
+
+XcodeprojExample.app / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 ✅ test_performance()

--- a/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.Xcworkspace-visionOS_success.txt
+++ b/Tests/PeekieTests/__Snapshots__/ListFormatterSnapshotTests/format_successOnly-_.Xcworkspace-visionOS_success.txt
@@ -1,13 +1,29 @@
-ExampleSUITests
+XcodeprojExample.app / (no suite)
+✅ 2 + 3 = 5
+✅ array[0] is nil?
+✅ divide(10, 2) / returns 5
+✅ root level with spaces in name
+✅ rootLevelAsync()
+✅ rootLevelSuccess()
+✅ success 🎯
+✅ сложение работает
+
+XcodeprojExample.app / ExampleSUITests
 ✅ async()
 ✅ success()
 ✅ withAttachment()
 
-OuterSuite
+XcodeprojExample.app / OuterSuite
 ✅ outer with spaces in name
 ✅ outerSuccess()
 
-XCTestTests
+XcodeprojExample.app / OuterSuite / InnerSuite
+✅ innerSuccess()
+
+XcodeprojExample.app / OuterSuite / InnerSuite / DeeplyNestedSuite
+✅ deeplyNestedSuccess()
+
+XcodeprojExample.app / XCTestTests
 ✅ test_async()
 ✅ test_asyncWithExpectation()
 ✅ test_performance()

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
@@ -364,6 +364,7 @@
           - totalLines: 106
       - files: 0 elements
       - name: "Calculator"
+      - rootLevelTests: 0 members
       - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
@@ -726,9 +727,558 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
+      ▿ rootLevelTests: 9 members
+        ▿ RepeatableTest
+          - name: "2 + 3 = 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 2.766847610473633 ms
+                - value: 2.766847610473633
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.766847610473633 ms
+                      - value: 2.766847610473633
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 2.2039413452148438 ms
+                - value: 2.2039413452148438
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.2039413452148438 ms
+                      - value: 2.2039413452148438
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.9660720825195312 ms
+                - value: 0.9660720825195312
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.9660720825195312 ms
+                      - value: 0.9660720825195312
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "array[0] is nil?"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 3.4058094024658203 ms
+                - value: 3.4058094024658203
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.4058094024658203 ms
+                      - value: 3.4058094024658203
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.9040107727050781 ms
+                - value: 1.9040107727050781
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.9040107727050781 ms
+                      - value: 1.9040107727050781
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.8440017700195312 ms
+                - value: 0.8440017700195312
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.8440017700195312 ms
+                      - value: 0.8440017700195312
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "divide(10, 2) / returns 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 4.081964492797852 ms
+                - value: 4.081964492797852
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.081964492797852 ms
+                      - value: 4.081964492797852
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.9440650939941406 ms
+                - value: 1.9440650939941406
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.9440650939941406 ms
+                      - value: 1.9440650939941406
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.6551742553710938 ms
+                - value: 0.6551742553710938
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.6551742553710938 ms
+                      - value: 0.6551742553710938
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "root level with spaces in name"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 3.579854965209961 ms
+                - value: 3.579854965209961
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.579854965209961 ms
+                      - value: 3.579854965209961
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.8868446350097656 ms
+                - value: 1.8868446350097656
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.8868446350097656 ms
+                      - value: 1.8868446350097656
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.3701915740966797 ms
+                - value: 1.3701915740966797
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.3701915740966797 ms
+                      - value: 1.3701915740966797
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelAsync()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 15.278816223144531 ms
+                - value: 15.278816223144531
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 15.278816223144531 ms
+                      - value: 15.278816223144531
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 12.305974960327148 ms
+                - value: 12.305974960327148
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 12.305974960327148 ms
+                      - value: 12.305974960327148
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.98887825012207 ms
+                - value: 11.98887825012207
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.98887825012207 ms
+                      - value: 11.98887825012207
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelFailure()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 6.963014602661133 ms
+                - value: 6.963014602661133
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.963014602661133 ms
+                      - value: 6.963014602661133
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 2.1381378173828125 ms
+                - value: 2.1381378173828125
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.1381378173828125 ms
+                      - value: 2.1381378173828125
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 0.4050731658935547 ms
+                - value: 0.4050731658935547
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.4050731658935547 ms
+                      - value: 0.4050731658935547
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+        ▿ RepeatableTest
+          - name: "rootLevelSuccess()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 7.035017013549805 ms
+                - value: 7.035017013549805
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 7.035017013549805 ms
+                      - value: 7.035017013549805
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 3.628969192504883 ms
+                - value: 3.628969192504883
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.628969192504883 ms
+                      - value: 3.628969192504883
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.5521774291992188 ms
+                - value: 0.5521774291992188
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.5521774291992188 ms
+                      - value: 0.5521774291992188
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "success 🎯"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 9.746074676513672 ms
+                - value: 9.746074676513672
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 9.746074676513672 ms
+                      - value: 9.746074676513672
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 2.1660327911376953 ms
+                - value: 2.1660327911376953
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.1660327911376953 ms
+                      - value: 2.1660327911376953
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.6301403045654297 ms
+                - value: 0.6301403045654297
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.6301403045654297 ms
+                      - value: 0.6301403045654297
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "сложение работает"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 9.649991989135742 ms
+                - value: 9.649991989135742
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 9.649991989135742 ms
+                      - value: 9.649991989135742
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 2.126932144165039 ms
+                - value: 2.126932144165039
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.126932144165039 ms
+                      - value: 2.126932144165039
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.7472038269042969 ms
+                - value: 0.7472038269042969
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.7472038269042969 ms
+                      - value: 0.7472038269042969
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
       ▿ suites: 3 elements
         ▿ Suite
+          - fullPath: "XCTestTests"
           - name: "XCTestTests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
           ▿ repeatableTests: 11 members
             ▿ RepeatableTest
@@ -1006,7 +1556,9 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "ExampleSUITests"
           - name: "ExampleSUITests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/ExampleSUITests"
           ▿ repeatableTests: 9 members
             ▿ RepeatableTest
@@ -1678,7 +2230,273 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "OuterSuite"
           - name: "OuterSuite"
+          ▿ nestedSuites: 1 element
+            ▿ Suite
+              - fullPath: "OuterSuite / InnerSuite"
+              - name: "InnerSuite"
+              ▿ nestedSuites: 1 element
+                ▿ Suite
+                  - fullPath: "OuterSuite / InnerSuite / DeeplyNestedSuite"
+                  - name: "DeeplyNestedSuite"
+                  - nestedSuites: 0 elements
+                  - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite"
+                  ▿ repeatableTests: 2 members
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedFailure()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 1.6570091247558594 ms
+                            - value: 1.6570091247558594
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.6570091247558594 ms
+                                  - value: 1.6570091247558594
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 0.5419254302978516 ms
+                            - value: 0.5419254302978516
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.5419254302978516 ms
+                                  - value: 0.5419254302978516
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 0.15616416931152344 ms
+                            - value: 0.15616416931152344
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.15616416931152344 ms
+                                  - value: 0.15616416931152344
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedSuccess()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 1.6651153564453125 ms
+                            - value: 1.6651153564453125
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.6651153564453125 ms
+                                  - value: 1.6651153564453125
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 0.5519390106201172 ms
+                            - value: 0.5519390106201172
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.5519390106201172 ms
+                                  - value: 0.5519390106201172
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 0.4792213439941406 ms
+                            - value: 0.4792213439941406
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.4792213439941406 ms
+                                  - value: 0.4792213439941406
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+              - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite/InnerSuite"
+              ▿ repeatableTests: 2 members
+                ▿ RepeatableTest
+                  - name: "innerFailure()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 2.7379989624023438 ms
+                        - value: 2.7379989624023438
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 2.7379989624023438 ms
+                              - value: 2.7379989624023438
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 1.2331008911132812 ms
+                        - value: 1.2331008911132812
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.2331008911132812 ms
+                              - value: 1.2331008911132812
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 0.8628368377685547 ms
+                        - value: 0.8628368377685547
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.8628368377685547 ms
+                              - value: 0.8628368377685547
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                ▿ RepeatableTest
+                  - name: "innerSuccess()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 2.9630661010742188 ms
+                        - value: 2.9630661010742188
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 2.9630661010742188 ms
+                              - value: 2.9630661010742188
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 1.1339187622070312 ms
+                        - value: 1.1339187622070312
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.1339187622070312 ms
+                              - value: 1.1339187622070312
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 1.0209083557128906 ms
+                        - value: 1.0209083557128906
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.0209083557128906 ms
+                              - value: 1.0209083557128906
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite"
           ▿ repeatableTests: 3 members
             ▿ RepeatableTest
@@ -1871,4 +2689,5 @@
       - coverage: Optional<Coverage>.none
       - files: 0 elements
       - name: "StringUtils"
+      - rootLevelTests: 0 members
       - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
@@ -364,6 +364,7 @@
           - totalLines: 106
       - files: 0 elements
       - name: "Calculator"
+      - rootLevelTests: 0 members
       - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
@@ -726,9 +727,558 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
+      ▿ rootLevelTests: 9 members
+        ▿ RepeatableTest
+          - name: "2 + 3 = 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 4.26793098449707 ms
+                - value: 4.26793098449707
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.26793098449707 ms
+                      - value: 4.26793098449707
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 4.575967788696289 ms
+                - value: 4.575967788696289
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.575967788696289 ms
+                      - value: 4.575967788696289
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.811971664428711 ms
+                - value: 11.811971664428711
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.811971664428711 ms
+                      - value: 11.811971664428711
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "array[0] is nil?"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 4.052877426147461 ms
+                - value: 4.052877426147461
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.052877426147461 ms
+                      - value: 4.052877426147461
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 4.556179046630859 ms
+                - value: 4.556179046630859
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.556179046630859 ms
+                      - value: 4.556179046630859
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.781930923461914 ms
+                - value: 11.781930923461914
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.781930923461914 ms
+                      - value: 11.781930923461914
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "divide(10, 2) / returns 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 3.977060317993164 ms
+                - value: 3.977060317993164
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.977060317993164 ms
+                      - value: 3.977060317993164
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 19.59395408630371 ms
+                - value: 19.59395408630371
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 19.59395408630371 ms
+                      - value: 19.59395408630371
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 12.012004852294922 ms
+                - value: 12.012004852294922
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 12.012004852294922 ms
+                      - value: 12.012004852294922
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "root level with spaces in name"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 4.302024841308594 ms
+                - value: 4.302024841308594
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.302024841308594 ms
+                      - value: 4.302024841308594
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 4.487037658691406 ms
+                - value: 4.487037658691406
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.487037658691406 ms
+                      - value: 4.487037658691406
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.886835098266602 ms
+                - value: 11.886835098266602
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.886835098266602 ms
+                      - value: 11.886835098266602
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelAsync()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 12.901067733764648 ms
+                - value: 12.901067733764648
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 12.901067733764648 ms
+                      - value: 12.901067733764648
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 19.989967346191406 ms
+                - value: 19.989967346191406
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 19.989967346191406 ms
+                      - value: 19.989967346191406
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 12.041091918945312 ms
+                - value: 12.041091918945312
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 12.041091918945312 ms
+                      - value: 12.041091918945312
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelFailure()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 4.221916198730469 ms
+                - value: 4.221916198730469
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.221916198730469 ms
+                      - value: 4.221916198730469
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 4.559040069580078 ms
+                - value: 4.559040069580078
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.559040069580078 ms
+                      - value: 4.559040069580078
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 12.044191360473633 ms
+                - value: 12.044191360473633
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 12.044191360473633 ms
+                      - value: 12.044191360473633
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+        ▿ RepeatableTest
+          - name: "rootLevelSuccess()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 3.965139389038086 ms
+                - value: 3.965139389038086
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.965139389038086 ms
+                      - value: 3.965139389038086
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 4.50587272644043 ms
+                - value: 4.50587272644043
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.50587272644043 ms
+                      - value: 4.50587272644043
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.363983154296875 ms
+                - value: 11.363983154296875
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.363983154296875 ms
+                      - value: 11.363983154296875
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "success 🎯"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 4.014015197753906 ms
+                - value: 4.014015197753906
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.014015197753906 ms
+                      - value: 4.014015197753906
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 4.490137100219727 ms
+                - value: 4.490137100219727
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.490137100219727 ms
+                      - value: 4.490137100219727
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.33108139038086 ms
+                - value: 11.33108139038086
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.33108139038086 ms
+                      - value: 11.33108139038086
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "сложение работает"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 4.0950775146484375 ms
+                - value: 4.0950775146484375
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.0950775146484375 ms
+                      - value: 4.0950775146484375
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 4.416942596435547 ms
+                - value: 4.416942596435547
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.416942596435547 ms
+                      - value: 4.416942596435547
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.46388053894043 ms
+                - value: 11.46388053894043
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.46388053894043 ms
+                      - value: 11.46388053894043
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
       ▿ suites: 3 elements
         ▿ Suite
+          - fullPath: "XCTestTests"
           - name: "XCTestTests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
           ▿ repeatableTests: 11 members
             ▿ RepeatableTest
@@ -1006,7 +1556,9 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "ExampleSUITests"
           - name: "ExampleSUITests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/ExampleSUITests"
           ▿ repeatableTests: 9 members
             ▿ RepeatableTest
@@ -1678,7 +2230,273 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "OuterSuite"
           - name: "OuterSuite"
+          ▿ nestedSuites: 1 element
+            ▿ Suite
+              - fullPath: "OuterSuite / InnerSuite"
+              - name: "InnerSuite"
+              ▿ nestedSuites: 1 element
+                ▿ Suite
+                  - fullPath: "OuterSuite / InnerSuite / DeeplyNestedSuite"
+                  - name: "DeeplyNestedSuite"
+                  - nestedSuites: 0 elements
+                  - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite"
+                  ▿ repeatableTests: 2 members
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedFailure()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 3.985166549682617 ms
+                            - value: 3.985166549682617
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 3.985166549682617 ms
+                                  - value: 3.985166549682617
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 15.54107666015625 ms
+                            - value: 15.54107666015625
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 15.54107666015625 ms
+                                  - value: 15.54107666015625
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 10.959148406982422 ms
+                            - value: 10.959148406982422
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 10.959148406982422 ms
+                                  - value: 10.959148406982422
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedSuccess()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 4.002094268798828 ms
+                            - value: 4.002094268798828
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 4.002094268798828 ms
+                                  - value: 4.002094268798828
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 15.543937683105469 ms
+                            - value: 15.543937683105469
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 15.543937683105469 ms
+                                  - value: 15.543937683105469
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 10.592937469482422 ms
+                            - value: 10.592937469482422
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 10.592937469482422 ms
+                                  - value: 10.592937469482422
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+              - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite/InnerSuite"
+              ▿ repeatableTests: 2 members
+                ▿ RepeatableTest
+                  - name: "innerFailure()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 3.840923309326172 ms
+                        - value: 3.840923309326172
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 3.840923309326172 ms
+                              - value: 3.840923309326172
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 15.71202278137207 ms
+                        - value: 15.71202278137207
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 15.71202278137207 ms
+                              - value: 15.71202278137207
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 11.094093322753906 ms
+                        - value: 11.094093322753906
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 11.094093322753906 ms
+                              - value: 11.094093322753906
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                ▿ RepeatableTest
+                  - name: "innerSuccess()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 4.102945327758789 ms
+                        - value: 4.102945327758789
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 4.102945327758789 ms
+                              - value: 4.102945327758789
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 15.594959259033203 ms
+                        - value: 15.594959259033203
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 15.594959259033203 ms
+                              - value: 15.594959259033203
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 10.97416877746582 ms
+                        - value: 10.97416877746582
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 10.97416877746582 ms
+                              - value: 10.97416877746582
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite"
           ▿ repeatableTests: 3 members
             ▿ RepeatableTest
@@ -1871,4 +2689,5 @@
       - coverage: Optional<Coverage>.none
       - files: 0 elements
       - name: "StringUtils"
+      - rootLevelTests: 0 members
       - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
@@ -364,6 +364,7 @@
           - totalLines: 106
       - files: 0 elements
       - name: "Calculator"
+      - rootLevelTests: 0 members
       - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
@@ -726,9 +727,558 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
+      ▿ rootLevelTests: 9 members
+        ▿ RepeatableTest
+          - name: "2 + 3 = 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 5.928993225097656 ms
+                - value: 5.928993225097656
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 5.928993225097656 ms
+                      - value: 5.928993225097656
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.8220672607421875 ms
+                - value: 0.8220672607421875
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.8220672607421875 ms
+                      - value: 0.8220672607421875
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.8709430694580078 ms
+                - value: 0.8709430694580078
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.8709430694580078 ms
+                      - value: 0.8709430694580078
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "array[0] is nil?"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 6.644010543823242 ms
+                - value: 6.644010543823242
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.644010543823242 ms
+                      - value: 6.644010543823242
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.8749237060546875 ms
+                - value: 1.8749237060546875
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.8749237060546875 ms
+                      - value: 1.8749237060546875
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.5018711090087891 ms
+                - value: 0.5018711090087891
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.5018711090087891 ms
+                      - value: 0.5018711090087891
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "divide(10, 2) / returns 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 6.332874298095703 ms
+                - value: 6.332874298095703
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.332874298095703 ms
+                      - value: 6.332874298095703
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.7479190826416016 ms
+                - value: 0.7479190826416016
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.7479190826416016 ms
+                      - value: 0.7479190826416016
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.4181861877441406 ms
+                - value: 0.4181861877441406
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.4181861877441406 ms
+                      - value: 0.4181861877441406
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "root level with spaces in name"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 6.123065948486328 ms
+                - value: 6.123065948486328
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.123065948486328 ms
+                      - value: 6.123065948486328
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.3070106506347656 ms
+                - value: 1.3070106506347656
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.3070106506347656 ms
+                      - value: 1.3070106506347656
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.576019287109375 ms
+                - value: 0.576019287109375
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.576019287109375 ms
+                      - value: 0.576019287109375
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelAsync()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 21.699190139770508 ms
+                - value: 21.699190139770508
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 21.699190139770508 ms
+                      - value: 21.699190139770508
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 12.372970581054688 ms
+                - value: 12.372970581054688
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 12.372970581054688 ms
+                      - value: 12.372970581054688
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 12.363910675048828 ms
+                - value: 12.363910675048828
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 12.363910675048828 ms
+                      - value: 12.363910675048828
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelFailure()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 13.770103454589844 ms
+                - value: 13.770103454589844
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 13.770103454589844 ms
+                      - value: 13.770103454589844
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 0.7319450378417969 ms
+                - value: 0.7319450378417969
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.7319450378417969 ms
+                      - value: 0.7319450378417969
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 0.4429817199707031 ms
+                - value: 0.4429817199707031
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.4429817199707031 ms
+                      - value: 0.4429817199707031
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+        ▿ RepeatableTest
+          - name: "rootLevelSuccess()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 6.166934967041016 ms
+                - value: 6.166934967041016
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.166934967041016 ms
+                      - value: 6.166934967041016
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.9520053863525391 ms
+                - value: 0.9520053863525391
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.9520053863525391 ms
+                      - value: 0.9520053863525391
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.6120204925537109 ms
+                - value: 0.6120204925537109
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.6120204925537109 ms
+                      - value: 0.6120204925537109
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "success 🎯"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 7.205963134765625 ms
+                - value: 7.205963134765625
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 7.205963134765625 ms
+                      - value: 7.205963134765625
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.0738372802734375 ms
+                - value: 1.0738372802734375
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.0738372802734375 ms
+                      - value: 1.0738372802734375
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.49304962158203125 ms
+                - value: 0.49304962158203125
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.49304962158203125 ms
+                      - value: 0.49304962158203125
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "сложение работает"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 6.2961578369140625 ms
+                - value: 6.2961578369140625
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.2961578369140625 ms
+                      - value: 6.2961578369140625
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.2791156768798828 ms
+                - value: 1.2791156768798828
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.2791156768798828 ms
+                      - value: 1.2791156768798828
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.5838871002197266 ms
+                - value: 0.5838871002197266
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.5838871002197266 ms
+                      - value: 0.5838871002197266
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
       ▿ suites: 3 elements
         ▿ Suite
+          - fullPath: "XCTestTests"
           - name: "XCTestTests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
           ▿ repeatableTests: 11 members
             ▿ RepeatableTest
@@ -1006,7 +1556,273 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "OuterSuite"
           - name: "OuterSuite"
+          ▿ nestedSuites: 1 element
+            ▿ Suite
+              - fullPath: "OuterSuite / InnerSuite"
+              - name: "InnerSuite"
+              ▿ nestedSuites: 1 element
+                ▿ Suite
+                  - fullPath: "OuterSuite / InnerSuite / DeeplyNestedSuite"
+                  - name: "DeeplyNestedSuite"
+                  - nestedSuites: 0 elements
+                  - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite"
+                  ▿ repeatableTests: 2 members
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedFailure()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 6.890058517456055 ms
+                            - value: 6.890058517456055
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 6.890058517456055 ms
+                                  - value: 6.890058517456055
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 1.007080078125 ms
+                            - value: 1.007080078125
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.007080078125 ms
+                                  - value: 1.007080078125
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 0.39196014404296875 ms
+                            - value: 0.39196014404296875
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.39196014404296875 ms
+                                  - value: 0.39196014404296875
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedSuccess()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 0.11992454528808594 ms
+                            - value: 0.11992454528808594
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.11992454528808594 ms
+                                  - value: 0.11992454528808594
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 0.6859302520751953 ms
+                            - value: 0.6859302520751953
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.6859302520751953 ms
+                                  - value: 0.6859302520751953
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 0.3669261932373047 ms
+                            - value: 0.3669261932373047
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.3669261932373047 ms
+                                  - value: 0.3669261932373047
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+              - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite/InnerSuite"
+              ▿ repeatableTests: 2 members
+                ▿ RepeatableTest
+                  - name: "innerFailure()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 7.856845855712891 ms
+                        - value: 7.856845855712891
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 7.856845855712891 ms
+                              - value: 7.856845855712891
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 1.338958740234375 ms
+                        - value: 1.338958740234375
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.338958740234375 ms
+                              - value: 1.338958740234375
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 0.6439685821533203 ms
+                        - value: 0.6439685821533203
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.6439685821533203 ms
+                              - value: 0.6439685821533203
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                ▿ RepeatableTest
+                  - name: "innerSuccess()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 7.879972457885742 ms
+                        - value: 7.879972457885742
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 7.879972457885742 ms
+                              - value: 7.879972457885742
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 1.0781288146972656 ms
+                        - value: 1.0781288146972656
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.0781288146972656 ms
+                              - value: 1.0781288146972656
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 0.5910396575927734 ms
+                        - value: 0.5910396575927734
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.5910396575927734 ms
+                              - value: 0.5910396575927734
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite"
           ▿ repeatableTests: 3 members
             ▿ RepeatableTest
@@ -1196,7 +2012,9 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "ExampleSUITests"
           - name: "ExampleSUITests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/ExampleSUITests"
           ▿ repeatableTests: 9 members
             ▿ RepeatableTest
@@ -1871,4 +2689,5 @@
       - coverage: Optional<Coverage>.none
       - files: 0 elements
       - name: "StringUtils"
+      - rootLevelTests: 0 members
       - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
@@ -364,6 +364,7 @@
           - totalLines: 106
       - files: 0 elements
       - name: "Calculator"
+      - rootLevelTests: 0 members
       - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
@@ -726,9 +727,558 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
+      ▿ rootLevelTests: 9 members
+        ▿ RepeatableTest
+          - name: "2 + 3 = 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 9.89985466003418 ms
+                - value: 9.89985466003418
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 9.89985466003418 ms
+                      - value: 9.89985466003418
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 2.0339488983154297 ms
+                - value: 2.0339488983154297
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.0339488983154297 ms
+                      - value: 2.0339488983154297
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.5540122985839844 ms
+                - value: 1.5540122985839844
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.5540122985839844 ms
+                      - value: 1.5540122985839844
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "array[0] is nil?"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 8.238077163696289 ms
+                - value: 8.238077163696289
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 8.238077163696289 ms
+                      - value: 8.238077163696289
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 2.4940967559814453 ms
+                - value: 2.4940967559814453
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.4940967559814453 ms
+                      - value: 2.4940967559814453
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.7611980438232422 ms
+                - value: 1.7611980438232422
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.7611980438232422 ms
+                      - value: 1.7611980438232422
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "divide(10, 2) / returns 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 8.70513916015625 ms
+                - value: 8.70513916015625
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 8.70513916015625 ms
+                      - value: 8.70513916015625
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.6510486602783203 ms
+                - value: 1.6510486602783203
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.6510486602783203 ms
+                      - value: 1.6510486602783203
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.592874526977539 ms
+                - value: 1.592874526977539
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.592874526977539 ms
+                      - value: 1.592874526977539
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "root level with spaces in name"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 8.61501693725586 ms
+                - value: 8.61501693725586
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 8.61501693725586 ms
+                      - value: 8.61501693725586
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.6179084777832031 ms
+                - value: 1.6179084777832031
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.6179084777832031 ms
+                      - value: 1.6179084777832031
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.5671253204345703 ms
+                - value: 1.5671253204345703
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.5671253204345703 ms
+                      - value: 1.5671253204345703
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelAsync()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 10.937929153442383 ms
+                - value: 10.937929153442383
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 10.937929153442383 ms
+                      - value: 10.937929153442383
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.619091033935547 ms
+                - value: 11.619091033935547
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.619091033935547 ms
+                      - value: 11.619091033935547
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.93094253540039 ms
+                - value: 11.93094253540039
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.93094253540039 ms
+                      - value: 11.93094253540039
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelFailure()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 6.043195724487305 ms
+                - value: 6.043195724487305
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.043195724487305 ms
+                      - value: 6.043195724487305
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 2.8619766235351562 ms
+                - value: 2.8619766235351562
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.8619766235351562 ms
+                      - value: 2.8619766235351562
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 1.6710758209228516 ms
+                - value: 1.6710758209228516
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.6710758209228516 ms
+                      - value: 1.6710758209228516
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+        ▿ RepeatableTest
+          - name: "rootLevelSuccess()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 11.35706901550293 ms
+                - value: 11.35706901550293
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.35706901550293 ms
+                      - value: 11.35706901550293
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 3.019094467163086 ms
+                - value: 3.019094467163086
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.019094467163086 ms
+                      - value: 3.019094467163086
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.7611980438232422 ms
+                - value: 1.7611980438232422
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.7611980438232422 ms
+                      - value: 1.7611980438232422
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "success 🎯"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 10.225057601928711 ms
+                - value: 10.225057601928711
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 10.225057601928711 ms
+                      - value: 10.225057601928711
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 3.2389163970947266 ms
+                - value: 3.2389163970947266
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.2389163970947266 ms
+                      - value: 3.2389163970947266
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 2.7408599853515625 ms
+                - value: 2.7408599853515625
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.7408599853515625 ms
+                      - value: 2.7408599853515625
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "сложение работает"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 1.7838478088378906 ms
+                - value: 1.7838478088378906
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.7838478088378906 ms
+                      - value: 1.7838478088378906
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 2.4368762969970703 ms
+                - value: 2.4368762969970703
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.4368762969970703 ms
+                      - value: 2.4368762969970703
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.8329620361328125 ms
+                - value: 1.8329620361328125
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.8329620361328125 ms
+                      - value: 1.8329620361328125
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
       ▿ suites: 3 elements
         ▿ Suite
+          - fullPath: "XCTestTests"
           - name: "XCTestTests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
           ▿ repeatableTests: 11 members
             ▿ RepeatableTest
@@ -1006,7 +1556,273 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "OuterSuite"
           - name: "OuterSuite"
+          ▿ nestedSuites: 1 element
+            ▿ Suite
+              - fullPath: "OuterSuite / InnerSuite"
+              - name: "InnerSuite"
+              ▿ nestedSuites: 1 element
+                ▿ Suite
+                  - fullPath: "OuterSuite / InnerSuite / DeeplyNestedSuite"
+                  - name: "DeeplyNestedSuite"
+                  - nestedSuites: 0 elements
+                  - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite"
+                  ▿ repeatableTests: 2 members
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedFailure()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 4.0760040283203125 ms
+                            - value: 4.0760040283203125
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 4.0760040283203125 ms
+                                  - value: 4.0760040283203125
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 1.127004623413086 ms
+                            - value: 1.127004623413086
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.127004623413086 ms
+                                  - value: 1.127004623413086
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 0.5180835723876953 ms
+                            - value: 0.5180835723876953
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.5180835723876953 ms
+                                  - value: 0.5180835723876953
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedSuccess()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 2.9239654541015625 ms
+                            - value: 2.9239654541015625
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 2.9239654541015625 ms
+                                  - value: 2.9239654541015625
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 0.7219314575195312 ms
+                            - value: 0.7219314575195312
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.7219314575195312 ms
+                                  - value: 0.7219314575195312
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 0.5259513854980469 ms
+                            - value: 0.5259513854980469
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.5259513854980469 ms
+                                  - value: 0.5259513854980469
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+              - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite/InnerSuite"
+              ▿ repeatableTests: 2 members
+                ▿ RepeatableTest
+                  - name: "innerFailure()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 8.697032928466797 ms
+                        - value: 8.697032928466797
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 8.697032928466797 ms
+                              - value: 8.697032928466797
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 1.7879009246826172 ms
+                        - value: 1.7879009246826172
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.7879009246826172 ms
+                              - value: 1.7879009246826172
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 1.074075698852539 ms
+                        - value: 1.074075698852539
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.074075698852539 ms
+                              - value: 1.074075698852539
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                ▿ RepeatableTest
+                  - name: "innerSuccess()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 9.640932083129883 ms
+                        - value: 9.640932083129883
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 9.640932083129883 ms
+                              - value: 9.640932083129883
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 1.573801040649414 ms
+                        - value: 1.573801040649414
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.573801040649414 ms
+                              - value: 1.573801040649414
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 1.962900161743164 ms
+                        - value: 1.962900161743164
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.962900161743164 ms
+                              - value: 1.962900161743164
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite"
           ▿ repeatableTests: 3 members
             ▿ RepeatableTest
@@ -1196,7 +2012,9 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "ExampleSUITests"
           - name: "ExampleSUITests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/ExampleSUITests"
           ▿ repeatableTests: 9 members
             ▿ RepeatableTest
@@ -1871,4 +2689,5 @@
       - coverage: Optional<Coverage>.none
       - files: 0 elements
       - name: "StringUtils"
+      - rootLevelTests: 0 members
       - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
@@ -364,6 +364,7 @@
           - totalLines: 106
       - files: 0 elements
       - name: "Calculator"
+      - rootLevelTests: 0 members
       - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
@@ -726,9 +727,558 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
+      ▿ rootLevelTests: 9 members
+        ▿ RepeatableTest
+          - name: "2 + 3 = 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 15.32888412475586 ms
+                - value: 15.32888412475586
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 15.32888412475586 ms
+                      - value: 15.32888412475586
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 6.515979766845703 ms
+                - value: 6.515979766845703
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.515979766845703 ms
+                      - value: 6.515979766845703
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 2.9909610748291016 ms
+                - value: 2.9909610748291016
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.9909610748291016 ms
+                      - value: 2.9909610748291016
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "array[0] is nil?"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 15.994071960449219 ms
+                - value: 15.994071960449219
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 15.994071960449219 ms
+                      - value: 15.994071960449219
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 6.516933441162109 ms
+                - value: 6.516933441162109
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.516933441162109 ms
+                      - value: 6.516933441162109
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.6420612335205078 ms
+                - value: 0.6420612335205078
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.6420612335205078 ms
+                      - value: 0.6420612335205078
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "divide(10, 2) / returns 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 15.423059463500977 ms
+                - value: 15.423059463500977
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 15.423059463500977 ms
+                      - value: 15.423059463500977
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 6.5479278564453125 ms
+                - value: 6.5479278564453125
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.5479278564453125 ms
+                      - value: 6.5479278564453125
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 2.0351409912109375 ms
+                - value: 2.0351409912109375
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.0351409912109375 ms
+                      - value: 2.0351409912109375
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "root level with spaces in name"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 5.372047424316406 ms
+                - value: 5.372047424316406
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 5.372047424316406 ms
+                      - value: 5.372047424316406
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 8.182048797607422 ms
+                - value: 8.182048797607422
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 8.182048797607422 ms
+                      - value: 8.182048797607422
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.7240047454833984 ms
+                - value: 1.7240047454833984
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.7240047454833984 ms
+                      - value: 1.7240047454833984
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelAsync()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 27.558088302612305 ms
+                - value: 27.558088302612305
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 27.558088302612305 ms
+                      - value: 27.558088302612305
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 15.149831771850586 ms
+                - value: 15.149831771850586
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 15.149831771850586 ms
+                      - value: 15.149831771850586
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.337041854858398 ms
+                - value: 11.337041854858398
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.337041854858398 ms
+                      - value: 11.337041854858398
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelFailure()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 16.00193977355957 ms
+                - value: 16.00193977355957
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 16.00193977355957 ms
+                      - value: 16.00193977355957
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 7.441997528076172 ms
+                - value: 7.441997528076172
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 7.441997528076172 ms
+                      - value: 7.441997528076172
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 1.5819072723388672 ms
+                - value: 1.5819072723388672
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.5819072723388672 ms
+                      - value: 1.5819072723388672
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+        ▿ RepeatableTest
+          - name: "rootLevelSuccess()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 15.708208084106445 ms
+                - value: 15.708208084106445
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 15.708208084106445 ms
+                      - value: 15.708208084106445
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 6.406068801879883 ms
+                - value: 6.406068801879883
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.406068801879883 ms
+                      - value: 6.406068801879883
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.1210441589355469 ms
+                - value: 1.1210441589355469
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.1210441589355469 ms
+                      - value: 1.1210441589355469
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "success 🎯"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 16.284942626953125 ms
+                - value: 16.284942626953125
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 16.284942626953125 ms
+                      - value: 16.284942626953125
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 6.575822830200195 ms
+                - value: 6.575822830200195
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.575822830200195 ms
+                      - value: 6.575822830200195
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 3.164052963256836 ms
+                - value: 3.164052963256836
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.164052963256836 ms
+                      - value: 3.164052963256836
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "сложение работает"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 5.033969879150391 ms
+                - value: 5.033969879150391
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 5.033969879150391 ms
+                      - value: 5.033969879150391
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 6.829023361206055 ms
+                - value: 6.829023361206055
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 6.829023361206055 ms
+                      - value: 6.829023361206055
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.6219615936279297 ms
+                - value: 1.6219615936279297
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.6219615936279297 ms
+                      - value: 1.6219615936279297
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
       ▿ suites: 3 elements
         ▿ Suite
+          - fullPath: "XCTestTests"
           - name: "XCTestTests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/XCTestTests"
           ▿ repeatableTests: 11 members
             ▿ RepeatableTest
@@ -1006,7 +1556,9 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "ExampleSUITests"
           - name: "ExampleSUITests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/ExampleSUITests"
           ▿ repeatableTests: 9 members
             ▿ RepeatableTest
@@ -1678,7 +2230,273 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "OuterSuite"
           - name: "OuterSuite"
+          ▿ nestedSuites: 1 element
+            ▿ Suite
+              - fullPath: "OuterSuite / InnerSuite"
+              - name: "InnerSuite"
+              ▿ nestedSuites: 1 element
+                ▿ Suite
+                  - fullPath: "OuterSuite / InnerSuite / DeeplyNestedSuite"
+                  - name: "DeeplyNestedSuite"
+                  - nestedSuites: 0 elements
+                  - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite"
+                  ▿ repeatableTests: 2 members
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedFailure()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 0.6759166717529297 ms
+                            - value: 0.6759166717529297
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.6759166717529297 ms
+                                  - value: 0.6759166717529297
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 1.3179779052734375 ms
+                            - value: 1.3179779052734375
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.3179779052734375 ms
+                                  - value: 1.3179779052734375
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 1.6031265258789062 ms
+                            - value: 1.6031265258789062
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.6031265258789062 ms
+                                  - value: 1.6031265258789062
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedSuccess()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 1.2378692626953125 ms
+                            - value: 1.2378692626953125
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.2378692626953125 ms
+                                  - value: 1.2378692626953125
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 1.0080337524414062 ms
+                            - value: 1.0080337524414062
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.0080337524414062 ms
+                                  - value: 1.0080337524414062
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 1.9850730895996094 ms
+                            - value: 1.9850730895996094
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.9850730895996094 ms
+                                  - value: 1.9850730895996094
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+              - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite/InnerSuite"
+              ▿ repeatableTests: 2 members
+                ▿ RepeatableTest
+                  - name: "innerFailure()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 0.7228851318359375 ms
+                        - value: 0.7228851318359375
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.7228851318359375 ms
+                              - value: 0.7228851318359375
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 5.233049392700195 ms
+                        - value: 5.233049392700195
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 5.233049392700195 ms
+                              - value: 5.233049392700195
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 1.4650821685791016 ms
+                        - value: 1.4650821685791016
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.4650821685791016 ms
+                              - value: 1.4650821685791016
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                ▿ RepeatableTest
+                  - name: "innerSuccess()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 1.1179447174072266 ms
+                        - value: 1.1179447174072266
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.1179447174072266 ms
+                              - value: 1.1179447174072266
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 5.712985992431641 ms
+                        - value: 5.712985992431641
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 5.712985992431641 ms
+                              - value: 5.712985992431641
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 1.661062240600586 ms
+                        - value: 1.661062240600586
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.661062240600586 ms
+                              - value: 1.661062240600586
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
           - nodeIdentifierURL: "test://com.apple.xcode/Examples/ExamplesTests/OuterSuite"
           ▿ repeatableTests: 3 members
             ▿ RepeatableTest
@@ -1871,4 +2689,5 @@
       - coverage: Optional<Coverage>.none
       - files: 0 elements
       - name: "StringUtils"
+      - rootLevelTests: 0 members
       - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
@@ -393,9 +393,558 @@
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
           - warnings: 0 elements
       - name: "XcodeprojExample.app"
+      ▿ rootLevelTests: 9 members
+        ▿ RepeatableTest
+          - name: "2 + 3 = 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 2.9480457305908203 ms
+                - value: 2.9480457305908203
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.9480457305908203 ms
+                      - value: 2.9480457305908203
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 143.65196228027344 ms
+                - value: 143.65196228027344
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 143.65196228027344 ms
+                      - value: 143.65196228027344
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.2731552124023438 ms
+                - value: 1.2731552124023438
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.2731552124023438 ms
+                      - value: 1.2731552124023438
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "array[0] is nil?"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 3.9451122283935547 ms
+                - value: 3.9451122283935547
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.9451122283935547 ms
+                      - value: 3.9451122283935547
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 145.53403854370117 ms
+                - value: 145.53403854370117
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 145.53403854370117 ms
+                      - value: 145.53403854370117
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.628875732421875 ms
+                - value: 1.628875732421875
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.628875732421875 ms
+                      - value: 1.628875732421875
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "divide(10, 2) / returns 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 3.8971900939941406 ms
+                - value: 3.8971900939941406
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.8971900939941406 ms
+                      - value: 3.8971900939941406
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 144.98519897460938 ms
+                - value: 144.98519897460938
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 144.98519897460938 ms
+                      - value: 144.98519897460938
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.6720294952392578 ms
+                - value: 1.6720294952392578
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.6720294952392578 ms
+                      - value: 1.6720294952392578
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "root level with spaces in name"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 2.8579235076904297 ms
+                - value: 2.8579235076904297
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 2.8579235076904297 ms
+                      - value: 2.8579235076904297
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 143.68295669555664 ms
+                - value: 143.68295669555664
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 143.68295669555664 ms
+                      - value: 143.68295669555664
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.7240047454833984 ms
+                - value: 1.7240047454833984
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.7240047454833984 ms
+                      - value: 1.7240047454833984
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelAsync()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 15.147924423217773 ms
+                - value: 15.147924423217773
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 15.147924423217773 ms
+                      - value: 15.147924423217773
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 145.40910720825195 ms
+                - value: 145.40910720825195
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 145.40910720825195 ms
+                      - value: 145.40910720825195
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 34.36589241027832 ms
+                - value: 34.36589241027832
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 34.36589241027832 ms
+                      - value: 34.36589241027832
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelFailure()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 4.141807556152344 ms
+                - value: 4.141807556152344
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.141807556152344 ms
+                      - value: 4.141807556152344
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 128.49092483520508 ms
+                - value: 128.49092483520508
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 128.49092483520508 ms
+                      - value: 128.49092483520508
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 1.7180442810058594 ms
+                - value: 1.7180442810058594
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.7180442810058594 ms
+                      - value: 1.7180442810058594
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+        ▿ RepeatableTest
+          - name: "rootLevelSuccess()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 4.073143005371094 ms
+                - value: 4.073143005371094
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.073143005371094 ms
+                      - value: 4.073143005371094
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 144.8678970336914 ms
+                - value: 144.8678970336914
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 144.8678970336914 ms
+                      - value: 144.8678970336914
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.692056655883789 ms
+                - value: 1.692056655883789
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.692056655883789 ms
+                      - value: 1.692056655883789
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "success 🎯"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 1.4181137084960938 ms
+                - value: 1.4181137084960938
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.4181137084960938 ms
+                      - value: 1.4181137084960938
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 144.85788345336914 ms
+                - value: 144.85788345336914
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 144.85788345336914 ms
+                      - value: 144.85788345336914
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.6150474548339844 ms
+                - value: 1.6150474548339844
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.6150474548339844 ms
+                      - value: 1.6150474548339844
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "сложение работает"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 3.0388832092285156 ms
+                - value: 3.0388832092285156
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.0388832092285156 ms
+                      - value: 3.0388832092285156
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 145.09010314941406 ms
+                - value: 145.09010314941406
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 145.09010314941406 ms
+                      - value: 145.09010314941406
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.2500286102294922 ms
+                - value: 1.2500286102294922
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.2500286102294922 ms
+                      - value: 1.2500286102294922
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
       ▿ suites: 3 elements
         ▿ Suite
+          - fullPath: "XCTestTests"
           - name: "XCTestTests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/XCTestTests"
           ▿ repeatableTests: 11 members
             ▿ RepeatableTest
@@ -673,7 +1222,273 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "OuterSuite"
           - name: "OuterSuite"
+          ▿ nestedSuites: 1 element
+            ▿ Suite
+              - fullPath: "OuterSuite / InnerSuite"
+              - name: "InnerSuite"
+              ▿ nestedSuites: 1 element
+                ▿ Suite
+                  - fullPath: "OuterSuite / InnerSuite / DeeplyNestedSuite"
+                  - name: "DeeplyNestedSuite"
+                  - nestedSuites: 0 elements
+                  - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/OuterSuite/InnerSuite/DeeplyNestedSuite"
+                  ▿ repeatableTests: 2 members
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedFailure()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 5.747079849243164 ms
+                            - value: 5.747079849243164
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 5.747079849243164 ms
+                                  - value: 5.747079849243164
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 11.535167694091797 ms
+                            - value: 11.535167694091797
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 11.535167694091797 ms
+                                  - value: 11.535167694091797
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 0.5369186401367188 ms
+                            - value: 0.5369186401367188
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.5369186401367188 ms
+                                  - value: 0.5369186401367188
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedSuccess()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 0.476837158203125 ms
+                            - value: 0.476837158203125
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.476837158203125 ms
+                                  - value: 0.476837158203125
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 11.526823043823242 ms
+                            - value: 11.526823043823242
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 11.526823043823242 ms
+                                  - value: 11.526823043823242
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 0.4401206970214844 ms
+                            - value: 0.4401206970214844
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.4401206970214844 ms
+                                  - value: 0.4401206970214844
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+              - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/OuterSuite/InnerSuite"
+              ▿ repeatableTests: 2 members
+                ▿ RepeatableTest
+                  - name: "innerFailure()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 5.836963653564453 ms
+                        - value: 5.836963653564453
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 5.836963653564453 ms
+                              - value: 5.836963653564453
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 11.715888977050781 ms
+                        - value: 11.715888977050781
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 11.715888977050781 ms
+                              - value: 11.715888977050781
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 1.4028549194335938 ms
+                        - value: 1.4028549194335938
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.4028549194335938 ms
+                              - value: 1.4028549194335938
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                ▿ RepeatableTest
+                  - name: "innerSuccess()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 0.5140304565429688 ms
+                        - value: 0.5140304565429688
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.5140304565429688 ms
+                              - value: 0.5140304565429688
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 0.6999969482421875 ms
+                        - value: 0.6999969482421875
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.6999969482421875 ms
+                              - value: 0.6999969482421875
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 1.4009475708007812 ms
+                        - value: 1.4009475708007812
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.4009475708007812 ms
+                              - value: 1.4009475708007812
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/OuterSuite"
           ▿ repeatableTests: 3 members
             ▿ RepeatableTest
@@ -863,7 +1678,9 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "ExampleSUITests"
           - name: "ExampleSUITests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/ExampleSUITests"
           ▿ repeatableTests: 9 members
             ▿ RepeatableTest
@@ -1688,6 +2505,7 @@
               - message: "No calls to throwing functions occur within \'try\' expression"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleFramework.framework"
+      - rootLevelTests: 0 members
       - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
@@ -1855,4 +2673,5 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"
+      - rootLevelTests: 0 members
       - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
@@ -393,9 +393,558 @@
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
           - warnings: 0 elements
       - name: "XcodeprojExample.app"
+      ▿ rootLevelTests: 9 members
+        ▿ RepeatableTest
+          - name: "2 + 3 = 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 0.926971435546875 ms
+                - value: 0.926971435546875
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.926971435546875 ms
+                      - value: 0.926971435546875
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.3790855407714844 ms
+                - value: 0.3790855407714844
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.3790855407714844 ms
+                      - value: 0.3790855407714844
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.39505958557128906 ms
+                - value: 0.39505958557128906
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.39505958557128906 ms
+                      - value: 0.39505958557128906
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "array[0] is nil?"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 1.1649131774902344 ms
+                - value: 1.1649131774902344
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.1649131774902344 ms
+                      - value: 1.1649131774902344
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.7791519165039062 ms
+                - value: 0.7791519165039062
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.7791519165039062 ms
+                      - value: 0.7791519165039062
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.45990943908691406 ms
+                - value: 0.45990943908691406
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.45990943908691406 ms
+                      - value: 0.45990943908691406
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "divide(10, 2) / returns 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 1.1489391326904297 ms
+                - value: 1.1489391326904297
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.1489391326904297 ms
+                      - value: 1.1489391326904297
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.8018016815185547 ms
+                - value: 0.8018016815185547
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.8018016815185547 ms
+                      - value: 0.8018016815185547
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.5338191986083984 ms
+                - value: 0.5338191986083984
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.5338191986083984 ms
+                      - value: 0.5338191986083984
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "root level with spaces in name"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 1.0159015655517578 ms
+                - value: 1.0159015655517578
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.0159015655517578 ms
+                      - value: 1.0159015655517578
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.5929470062255859 ms
+                - value: 0.5929470062255859
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.5929470062255859 ms
+                      - value: 0.5929470062255859
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.9338855743408203 ms
+                - value: 0.9338855743408203
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.9338855743408203 ms
+                      - value: 0.9338855743408203
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelAsync()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 11.485099792480469 ms
+                - value: 11.485099792480469
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.485099792480469 ms
+                      - value: 11.485099792480469
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.503934860229492 ms
+                - value: 11.503934860229492
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.503934860229492 ms
+                      - value: 11.503934860229492
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 11.647224426269531 ms
+                - value: 11.647224426269531
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 11.647224426269531 ms
+                      - value: 11.647224426269531
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelFailure()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 0.6542205810546875 ms
+                - value: 0.6542205810546875
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.6542205810546875 ms
+                      - value: 0.6542205810546875
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 0.6279945373535156 ms
+                - value: 0.6279945373535156
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.6279945373535156 ms
+                      - value: 0.6279945373535156
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 0.3960132598876953 ms
+                - value: 0.3960132598876953
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.3960132598876953 ms
+                      - value: 0.3960132598876953
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+        ▿ RepeatableTest
+          - name: "rootLevelSuccess()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 1.2738704681396484 ms
+                - value: 1.2738704681396484
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.2738704681396484 ms
+                      - value: 1.2738704681396484
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.5340576171875 ms
+                - value: 0.5340576171875
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.5340576171875 ms
+                      - value: 0.5340576171875
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.8289813995361328 ms
+                - value: 0.8289813995361328
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.8289813995361328 ms
+                      - value: 0.8289813995361328
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "success 🎯"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 1.2521743774414062 ms
+                - value: 1.2521743774414062
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.2521743774414062 ms
+                      - value: 1.2521743774414062
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.7550716400146484 ms
+                - value: 0.7550716400146484
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.7550716400146484 ms
+                      - value: 0.7550716400146484
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.9279251098632812 ms
+                - value: 0.9279251098632812
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.9279251098632812 ms
+                      - value: 0.9279251098632812
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "сложение работает"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 1.5919208526611328 ms
+                - value: 1.5919208526611328
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.5919208526611328 ms
+                      - value: 1.5919208526611328
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.6129741668701172 ms
+                - value: 0.6129741668701172
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.6129741668701172 ms
+                      - value: 0.6129741668701172
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.3821849822998047 ms
+                - value: 0.3821849822998047
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.3821849822998047 ms
+                      - value: 0.3821849822998047
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
       ▿ suites: 3 elements
         ▿ Suite
+          - fullPath: "XCTestTests"
           - name: "XCTestTests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/XCTestTests"
           ▿ repeatableTests: 11 members
             ▿ RepeatableTest
@@ -673,7 +1222,9 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "ExampleSUITests"
           - name: "ExampleSUITests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/ExampleSUITests"
           ▿ repeatableTests: 9 members
             ▿ RepeatableTest
@@ -1345,7 +1896,273 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "OuterSuite"
           - name: "OuterSuite"
+          ▿ nestedSuites: 1 element
+            ▿ Suite
+              - fullPath: "OuterSuite / InnerSuite"
+              - name: "InnerSuite"
+              ▿ nestedSuites: 1 element
+                ▿ Suite
+                  - fullPath: "OuterSuite / InnerSuite / DeeplyNestedSuite"
+                  - name: "DeeplyNestedSuite"
+                  - nestedSuites: 0 elements
+                  - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/OuterSuite/InnerSuite/DeeplyNestedSuite"
+                  ▿ repeatableTests: 2 members
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedFailure()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 0.6990432739257812 ms
+                            - value: 0.6990432739257812
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.6990432739257812 ms
+                                  - value: 0.6990432739257812
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 0.33211708068847656 ms
+                            - value: 0.33211708068847656
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.33211708068847656 ms
+                                  - value: 0.33211708068847656
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 0.32401084899902344 ms
+                            - value: 0.32401084899902344
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.32401084899902344 ms
+                                  - value: 0.32401084899902344
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedSuccess()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 0.7460117340087891 ms
+                            - value: 0.7460117340087891
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.7460117340087891 ms
+                                  - value: 0.7460117340087891
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 0.3418922424316406 ms
+                            - value: 0.3418922424316406
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.3418922424316406 ms
+                                  - value: 0.3418922424316406
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 0.34999847412109375 ms
+                            - value: 0.34999847412109375
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.34999847412109375 ms
+                                  - value: 0.34999847412109375
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+              - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/OuterSuite/InnerSuite"
+              ▿ repeatableTests: 2 members
+                ▿ RepeatableTest
+                  - name: "innerFailure()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 0.86212158203125 ms
+                        - value: 0.86212158203125
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.86212158203125 ms
+                              - value: 0.86212158203125
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 0.5719661712646484 ms
+                        - value: 0.5719661712646484
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.5719661712646484 ms
+                              - value: 0.5719661712646484
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 0.6880760192871094 ms
+                        - value: 0.6880760192871094
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.6880760192871094 ms
+                              - value: 0.6880760192871094
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                ▿ RepeatableTest
+                  - name: "innerSuccess()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 0.7979869842529297 ms
+                        - value: 0.7979869842529297
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.7979869842529297 ms
+                              - value: 0.7979869842529297
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 0.5369186401367188 ms
+                        - value: 0.5369186401367188
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.5369186401367188 ms
+                              - value: 0.5369186401367188
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 0.8728504180908203 ms
+                        - value: 0.8728504180908203
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 0.8728504180908203 ms
+                              - value: 0.8728504180908203
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/OuterSuite"
           ▿ repeatableTests: 3 members
             ▿ RepeatableTest
@@ -1688,6 +2505,7 @@
               - message: "No calls to throwing functions occur within \'try\' expression"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleFramework.framework"
+      - rootLevelTests: 0 members
       - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
@@ -1855,4 +2673,5 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"
+      - rootLevelTests: 0 members
       - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
@@ -393,9 +393,558 @@
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
           - warnings: 0 elements
       - name: "XcodeprojExample.app"
+      ▿ rootLevelTests: 9 members
+        ▿ RepeatableTest
+          - name: "2 + 3 = 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 14.372110366821289 ms
+                - value: 14.372110366821289
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 14.372110366821289 ms
+                      - value: 14.372110366821289
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 4.546880722045898 ms
+                - value: 4.546880722045898
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.546880722045898 ms
+                      - value: 4.546880722045898
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.7119178771972656 ms
+                - value: 0.7119178771972656
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "2 + 3 = 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.7119178771972656 ms
+                      - value: 0.7119178771972656
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "array[0] is nil?"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 14.128923416137695 ms
+                - value: 14.128923416137695
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 14.128923416137695 ms
+                      - value: 14.128923416137695
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 3.851175308227539 ms
+                - value: 3.851175308227539
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.851175308227539 ms
+                      - value: 3.851175308227539
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 52.51502990722656 ms
+                - value: 52.51502990722656
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "array[0] is nil?"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 52.51502990722656 ms
+                      - value: 52.51502990722656
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "divide(10, 2) / returns 5"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 17.763137817382812 ms
+                - value: 17.763137817382812
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 17.763137817382812 ms
+                      - value: 17.763137817382812
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 4.50897216796875 ms
+                - value: 4.50897216796875
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.50897216796875 ms
+                      - value: 4.50897216796875
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 0.6570816040039062 ms
+                - value: 0.6570816040039062
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "divide(10, 2) / returns 5"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 0.6570816040039062 ms
+                      - value: 0.6570816040039062
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "root level with spaces in name"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 14.347076416015625 ms
+                - value: 14.347076416015625
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 14.347076416015625 ms
+                      - value: 14.347076416015625
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 3.957033157348633 ms
+                - value: 3.957033157348633
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 3.957033157348633 ms
+                      - value: 3.957033157348633
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 52.616119384765625 ms
+                - value: 52.616119384765625
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "root level with spaces in name"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 52.616119384765625 ms
+                      - value: 52.616119384765625
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelAsync()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 23.38409423828125 ms
+                - value: 23.38409423828125
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 23.38409423828125 ms
+                      - value: 23.38409423828125
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 15.09714126586914 ms
+                - value: 15.09714126586914
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 15.09714126586914 ms
+                      - value: 15.09714126586914
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 63.794851303100586 ms
+                - value: 63.794851303100586
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelAsync()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 63.794851303100586 ms
+                      - value: 63.794851303100586
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "rootLevelFailure()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 23.44489097595215 ms
+                - value: 23.44489097595215
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 23.44489097595215 ms
+                      - value: 23.44489097595215
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 4.179954528808594 ms
+                - value: 4.179954528808594
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.179954528808594 ms
+                      - value: 4.179954528808594
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+            ▿ Test
+              ▿ duration: 53.4520149230957 ms
+                - value: 53.4520149230957
+                - unit: "ms"
+              ▿ failureMessage: Optional<String>
+                - some: "Expected 5.0 but got 6.0"
+              - name: "rootLevelFailure()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 53.4520149230957 ms
+                      - value: 53.4520149230957
+                      - unit: "ms"
+                  ▿ message: Optional<String>
+                    - some: "Expected 5.0 but got 6.0"
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.failure
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.failure
+        ▿ RepeatableTest
+          - name: "rootLevelSuccess()"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 14.204025268554688 ms
+                - value: 14.204025268554688
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 14.204025268554688 ms
+                      - value: 14.204025268554688
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 4.582881927490234 ms
+                - value: 4.582881927490234
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.582881927490234 ms
+                      - value: 4.582881927490234
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 52.697181701660156 ms
+                - value: 52.697181701660156
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "rootLevelSuccess()"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 52.697181701660156 ms
+                      - value: 52.697181701660156
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "success 🎯"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 13.852119445800781 ms
+                - value: 13.852119445800781
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 13.852119445800781 ms
+                      - value: 13.852119445800781
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 4.188060760498047 ms
+                - value: 4.188060760498047
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 4.188060760498047 ms
+                      - value: 4.188060760498047
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 53.967952728271484 ms
+                - value: 53.967952728271484
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "success 🎯"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 53.967952728271484 ms
+                      - value: 53.967952728271484
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+        ▿ RepeatableTest
+          - name: "сложение работает"
+          ▿ tests: 3 elements
+            ▿ Test
+              ▿ duration: 17.46988296508789 ms
+                - value: 17.46988296508789
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 17.46988296508789 ms
+                      - value: 17.46988296508789
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "First Run"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 1.2209415435791016 ms
+                - value: 1.2209415435791016
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 1.2209415435791016 ms
+                      - value: 1.2209415435791016
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 1"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
+            ▿ Test
+              ▿ duration: 53.23910713195801 ms
+                - value: 53.23910713195801
+                - unit: "ms"
+              - failureMessage: Optional<String>.none
+              - name: "сложение работает"
+              ▿ path: 1 element
+                ▿ PathNode
+                  ▿ duration: Optional<Measurement<NSUnitDuration>>
+                    ▿ some: 53.23910713195801 ms
+                      - value: 53.23910713195801
+                      - unit: "ms"
+                  - message: Optional<String>.none
+                  - name: "Retry 2"
+                  ▿ result: Optional<Status>
+                    - some: Status.success
+                  - type: NodeType.repetition
+              - skipMessage: Optional<String>.none
+              - status: Status.success
       ▿ suites: 3 elements
         ▿ Suite
+          - fullPath: "XCTestTests"
           - name: "XCTestTests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/XCTestTests"
           ▿ repeatableTests: 11 members
             ▿ RepeatableTest
@@ -673,7 +1222,273 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "OuterSuite"
           - name: "OuterSuite"
+          ▿ nestedSuites: 1 element
+            ▿ Suite
+              - fullPath: "OuterSuite / InnerSuite"
+              - name: "InnerSuite"
+              ▿ nestedSuites: 1 element
+                ▿ Suite
+                  - fullPath: "OuterSuite / InnerSuite / DeeplyNestedSuite"
+                  - name: "DeeplyNestedSuite"
+                  - nestedSuites: 0 elements
+                  - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/OuterSuite/InnerSuite/DeeplyNestedSuite"
+                  ▿ repeatableTests: 2 members
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedFailure()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 5.642175674438477 ms
+                            - value: 5.642175674438477
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 5.642175674438477 ms
+                                  - value: 5.642175674438477
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 0.6990432739257812 ms
+                            - value: 0.6990432739257812
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.6990432739257812 ms
+                                  - value: 0.6990432739257812
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                        ▿ Test
+                          ▿ duration: 1.8551349639892578 ms
+                            - value: 1.8551349639892578
+                            - unit: "ms"
+                          ▿ failureMessage: Optional<String>
+                            - some: "Deeply nested failure: result was 0.0"
+                          - name: "deeplyNestedFailure()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.8551349639892578 ms
+                                  - value: 1.8551349639892578
+                                  - unit: "ms"
+                              ▿ message: Optional<String>
+                                - some: "Deeply nested failure: result was 0.0"
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.failure
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.failure
+                    ▿ RepeatableTest
+                      - name: "deeplyNestedSuccess()"
+                      ▿ tests: 3 elements
+                        ▿ Test
+                          ▿ duration: 2.3717880249023438 ms
+                            - value: 2.3717880249023438
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 2.3717880249023438 ms
+                                  - value: 2.3717880249023438
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "First Run"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 0.3399848937988281 ms
+                            - value: 0.3399848937988281
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 0.3399848937988281 ms
+                                  - value: 0.3399848937988281
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 1"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+                        ▿ Test
+                          ▿ duration: 1.8138885498046875 ms
+                            - value: 1.8138885498046875
+                            - unit: "ms"
+                          - failureMessage: Optional<String>.none
+                          - name: "deeplyNestedSuccess()"
+                          ▿ path: 1 element
+                            ▿ PathNode
+                              ▿ duration: Optional<Measurement<NSUnitDuration>>
+                                ▿ some: 1.8138885498046875 ms
+                                  - value: 1.8138885498046875
+                                  - unit: "ms"
+                              - message: Optional<String>.none
+                              - name: "Retry 2"
+                              ▿ result: Optional<Status>
+                                - some: Status.success
+                              - type: NodeType.repetition
+                          - skipMessage: Optional<String>.none
+                          - status: Status.success
+              - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/OuterSuite/InnerSuite"
+              ▿ repeatableTests: 2 members
+                ▿ RepeatableTest
+                  - name: "innerFailure()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 13.020038604736328 ms
+                        - value: 13.020038604736328
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 13.020038604736328 ms
+                              - value: 13.020038604736328
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 1.0519027709960938 ms
+                        - value: 1.0519027709960938
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.0519027709960938 ms
+                              - value: 1.0519027709960938
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                    ▿ Test
+                      ▿ duration: 53.466081619262695 ms
+                        - value: 53.466081619262695
+                        - unit: "ms"
+                      ▿ failureMessage: Optional<String>
+                        - some: "Inner suite failure: result was 12.0"
+                      - name: "innerFailure()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 53.466081619262695 ms
+                              - value: 53.466081619262695
+                              - unit: "ms"
+                          ▿ message: Optional<String>
+                            - some: "Inner suite failure: result was 12.0"
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.failure
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.failure
+                ▿ RepeatableTest
+                  - name: "innerSuccess()"
+                  ▿ tests: 3 elements
+                    ▿ Test
+                      ▿ duration: 6.487846374511719 ms
+                        - value: 6.487846374511719
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 6.487846374511719 ms
+                              - value: 6.487846374511719
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "First Run"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 1.071929931640625 ms
+                        - value: 1.071929931640625
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 1.071929931640625 ms
+                              - value: 1.071929931640625
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 1"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
+                    ▿ Test
+                      ▿ duration: 53.45296859741211 ms
+                        - value: 53.45296859741211
+                        - unit: "ms"
+                      - failureMessage: Optional<String>.none
+                      - name: "innerSuccess()"
+                      ▿ path: 1 element
+                        ▿ PathNode
+                          ▿ duration: Optional<Measurement<NSUnitDuration>>
+                            ▿ some: 53.45296859741211 ms
+                              - value: 53.45296859741211
+                              - unit: "ms"
+                          - message: Optional<String>.none
+                          - name: "Retry 2"
+                          ▿ result: Optional<Status>
+                            - some: Status.success
+                          - type: NodeType.repetition
+                      - skipMessage: Optional<String>.none
+                      - status: Status.success
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/OuterSuite"
           ▿ repeatableTests: 3 members
             ▿ RepeatableTest
@@ -863,7 +1678,9 @@
                   - skipMessage: Optional<String>.none
                   - status: Status.success
         ▿ Suite
+          - fullPath: "ExampleSUITests"
           - name: "ExampleSUITests"
+          - nestedSuites: 0 elements
           - nodeIdentifierURL: "test://com.apple.xcode/XcodeprojExample/XcodeprojExampleTests/ExampleSUITests"
           ▿ repeatableTests: 9 members
             ▿ RepeatableTest
@@ -1688,6 +2505,7 @@
               - message: "No calls to throwing functions occur within \'try\' expression"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleFramework.framework"
+      - rootLevelTests: 0 members
       - suites: 0 elements
     ▿ Module
       ▿ coverage: Optional<Coverage>
@@ -1855,4 +2673,5 @@
               - message: "Some warning from ExampleSUITests"
               - type: IssueType.swiftCompilerWarning
       - name: "XcodeprojExampleTests.xctest"
+      - rootLevelTests: 0 members
       - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-iOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-iOS_sonar.txt
@@ -1,48 +1,60 @@
 <testExecutions version="1">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-iOS/DeeplyNestedSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedFailure()" duration="2">
+            <failure message="Deeply nested failure: result was 0.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedSuccess()" duration="2" />
+    </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-iOS/ExampleSUITests.swift">
-        <testCase name="async()" duration="37" />
-        <testCase name="disabled()" duration="0">
+        <testCase name="ExampleSUITests / async()" duration="37" />
+        <testCase name="ExampleSUITests / disabled()" duration="0">
             <skipped message="Test skipped: Disabled reason" />
         </testCase>
-        <testCase name="expectedFailure()" duration="6" />
-        <testCase name="failure()" duration="18">
+        <testCase name="ExampleSUITests / expectedFailure()" duration="6" />
+        <testCase name="ExampleSUITests / failure()" duration="18">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="flacky()" duration="7" />
-        <testCase name="flackyParameterized(value:) [false]" duration="4">
+        <testCase name="ExampleSUITests / flacky()" duration="7" />
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [false]" duration="4">
             <failure message="SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0" />
         </testCase>
-        <testCase name="flackyParameterized(value:) [true]" duration="0" />
-        <testCase name="success()" duration="6" />
-        <testCase name="throwing()" duration="11">
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [true]" duration="0" />
+        <testCase name="ExampleSUITests / success()" duration="6" />
+        <testCase name="ExampleSUITests / throwing()" duration="11">
             <failure message="Calculator.swift:26: Caught error: .divisionByZero" />
         </testCase>
-        <testCase name="withAttachment()" duration="4" />
+        <testCase name="ExampleSUITests / withAttachment()" duration="4" />
+    </file>
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-iOS/InnerSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / innerFailure()" duration="4">
+            <failure message="Inner suite failure: result was 12.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / innerSuccess()" duration="5" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-iOS/OuterSuite.swift">
-        <testCase name="outer with spaces in name" duration="4" />
-        <testCase name="outerFailure()" duration="8">
+        <testCase name="OuterSuite / outer with spaces in name" duration="4" />
+        <testCase name="OuterSuite / outerFailure()" duration="8">
             <failure message="Outer suite failure: result was 200.0" />
         </testCase>
-        <testCase name="outerSuccess()" duration="5" />
+        <testCase name="OuterSuite / outerSuccess()" duration="5" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-iOS/XCTestTests.swift">
-        <testCase name="test_async()" duration="13" />
-        <testCase name="test_asyncWithExpectation()" duration="14" />
-        <testCase name="test_expectedFailure()" duration="577" />
-        <testCase name="test_failure()" duration="20">
+        <testCase name="XCTestTests / test_async()" duration="13" />
+        <testCase name="XCTestTests / test_asyncWithExpectation()" duration="14" />
+        <testCase name="XCTestTests / test_expectedFailure()" duration="577" />
+        <testCase name="XCTestTests / test_failure()" duration="20">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="test_flacky()" duration="4" />
-        <testCase name="test_performance()" duration="262" />
-        <testCase name="test_skip()" duration="7">
+        <testCase name="XCTestTests / test_flacky()" duration="4" />
+        <testCase name="XCTestTests / test_performance()" duration="262" />
+        <testCase name="XCTestTests / test_skip()" duration="7">
             <skipped message="Skip message" />
         </testCase>
-        <testCase name="test_success()" duration="1" />
-        <testCase name="test_throwing()" duration="10">
+        <testCase name="XCTestTests / test_success()" duration="1" />
+        <testCase name="XCTestTests / test_throwing()" duration="10">
             <failure message="Calculator.swift:26: failed: caught error: &quot;divisionByZero&quot;" />
         </testCase>
-        <testCase name="test_withAttachment()" duration="4" />
-        <testCase name="test_withWarning()" duration="0" />
+        <testCase name="XCTestTests / test_withAttachment()" duration="4" />
+        <testCase name="XCTestTests / test_withWarning()" duration="0" />
     </file>
 </testExecutions>

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-macOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-macOS_sonar.txt
@@ -1,48 +1,60 @@
 <testExecutions version="1">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-macOS/DeeplyNestedSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedFailure()" duration="30">
+            <failure message="Deeply nested failure: result was 0.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedSuccess()" duration="30" />
+    </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-macOS/ExampleSUITests.swift">
-        <testCase name="async()" duration="56" />
-        <testCase name="disabled()" duration="15">
+        <testCase name="ExampleSUITests / async()" duration="56" />
+        <testCase name="ExampleSUITests / disabled()" duration="15">
             <skipped message="Test skipped: Disabled reason" />
         </testCase>
-        <testCase name="expectedFailure()" duration="39" />
-        <testCase name="failure()" duration="35">
+        <testCase name="ExampleSUITests / expectedFailure()" duration="39" />
+        <testCase name="ExampleSUITests / failure()" duration="35">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="flacky()" duration="35" />
-        <testCase name="flackyParameterized(value:) [false]" duration="5">
+        <testCase name="ExampleSUITests / flacky()" duration="35" />
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [false]" duration="5">
             <failure message="SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0" />
         </testCase>
-        <testCase name="flackyParameterized(value:) [true]" duration="0" />
-        <testCase name="success()" duration="35" />
-        <testCase name="throwing()" duration="24">
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [true]" duration="0" />
+        <testCase name="ExampleSUITests / success()" duration="35" />
+        <testCase name="ExampleSUITests / throwing()" duration="24">
             <failure message="Calculator.swift:26: Caught error: .divisionByZero" />
         </testCase>
-        <testCase name="withAttachment()" duration="35" />
+        <testCase name="ExampleSUITests / withAttachment()" duration="35" />
+    </file>
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-macOS/InnerSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / innerFailure()" duration="30">
+            <failure message="Inner suite failure: result was 12.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / innerSuccess()" duration="30" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-macOS/OuterSuite.swift">
-        <testCase name="outer with spaces in name" duration="30" />
-        <testCase name="outerFailure()" duration="45">
+        <testCase name="OuterSuite / outer with spaces in name" duration="30" />
+        <testCase name="OuterSuite / outerFailure()" duration="45">
             <failure message="Outer suite failure: result was 200.0" />
         </testCase>
-        <testCase name="outerSuccess()" duration="31" />
+        <testCase name="OuterSuite / outerSuccess()" duration="31" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-macOS/XCTestTests.swift">
-        <testCase name="test_async()" duration="13" />
-        <testCase name="test_asyncWithExpectation()" duration="13" />
-        <testCase name="test_expectedFailure()" duration="363" />
-        <testCase name="test_failure()" duration="2">
+        <testCase name="XCTestTests / test_async()" duration="13" />
+        <testCase name="XCTestTests / test_asyncWithExpectation()" duration="13" />
+        <testCase name="XCTestTests / test_expectedFailure()" duration="363" />
+        <testCase name="XCTestTests / test_failure()" duration="2">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="test_flacky()" duration="1" />
-        <testCase name="test_performance()" duration="256" />
-        <testCase name="test_skip()" duration="1">
+        <testCase name="XCTestTests / test_flacky()" duration="1" />
+        <testCase name="XCTestTests / test_performance()" duration="256" />
+        <testCase name="XCTestTests / test_skip()" duration="1">
             <skipped message="Skip message" />
         </testCase>
-        <testCase name="test_success()" duration="0" />
-        <testCase name="test_throwing()" duration="3">
+        <testCase name="XCTestTests / test_success()" duration="0" />
+        <testCase name="XCTestTests / test_throwing()" duration="3">
             <failure message="Calculator.swift:26: failed: caught error: &quot;divisionByZero&quot;" />
         </testCase>
-        <testCase name="test_withAttachment()" duration="0" />
-        <testCase name="test_withWarning()" duration="0" />
+        <testCase name="XCTestTests / test_withAttachment()" duration="0" />
+        <testCase name="XCTestTests / test_withWarning()" duration="0" />
     </file>
 </testExecutions>

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-tvOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-tvOS_sonar.txt
@@ -1,48 +1,60 @@
 <testExecutions version="1">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-tvOS/DeeplyNestedSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedFailure()" duration="8">
+            <failure message="Deeply nested failure: result was 0.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedSuccess()" duration="1" />
+    </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-tvOS/ExampleSUITests.swift">
-        <testCase name="async()" duration="39" />
-        <testCase name="disabled()" duration="0">
+        <testCase name="ExampleSUITests / async()" duration="39" />
+        <testCase name="ExampleSUITests / disabled()" duration="0">
             <skipped message="Test skipped: Disabled reason" />
         </testCase>
-        <testCase name="expectedFailure()" duration="10" />
-        <testCase name="failure()" duration="9">
+        <testCase name="ExampleSUITests / expectedFailure()" duration="10" />
+        <testCase name="ExampleSUITests / failure()" duration="9">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="flacky()" duration="9" />
-        <testCase name="flackyParameterized(value:) [false]" duration="8">
+        <testCase name="ExampleSUITests / flacky()" duration="9" />
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [false]" duration="8">
             <failure message="SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0" />
         </testCase>
-        <testCase name="flackyParameterized(value:) [true]" duration="1" />
-        <testCase name="success()" duration="9" />
-        <testCase name="throwing()" duration="10">
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [true]" duration="1" />
+        <testCase name="ExampleSUITests / success()" duration="9" />
+        <testCase name="ExampleSUITests / throwing()" duration="10">
             <failure message="Calculator.swift:26: Caught error: .divisionByZero" />
         </testCase>
-        <testCase name="withAttachment()" duration="9" />
+        <testCase name="ExampleSUITests / withAttachment()" duration="9" />
+    </file>
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-tvOS/InnerSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / innerFailure()" duration="9">
+            <failure message="Inner suite failure: result was 12.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / innerSuccess()" duration="9" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-tvOS/OuterSuite.swift">
-        <testCase name="outer with spaces in name" duration="7" />
-        <testCase name="outerFailure()" duration="10">
+        <testCase name="OuterSuite / outer with spaces in name" duration="7" />
+        <testCase name="OuterSuite / outerFailure()" duration="10">
             <failure message="Outer suite failure: result was 200.0" />
         </testCase>
-        <testCase name="outerSuccess()" duration="8" />
+        <testCase name="OuterSuite / outerSuccess()" duration="8" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-tvOS/XCTestTests.swift">
-        <testCase name="test_async()" duration="12" />
-        <testCase name="test_asyncWithExpectation()" duration="12" />
-        <testCase name="test_expectedFailure()" duration="404" />
-        <testCase name="test_failure()" duration="5">
+        <testCase name="XCTestTests / test_async()" duration="12" />
+        <testCase name="XCTestTests / test_asyncWithExpectation()" duration="12" />
+        <testCase name="XCTestTests / test_expectedFailure()" duration="404" />
+        <testCase name="XCTestTests / test_failure()" duration="5">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="test_flacky()" duration="2" />
-        <testCase name="test_performance()" duration="256" />
-        <testCase name="test_skip()" duration="3">
+        <testCase name="XCTestTests / test_flacky()" duration="2" />
+        <testCase name="XCTestTests / test_performance()" duration="256" />
+        <testCase name="XCTestTests / test_skip()" duration="3">
             <skipped message="Skip message" />
         </testCase>
-        <testCase name="test_success()" duration="0" />
-        <testCase name="test_throwing()" duration="3">
+        <testCase name="XCTestTests / test_success()" duration="0" />
+        <testCase name="XCTestTests / test_throwing()" duration="3">
             <failure message="Calculator.swift:26: failed: caught error: &quot;divisionByZero&quot;" />
         </testCase>
-        <testCase name="test_withAttachment()" duration="0" />
-        <testCase name="test_withWarning()" duration="0" />
+        <testCase name="XCTestTests / test_withAttachment()" duration="0" />
+        <testCase name="XCTestTests / test_withWarning()" duration="0" />
     </file>
 </testExecutions>

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-visionOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-visionOS_sonar.txt
@@ -1,48 +1,60 @@
 <testExecutions version="1">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-visionOS/DeeplyNestedSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedFailure()" duration="5">
+            <failure message="Deeply nested failure: result was 0.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedSuccess()" duration="4" />
+    </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-visionOS/ExampleSUITests.swift">
-        <testCase name="async()" duration="38" />
-        <testCase name="disabled()" duration="0">
+        <testCase name="ExampleSUITests / async()" duration="38" />
+        <testCase name="ExampleSUITests / disabled()" duration="0">
             <skipped message="Test skipped: Disabled reason" />
         </testCase>
-        <testCase name="expectedFailure()" duration="10" />
-        <testCase name="failure()" duration="7">
+        <testCase name="ExampleSUITests / expectedFailure()" duration="10" />
+        <testCase name="ExampleSUITests / failure()" duration="7">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="flacky()" duration="10" />
-        <testCase name="flackyParameterized(value:) [false]" duration="4">
+        <testCase name="ExampleSUITests / flacky()" duration="10" />
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [false]" duration="4">
             <failure message="SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0" />
         </testCase>
-        <testCase name="flackyParameterized(value:) [true]" duration="1" />
-        <testCase name="success()" duration="11" />
-        <testCase name="throwing()" duration="10">
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [true]" duration="1" />
+        <testCase name="ExampleSUITests / success()" duration="11" />
+        <testCase name="ExampleSUITests / throwing()" duration="10">
             <failure message="Calculator.swift:26: Caught error: .divisionByZero" />
         </testCase>
-        <testCase name="withAttachment()" duration="10" />
+        <testCase name="ExampleSUITests / withAttachment()" duration="10" />
+    </file>
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-visionOS/InnerSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / innerFailure()" duration="11">
+            <failure message="Inner suite failure: result was 12.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / innerSuccess()" duration="13" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-visionOS/OuterSuite.swift">
-        <testCase name="outer with spaces in name" duration="12" />
-        <testCase name="outerFailure()" duration="9">
+        <testCase name="OuterSuite / outer with spaces in name" duration="12" />
+        <testCase name="OuterSuite / outerFailure()" duration="9">
             <failure message="Outer suite failure: result was 200.0" />
         </testCase>
-        <testCase name="outerSuccess()" duration="7" />
+        <testCase name="OuterSuite / outerSuccess()" duration="7" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-visionOS/XCTestTests.swift">
-        <testCase name="test_async()" duration="12" />
-        <testCase name="test_asyncWithExpectation()" duration="14" />
-        <testCase name="test_expectedFailure()" duration="459" />
-        <testCase name="test_failure()" duration="4">
+        <testCase name="XCTestTests / test_async()" duration="12" />
+        <testCase name="XCTestTests / test_asyncWithExpectation()" duration="14" />
+        <testCase name="XCTestTests / test_expectedFailure()" duration="459" />
+        <testCase name="XCTestTests / test_failure()" duration="4">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="test_flacky()" duration="4" />
-        <testCase name="test_performance()" duration="257" />
-        <testCase name="test_skip()" duration="11">
+        <testCase name="XCTestTests / test_flacky()" duration="4" />
+        <testCase name="XCTestTests / test_performance()" duration="257" />
+        <testCase name="XCTestTests / test_skip()" duration="11">
             <skipped message="Skip message" />
         </testCase>
-        <testCase name="test_success()" duration="1" />
-        <testCase name="test_throwing()" duration="8">
+        <testCase name="XCTestTests / test_success()" duration="1" />
+        <testCase name="XCTestTests / test_throwing()" duration="8">
             <failure message="Calculator.swift:26: failed: caught error: &quot;divisionByZero&quot;" />
         </testCase>
-        <testCase name="test_withAttachment()" duration="5" />
-        <testCase name="test_withWarning()" duration="0" />
+        <testCase name="XCTestTests / test_withAttachment()" duration="5" />
+        <testCase name="XCTestTests / test_withWarning()" duration="0" />
     </file>
 </testExecutions>

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-watchOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.SPM-watchOS_sonar.txt
@@ -1,48 +1,60 @@
 <testExecutions version="1">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-watchOS/DeeplyNestedSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedFailure()" duration="3">
+            <failure message="Deeply nested failure: result was 0.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedSuccess()" duration="4" />
+    </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-watchOS/ExampleSUITests.swift">
-        <testCase name="async()" duration="47" />
-        <testCase name="disabled()" duration="2">
+        <testCase name="ExampleSUITests / async()" duration="47" />
+        <testCase name="ExampleSUITests / disabled()" duration="2">
             <skipped message="Test skipped: Disabled reason" />
         </testCase>
-        <testCase name="expectedFailure()" duration="20" />
-        <testCase name="failure()" duration="18">
+        <testCase name="ExampleSUITests / expectedFailure()" duration="20" />
+        <testCase name="ExampleSUITests / failure()" duration="18">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="flacky()" duration="20" />
-        <testCase name="flackyParameterized(value:) [false]" duration="1">
+        <testCase name="ExampleSUITests / flacky()" duration="20" />
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [false]" duration="1">
             <failure message="SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0" />
         </testCase>
-        <testCase name="flackyParameterized(value:) [true]" duration="1" />
-        <testCase name="success()" duration="10" />
-        <testCase name="throwing()" duration="22">
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [true]" duration="1" />
+        <testCase name="ExampleSUITests / success()" duration="10" />
+        <testCase name="ExampleSUITests / throwing()" duration="22">
             <failure message="Calculator.swift:26: Caught error: .divisionByZero" />
         </testCase>
-        <testCase name="withAttachment()" duration="19" />
+        <testCase name="ExampleSUITests / withAttachment()" duration="19" />
+    </file>
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-watchOS/InnerSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / innerFailure()" duration="7">
+            <failure message="Inner suite failure: result was 12.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / innerSuccess()" duration="8" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-watchOS/OuterSuite.swift">
-        <testCase name="outer with spaces in name" duration="10" />
-        <testCase name="outerFailure()" duration="20">
+        <testCase name="OuterSuite / outer with spaces in name" duration="10" />
+        <testCase name="OuterSuite / outerFailure()" duration="20">
             <failure message="Outer suite failure: result was 200.0" />
         </testCase>
-        <testCase name="outerSuccess()" duration="10" />
+        <testCase name="OuterSuite / outerSuccess()" duration="10" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-SPM-watchOS/XCTestTests.swift">
-        <testCase name="test_async()" duration="13" />
-        <testCase name="test_asyncWithExpectation()" duration="12" />
-        <testCase name="test_expectedFailure()" duration="1783" />
-        <testCase name="test_failure()" duration="8">
+        <testCase name="XCTestTests / test_async()" duration="13" />
+        <testCase name="XCTestTests / test_asyncWithExpectation()" duration="12" />
+        <testCase name="XCTestTests / test_expectedFailure()" duration="1783" />
+        <testCase name="XCTestTests / test_failure()" duration="8">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="test_flacky()" duration="1" />
-        <testCase name="test_performance()" duration="257" />
-        <testCase name="test_skip()" duration="3">
+        <testCase name="XCTestTests / test_flacky()" duration="1" />
+        <testCase name="XCTestTests / test_performance()" duration="257" />
+        <testCase name="XCTestTests / test_skip()" duration="3">
             <skipped message="Skip message" />
         </testCase>
-        <testCase name="test_success()" duration="0" />
-        <testCase name="test_throwing()" duration="4">
+        <testCase name="XCTestTests / test_success()" duration="0" />
+        <testCase name="XCTestTests / test_throwing()" duration="4">
             <failure message="Calculator.swift:26: failed: caught error: &quot;divisionByZero&quot;" />
         </testCase>
-        <testCase name="test_withAttachment()" duration="0" />
-        <testCase name="test_withWarning()" duration="0" />
+        <testCase name="XCTestTests / test_withAttachment()" duration="0" />
+        <testCase name="XCTestTests / test_withWarning()" duration="0" />
     </file>
 </testExecutions>

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-iOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-iOS_sonar.txt
@@ -1,48 +1,60 @@
 <testExecutions version="1">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-iOS/DeeplyNestedSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedFailure()" duration="17">
+            <failure message="Deeply nested failure: result was 0.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedSuccess()" duration="12" />
+    </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-iOS/ExampleSUITests.swift">
-        <testCase name="async()" duration="187" />
-        <testCase name="disabled()" duration="3">
+        <testCase name="ExampleSUITests / async()" duration="187" />
+        <testCase name="ExampleSUITests / disabled()" duration="3">
             <skipped message="Test skipped: Disabled reason" />
         </testCase>
-        <testCase name="expectedFailure()" duration="132" />
-        <testCase name="failure()" duration="134">
+        <testCase name="ExampleSUITests / expectedFailure()" duration="132" />
+        <testCase name="ExampleSUITests / failure()" duration="134">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="flacky()" duration="132" />
-        <testCase name="flackyParameterized(value:) [false]" duration="3">
+        <testCase name="ExampleSUITests / flacky()" duration="132" />
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [false]" duration="3">
             <failure message="SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0" />
         </testCase>
-        <testCase name="flackyParameterized(value:) [true]" duration="1" />
-        <testCase name="success()" duration="133" />
-        <testCase name="throwing()" duration="134">
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [true]" duration="1" />
+        <testCase name="ExampleSUITests / success()" duration="133" />
+        <testCase name="ExampleSUITests / throwing()" duration="134">
             <failure message="SwiftTestingTests.swift:85: Caught error: .divisionByZero" />
         </testCase>
-        <testCase name="withAttachment()" duration="132" />
+        <testCase name="ExampleSUITests / withAttachment()" duration="132" />
+    </file>
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-iOS/InnerSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / innerFailure()" duration="18">
+            <failure message="Inner suite failure: result was 12.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / innerSuccess()" duration="2" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-iOS/OuterSuite.swift">
-        <testCase name="outer with spaces in name" duration="133" />
-        <testCase name="outerFailure()" duration="132">
+        <testCase name="OuterSuite / outer with spaces in name" duration="133" />
+        <testCase name="OuterSuite / outerFailure()" duration="132">
             <failure message="Outer suite failure: result was 200.0" />
         </testCase>
-        <testCase name="outerSuccess()" duration="131" />
+        <testCase name="OuterSuite / outerSuccess()" duration="131" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-iOS/XCTestTests.swift">
-        <testCase name="test_async()" duration="12" />
-        <testCase name="test_asyncWithExpectation()" duration="19" />
-        <testCase name="test_expectedFailure()" duration="303" />
-        <testCase name="test_failure()" duration="1544">
+        <testCase name="XCTestTests / test_async()" duration="12" />
+        <testCase name="XCTestTests / test_asyncWithExpectation()" duration="19" />
+        <testCase name="XCTestTests / test_expectedFailure()" duration="303" />
+        <testCase name="XCTestTests / test_failure()" duration="1544">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="test_flacky()" duration="1" />
-        <testCase name="test_performance()" duration="253" />
-        <testCase name="test_skip()" duration="5">
+        <testCase name="XCTestTests / test_flacky()" duration="1" />
+        <testCase name="XCTestTests / test_performance()" duration="253" />
+        <testCase name="XCTestTests / test_skip()" duration="5">
             <skipped message="Skip message" />
         </testCase>
-        <testCase name="test_success()" duration="0" />
-        <testCase name="test_throwing()" duration="4">
+        <testCase name="XCTestTests / test_success()" duration="0" />
+        <testCase name="XCTestTests / test_throwing()" duration="4">
             <failure message="XCTestTests.swift:77: failed: caught error: &quot;divisionByZero&quot;" />
         </testCase>
-        <testCase name="test_withAttachment()" duration="0" />
-        <testCase name="test_withWarning()" duration="0" />
+        <testCase name="XCTestTests / test_withAttachment()" duration="0" />
+        <testCase name="XCTestTests / test_withWarning()" duration="0" />
     </file>
 </testExecutions>

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-macOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-macOS_sonar.txt
@@ -1,48 +1,60 @@
 <testExecutions version="1">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-macOS/DeeplyNestedSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedFailure()" duration="1">
+            <failure message="Deeply nested failure: result was 0.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedSuccess()" duration="1" />
+    </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-macOS/ExampleSUITests.swift">
-        <testCase name="async()" duration="33" />
-        <testCase name="disabled()" duration="0">
+        <testCase name="ExampleSUITests / async()" duration="33" />
+        <testCase name="ExampleSUITests / disabled()" duration="0">
             <skipped message="Test skipped: Disabled reason" />
         </testCase>
-        <testCase name="expectedFailure()" duration="2" />
-        <testCase name="failure()" duration="2">
+        <testCase name="ExampleSUITests / expectedFailure()" duration="2" />
+        <testCase name="ExampleSUITests / failure()" duration="2">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="flacky()" duration="2" />
-        <testCase name="flackyParameterized(value:) [false]" duration="1">
+        <testCase name="ExampleSUITests / flacky()" duration="2" />
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [false]" duration="1">
             <failure message="SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0" />
         </testCase>
-        <testCase name="flackyParameterized(value:) [true]" duration="0" />
-        <testCase name="success()" duration="2" />
-        <testCase name="throwing()" duration="3">
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [true]" duration="0" />
+        <testCase name="ExampleSUITests / success()" duration="2" />
+        <testCase name="ExampleSUITests / throwing()" duration="3">
             <failure message="SwiftTestingTests.swift:85: Caught error: .divisionByZero" />
         </testCase>
-        <testCase name="withAttachment()" duration="2" />
+        <testCase name="ExampleSUITests / withAttachment()" duration="2" />
+    </file>
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-macOS/InnerSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / innerFailure()" duration="2">
+            <failure message="Inner suite failure: result was 12.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / innerSuccess()" duration="2" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-macOS/OuterSuite.swift">
-        <testCase name="outer with spaces in name" duration="2" />
-        <testCase name="outerFailure()" duration="2">
+        <testCase name="OuterSuite / outer with spaces in name" duration="2" />
+        <testCase name="OuterSuite / outerFailure()" duration="2">
             <failure message="Outer suite failure: result was 200.0" />
         </testCase>
-        <testCase name="outerSuccess()" duration="2" />
+        <testCase name="OuterSuite / outerSuccess()" duration="2" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-macOS/XCTestTests.swift">
-        <testCase name="test_async()" duration="12" />
-        <testCase name="test_asyncWithExpectation()" duration="11" />
-        <testCase name="test_expectedFailure()" duration="44" />
-        <testCase name="test_failure()" duration="2">
+        <testCase name="XCTestTests / test_async()" duration="12" />
+        <testCase name="XCTestTests / test_asyncWithExpectation()" duration="11" />
+        <testCase name="XCTestTests / test_expectedFailure()" duration="44" />
+        <testCase name="XCTestTests / test_failure()" duration="2">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="test_flacky()" duration="2" />
-        <testCase name="test_performance()" duration="256" />
-        <testCase name="test_skip()" duration="2">
+        <testCase name="XCTestTests / test_flacky()" duration="2" />
+        <testCase name="XCTestTests / test_performance()" duration="256" />
+        <testCase name="XCTestTests / test_skip()" duration="2">
             <skipped message="Skip message" />
         </testCase>
-        <testCase name="test_success()" duration="0" />
-        <testCase name="test_throwing()" duration="9">
+        <testCase name="XCTestTests / test_success()" duration="0" />
+        <testCase name="XCTestTests / test_throwing()" duration="9">
             <failure message="XCTestTests.swift:77: failed: caught error: &quot;divisionByZero&quot;" />
         </testCase>
-        <testCase name="test_withAttachment()" duration="1" />
-        <testCase name="test_withWarning()" duration="33" />
+        <testCase name="XCTestTests / test_withAttachment()" duration="1" />
+        <testCase name="XCTestTests / test_withWarning()" duration="33" />
     </file>
 </testExecutions>

--- a/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-visionOS_sonar.txt
+++ b/Tests/PeekieTests/__Snapshots__/SonarFormatterSnapshotTests/sonarFormat_allStatuses-_.Xcworkspace-visionOS_sonar.txt
@@ -1,48 +1,60 @@
 <testExecutions version="1">
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-visionOS/DeeplyNestedSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedFailure()" duration="8">
+            <failure message="Deeply nested failure: result was 0.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / DeeplyNestedSuite / deeplyNestedSuccess()" duration="4" />
+    </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-visionOS/ExampleSUITests.swift">
-        <testCase name="async()" duration="94" />
-        <testCase name="disabled()" duration="1">
+        <testCase name="ExampleSUITests / async()" duration="94" />
+        <testCase name="ExampleSUITests / disabled()" duration="1">
             <skipped message="Test skipped: Disabled reason" />
         </testCase>
-        <testCase name="expectedFailure()" duration="69" />
-        <testCase name="failure()" duration="68">
+        <testCase name="ExampleSUITests / expectedFailure()" duration="69" />
+        <testCase name="ExampleSUITests / failure()" duration="68">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="flacky()" duration="68" />
-        <testCase name="flackyParameterized(value:) [false]" duration="9">
+        <testCase name="ExampleSUITests / flacky()" duration="68" />
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [false]" duration="9">
             <failure message="SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0" />
         </testCase>
-        <testCase name="flackyParameterized(value:) [true]" duration="6" />
-        <testCase name="success()" duration="58" />
-        <testCase name="throwing()" duration="69">
+        <testCase name="ExampleSUITests / flackyParameterized(value:) [true]" duration="6" />
+        <testCase name="ExampleSUITests / success()" duration="58" />
+        <testCase name="ExampleSUITests / throwing()" duration="69">
             <failure message="SwiftTestingTests.swift:85: Caught error: .divisionByZero" />
         </testCase>
-        <testCase name="withAttachment()" duration="62" />
+        <testCase name="ExampleSUITests / withAttachment()" duration="62" />
+    </file>
+    <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-visionOS/InnerSuite.swift">
+        <testCase name="OuterSuite / InnerSuite / innerFailure()" duration="67">
+            <failure message="Inner suite failure: result was 12.0" />
+        </testCase>
+        <testCase name="OuterSuite / InnerSuite / innerSuccess()" duration="61" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-visionOS/OuterSuite.swift">
-        <testCase name="outer with spaces in name" duration="62" />
-        <testCase name="outerFailure()" duration="66">
+        <testCase name="OuterSuite / outer with spaces in name" duration="62" />
+        <testCase name="OuterSuite / outerFailure()" duration="66">
             <failure message="Outer suite failure: result was 200.0" />
         </testCase>
-        <testCase name="outerSuccess()" duration="63" />
+        <testCase name="OuterSuite / outerSuccess()" duration="63" />
     </file>
     <file path="{TEMP_DIR}/sonarFormat_allStatuses(_:)-Xcworkspace-visionOS/XCTestTests.swift">
-        <testCase name="test_async()" duration="14" />
-        <testCase name="test_asyncWithExpectation()" duration="11" />
-        <testCase name="test_expectedFailure()" duration="699" />
-        <testCase name="test_failure()" duration="1373">
+        <testCase name="XCTestTests / test_async()" duration="14" />
+        <testCase name="XCTestTests / test_asyncWithExpectation()" duration="11" />
+        <testCase name="XCTestTests / test_expectedFailure()" duration="699" />
+        <testCase name="XCTestTests / test_failure()" duration="1373">
             <failure message="Expected 5.0 but got 6.0" />
         </testCase>
-        <testCase name="test_flacky()" duration="4" />
-        <testCase name="test_performance()" duration="294" />
-        <testCase name="test_skip()" duration="51">
+        <testCase name="XCTestTests / test_flacky()" duration="4" />
+        <testCase name="XCTestTests / test_performance()" duration="294" />
+        <testCase name="XCTestTests / test_skip()" duration="51">
             <skipped message="Skip message" />
         </testCase>
-        <testCase name="test_success()" duration="0" />
-        <testCase name="test_throwing()" duration="6">
+        <testCase name="XCTestTests / test_success()" duration="0" />
+        <testCase name="XCTestTests / test_throwing()" duration="6">
             <failure message="XCTestTests.swift:77: failed: caught error: &quot;divisionByZero&quot;" />
         </testCase>
-        <testCase name="test_withAttachment()" duration="3" />
-        <testCase name="test_withWarning()" duration="0" />
+        <testCase name="XCTestTests / test_withAttachment()" duration="3" />
+        <testCase name="XCTestTests / test_withWarning()" duration="0" />
     </file>
 </testExecutions>


### PR DESCRIPTION
## Summary

Adds support for two Swift Testing patterns that Peekie previously ignored:

* **Root-level `@Test`** — free functions declared at file scope, without an enclosing `@Suite` type (closes #127).
* **Nested `@Suite`** — `@Suite` types declared inside other `@Suite` types, arbitrary depth.

Backtick-escaped test names with spaces, punctuation, emoji, Cyrillic, brackets are also exercised in the new fixtures — they already worked at the parser level, now they have snapshot coverage.

## Key Changes

* **Model (`Sources/PeekieSDK/Models/Report.swift`)** — `Module` gains `rootLevelTests: Set<Suite.RepeatableTest>`. `Suite` gains `fullPath: String` (` / `-joined ancestor names, e.g. `OuterSuite / InnerSuite`) and `nestedSuites: [Self]`. `Suite` `Hashable`/`Equatable` switch from `name` to `fullPath` so same-named suites in different parents don't collide.
* **Parser (`Sources/PeekieSDK/Models/Report+Convenience+Suites.swift`)** — walks `Test Case` children of the `Unit test bundle` into `Module.rootLevelTests`; recurses through `Test Suite` children into `Suite.nestedSuites`. Synthesizes a `nodeIdentifierURL` for nested-suite nodes when `xcresulttool` returns `null`.
* **`ListFormatter`** — new public `Grouping` enum:
  * `.bySuite` (default) — section headers `Module / Suite-path` and `Module / (no suite)`, tests under them by name.
  * `.fullyQualified` — flat, one line per test, `<status> Module / [Suite-path /] testName`.
* **`JsonFormatter`** — module JSON adds `rootLevelTests`; each suite gains `fullPath` and `nestedSuites: []` (always present).
* **`SonarFormatter`** — `<testCase name>` uses `fullPath / testName`. Root-level tests are dropped from Sonar XML (no source-file anchor) — documented inline.
* **Test helpers (`Sources/PeekieTestHelpers/Report+TestHelpers.swift`)** — `testMake` overloads default the new fields to empty/`nil` so existing test code keeps compiling.

## Additional Changes

* **Fixtures regenerated** on Xcode 26.5 from updated [`dodobrands/swift-tests-example`](https://github.com/dodobrands/swift-tests-example/pull/3) — all 8 xcresult bundles (5 SPM + 3 Xcworkspace) now include root-level tests, nested suites, and backtick-escaped test names.
* **Snapshots regenerated** for `ReportSnapshotTests`, `ListFormatterSnapshotTests`, `SonarFormatterSnapshotTests` to reflect the new model and parsing.
* `SonarFormatterSnapshotTests.createTestDirectory` walks nested suite trees so mock `.swift` files exist for inner suites — without this fix nested suites would silently drop from the XML snapshot.

Local gate green: `swift test` (54 tests, 17 suites), `swiftformat --lint`, `swiftlint --strict`, `periphery scan --skip-build --strict`.

`IssuesFormatter` not touched (it formats build warnings/errors, not tests).