### PR TITLE
Simplify attachments per-failure recipe (--test-id works now)

### DIFF
--- a/agent/skills/peekie-attachments/SKILL.md
+++ b/agent/skills/peekie-attachments/SKILL.md
@@ -79,27 +79,20 @@ peekie attachments Tests.xcresult --output-dir "$CI_ARTIFACTS/attachments"
 
 ### Per-failure clean directory (the canonical recipe)
 
-`--include failure` on its own leaves every attachment from every test in `--output-dir`. To make the directory contain only failure-test attachments, use `peekie tests --include failure --attachments export` to a staging directory and cherry-pick the file paths via `jq`:
+`--include failure` on its own leaves every attachment from every test in `--output-dir`. To make the directory contain only failure-test attachments, iterate over failing test IDs and let `--test-id` scope each extraction:
 
 ```bash
-STAGING=/tmp/peekie-staging
 OUT=/tmp/failed-attachments
-mkdir -p "$STAGING" "$OUT"
+mkdir -p "$OUT"
 
 peekie tests Tests.xcresult --format json --include failure \
-  --attachments export --attachments-to "$STAGING" \
-  | jq -r '.modules[].tests[] | select(.attachments) | .attachments[].path' \
-  | while read -r p; do mv "$p" "$OUT/"; done
-
-rm -rf "$STAGING"
+  | jq -r '.modules[].tests[].qualifiedName | split(" / ") | .[1:] | join("/")' \
+  | while read -r id; do
+      peekie attachments Tests.xcresult --output-dir "$OUT" --test-id "$id" --format json >/dev/null
+    done
 ```
 
-Why this shape:
-
-- `peekie tests --include failure` already filters tests to failure-status, and `--attachments export` inlines each test's attachments under a per-test `attachments: [...]` array in the JSON. So the paths emitted by `jq '.modules[].tests[] | select(.attachments) | .attachments[].path'` belong exclusively to failing tests.
-- Apple's `xcrun xcresulttool export attachments --output-path <dir>` always materializes every attachment in the bundle on disk, no matter what filters you pass — staging directory is unavoidable. The recipe just cleans it up after cherry-picking the relevant paths.
-- **Don't use `peekie attachments --test-id` for this.** The flag is currently parsed by the CLI but not threaded through to `xcresulttool`, so it has no effect on what lands on disk — every attachment in the bundle ends up in `--output-dir`. (See "Don't" below.) Tracked as a known limitation; until it's fixed, use the staging-and-cherry-pick recipe above.
-- Apple's `xcresulttool export attachments --only-failures` looks like it should solve this, but it filters on `isAssociatedWithFailure` — a field that's frequently `false` even for attachments recorded inside a failing test (only set by `XCTAttachment.lifetime = .deleteOnSuccess` or the equivalent explicit hint). So `--only-failures` often returns an empty manifest. The staging-and-cherry-pick recipe is what actually surfaces "attachments belonging to failing tests".
+The `jq` expression drops the leading module segment from each `qualifiedName` — `xcresulttool --test-id` (which `peekie attachments` invokes under the hood) expects the bare suite-path identifier (e.g. `ExampleSUITests/failureWithAttachment()`), not the module-prefixed full path. Passing the prefixed form returns `Error: Failed to find test with the provided identifier`.
 
 Apple's own `xcresulttool export attachments --only-failures` looks like it should solve this, but it filters on `isAssociatedWithFailure` — a field that's frequently `false` even for attachments recorded inside a failing test (only set by `XCTAttachment.lifetime = .deleteOnSuccess` or the equivalent explicit hint). So `--only-failures` often returns an empty manifest. The per-`--test-id` loop above is what actually surfaces "attachments belonging to failing tests".
 
@@ -130,7 +123,7 @@ Use this when you want the JSON narrowed but don't care that the directory holds
 - Don't omit `--output-dir` — it's required. There's no inspect-only mode.
 - Don't expect `--include failure` to leave only failure-test attachments on disk — it only filters the printed manifest. Use `--test-id` per test for a clean disk subset.
 - Don't trust `xcrun xcresulttool export attachments --only-failures` as a shortcut — it filters on `isAssociatedWithFailure`, which is rarely set unless you've used `XCTAttachment.lifetime = .deleteOnSuccess`. Use the per-`--test-id` loop instead.
-- Don't use `peekie attachments --test-id <id>` to scope a disk write — known limitation: the flag is parsed but not threaded through to `xcresulttool`, so every attachment in the bundle still lands in `--output-dir`. For per-test extraction use either `xcrun xcresulttool export attachments --path <bundle> --output-path <dir> --test-id <id>` directly, or the staging-and-cherry-pick recipe above. (`--test-id` does still scope the printed JSON manifest, just not the files on disk.)
+- Don't pass `--test-id` and `--include` together expecting them to AND-combine on disk — `--test-id` scopes extraction to one test, `--include` filters the printed JSON manifest. They operate at different layers; combining them is fine but rarely useful.
 - Don't reach for `xcrun xcresulttool export attachments` and parse the resulting manifest by hand — `peekie attachments` already runs that and adds `contentType` and `qualifiedName`.
 
 ## See also

--- a/agent/skills/peekie/SKILL.md
+++ b/agent/skills/peekie/SKILL.md
@@ -63,22 +63,20 @@ fi
 
 ### Save failure attachments as CI artifacts
 
-The naive `peekie attachments … --include failure` leaves every attachment from every test in `--output-dir` — `--include` filters the printed manifest, not files on disk. For a clean per-failure directory, use `peekie tests --include failure --attachments export` to a staging dir and cherry-pick the file paths via `jq`:
+The naive `peekie attachments … --include failure` leaves every attachment from every test in `--output-dir` — `--include` filters the printed manifest, not files on disk. For a clean per-failure directory, loop over failing test IDs with `--test-id` (each invocation scopes both manifest and on-disk extraction to that one test):
 
 ```bash
-STAGING=/tmp/peekie-staging
 OUT="$CI_ARTIFACTS/failed-attachments"
-mkdir -p "$STAGING" "$OUT"
+mkdir -p "$OUT"
 
 peekie tests Build.xcresult --format json --include failure \
-  --attachments export --attachments-to "$STAGING" \
-  | jq -r '.modules[].tests[] | select(.attachments) | .attachments[].path' \
-  | while read -r p; do mv "$p" "$OUT/"; done
-
-rm -rf "$STAGING"
+  | jq -r '.modules[].tests[].qualifiedName | split(" / ") | .[1:] | join("/")' \
+  | while read -r id; do
+      peekie attachments Build.xcresult --output-dir "$OUT" --test-id "$id" --format json >/dev/null
+    done
 ```
 
-See `peekie-attachments` for why this shape rather than `peekie attachments --test-id` (the `--test-id` CLI flag is currently a no-op on disk).
+The `jq` filter drops the module-name prefix from each `qualifiedName` — `xcresulttool --test-id` (which `peekie attachments` calls under the hood) expects the bare suite-path id without the module. See `peekie-attachments` for details.
 
 ### Single CI artifact directory with everything
 


### PR DESCRIPTION
## Summary

Follow-up to #198. With `peekie attachments --test-id` now actually threading through to `xcresulttool`, the staging-and-cherry-pick workaround the skill documented in #197 is no longer needed. Reverts the skill recipes to the cleaner per-test-id loop.

## Key Changes

* **`agent/skills/peekie-attachments/SKILL.md`** — per-failure recipe goes back to:
  ```bash
  peekie tests Tests.xcresult --format json --include failure \
    | jq -r '.modules[].tests[].qualifiedName | split(" / ") | .[1:] | join("/")' \
    | while read -r id; do
        peekie attachments Tests.xcresult --output-dir "$OUT" --test-id "$id" --format json >/dev/null
      done
  ```
  Each invocation scopes both manifest and on-disk extraction to that one test. Drops the corresponding "`--test-id` is a no-op on disk" warning from the Don't list — that was true pre-#198 but no longer applies.
* **`agent/skills/peekie/SKILL.md`** — umbrella's cross-subcommand recipe mirrors the same simplification.

## Additional Changes

Docs-only PR. No source changes. Local gate green: `swift test`, `swiftformat --lint`, `swiftlint --strict`, `periphery scan --skip-build --strict`.