### PR TITLE
Add CODEOWNERS with @AllDmeat as repo owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AllDmeat


### PR DESCRIPTION
## Summary

Adds a `.github/CODEOWNERS` file that makes @AllDmeat the default required reviewer on every pull request in this repo.

## Key Changes

* **`.github/CODEOWNERS`** — single rule `* @AllDmeat`, so every file path is owned by @AllDmeat. With "Require review from Code Owners" enabled in branch protection, this auto-routes review requests instead of needing them set per-PR.

## Additional Changes

None.