### PR TITLE
Fix peekie attachments --test-id silently dropping into a no-op

### DIFF
--- a/Sources/Peekie/Attachments.swift
+++ b/Sources/Peekie/Attachments.swift
@@ -52,7 +52,7 @@ public struct Attachments: AsyncParsableCommand {
             includeCoverage: false,
             includeWarnings: false,
             includeTests: true,
-            attachments: .extractTo(outputURL)
+            attachments: .extractTo(outputURL, testID: testID)
         )
 
         let formatter = AttachmentsFormatter()

--- a/Sources/PeekieSDK/Models/Report+Convenience.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience.swift
@@ -19,7 +19,13 @@ public enum AttachmentPolicy: Sendable {
 
     /// Export attachments into the supplied directory. Caller owns the directory
     /// lifetime (create + cleanup).
-    case extractTo(URL)
+    ///
+    /// When `testID` is non-nil, `xcresulttool` is invoked with
+    /// `--test-id <id>`, scoping both the manifest and the on-disk file set
+    /// to that single test's attachments. The id is the bare suite-path
+    /// identifier as accepted by `xcresulttool` (e.g.
+    /// `"ExampleSUITests/foo()"`), without the module prefix.
+    case extractTo(URL, testID: String? = nil)
 }
 
 // MARK: - AttachmentLookupKey
@@ -76,14 +82,15 @@ extension Report {
             includeCoverage ? try await CoverageReportDTO(from: xcresultPath) : nil
 
         let attachmentLookup: [AttachmentLookupKey: [Module.Suite.RepeatableTest.Test.Attachment]]
-        if includeTests, case .extractTo(let outputDirectory) = attachments {
+        if includeTests, case .extractTo(let outputDirectory, let testID) = attachments {
             try FileManager.default.createDirectory(
                 at: outputDirectory,
                 withIntermediateDirectories: true
             )
             let dto = try await AttachmentsDTO(
                 from: xcresultPath,
-                outputDirectory: outputDirectory
+                outputDirectory: outputDirectory,
+                testID: testID
             )
             attachmentLookup = Self.buildAttachmentLookup(
                 dto: dto,


### PR DESCRIPTION
## Summary

`peekie attachments` accepts `--test-id <id>` and parses it into a CLI option, but the value was never propagated past the parser. `Report(... attachments: .extractTo(url))` always shelled out to `xcrun xcresulttool export attachments --path X --output-path Y` with **no** `--test-id`, so the entire bundle's attachments materialized on disk regardless of what the user passed.

The JSON manifest filtered itself client-side post-export (so `peekie attachments --test-id …` printed sensible JSON), but the file count in `--output-dir` was always "every attachment in the bundle" — ~35 in our fixture vs. the 4 a single-test export should produce.

Surfaced in skill-creator iteration testing (PR #197): per-failure attachment recipes the skill documented didn't actually work, forcing a more complex `peekie tests --attachments export | jq | cp` workaround in the skill.

## Key Changes

* **`Sources/PeekieSDK/Models/Report+Convenience.swift`** — `AttachmentPolicy.extractTo` gains a labeled `testID: String? = nil` associated value. Defaulted to `nil` for source compatibility, so existing callers using `.extractTo(url)` keep compiling.
* **`Sources/PeekieSDK/Models/Report+Convenience.swift`** — when destructuring the policy in `Report.init`, the new `testID` is passed to `AttachmentsDTO.init(from:outputDirectory:testID:)`, which already supported the parameter and threads it through to `xcresulttool --test-id <id>`.
* **`Sources/Peekie/Attachments.swift`** — passes `testID` from the parsed CLI option into `.extractTo(outputURL, testID: testID)`.

## Additional Changes

Verified empirically on `Tests/PeekieTests/Resources/SPM-26.5-iOS.xcresult`:

```
swift run peekie attachments <bundle> --output-dir <tmp> --test-id "ExampleSUITests/failureWithAttachment()"
# before: 35+ files on disk (entire bundle)
# after:  4 files on disk (just that test × 2 repetitions × 2 attachments)
```

Local gate green: `swift test` (65 tests / 18 suites), `swiftformat --lint`, `swiftlint --strict`, `periphery scan --skip-build --strict`.

The skill recipes in `agent/skills/peekie-attachments/SKILL.md` and `agent/skills/peekie/SKILL.md` currently document the staging-and-cherry-pick workaround for this bug. They'll be simplified back to the natural `--test-id` loop in a follow-up commit once this PR lands.