### PR TITLE
Speed up xcresult parsing: bytes stdout + concurrent DTO fetches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ agent/skills/*-workspace/
 
 # xcresulttool side-effect (per-test database, not part of bundle state)
 Tests/PeekieTests/Resources/*.xcresult/database.sqlite3
+
+# Local benchmark fixtures and outputs (multi-hundred-MB xcresult bundles)
+bench/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,16 @@ git checkout -b your-branch-name
 
 ### Language Requirements
 
-**All issues and pull requests must be written in English.** This includes titles, descriptions, and comments. This ensures consistency and accessibility for all contributors.
+**Everything inside this repository must be written in English.** This covers:
+
+- Source code identifiers (types, methods, properties, parameters, locals).
+- Code comments and documentation comments (`///`).
+- Commit messages — both subject lines and bodies.
+- Pull request titles, descriptions, and review comments.
+- Issue titles, descriptions, and comments.
+- Markdown files committed to the repo (READMEs, plans, design notes).
+
+This ensures consistency and accessibility for all contributors and tooling (search, code review bots, static analysis).
 
 ### Using GitHub CLI (`gh`)
 

--- a/Sources/PeekieSDK/Models/DTO/DTO+Helpers.swift
+++ b/Sources/PeekieSDK/Models/DTO/DTO+Helpers.swift
@@ -4,7 +4,7 @@ import Logging
 extension TestResultsDTO {
     private static let logger = Logger(label: "com.peekie.dto")
     init(from xcresultPath: URL) async throws {
-        let output = try await Shell.execute(
+        let data = try await Shell.execute(
             "xcrun",
             arguments: [
                 "xcresulttool", "get", "test-results", "tests",
@@ -12,14 +12,6 @@ extension TestResultsDTO {
                 "--compact",
             ]
         )
-        guard let data = output.data(using: .utf8) else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
-                    codingPath: [],
-                    debugDescription: "Failed to convert output to Data"
-                )
-            )
-        }
 
         Self.logger.debug(
             "Parsing TestResultsDTO",
@@ -41,21 +33,13 @@ extension CoverageReportDTO {
     private static let logger = Logger(label: "com.peekie.dto")
 
     init(from xcresultPath: URL) async throws {
-        let output = try await Shell.execute(
+        let data = try await Shell.execute(
             "xcrun",
             arguments: [
                 "xccov", "view", "--report", "--json",
                 xcresultPath.path,
             ]
         )
-        guard let data = output.data(using: .utf8) else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
-                    codingPath: [],
-                    debugDescription: "Failed to convert output to Data"
-                )
-            )
-        }
 
         Self.logger.debug("Parsing CoverageReportDTO")
         self = try JSONDecoder().decode(CoverageReportDTO.self, from: data)
@@ -133,7 +117,7 @@ extension BuildResultsDTO {
     private static let logger = Logger(label: "com.peekie.dto")
 
     init(from xcresultPath: URL) async throws {
-        let output = try await Shell.execute(
+        let data = try await Shell.execute(
             "xcrun",
             arguments: [
                 "xcresulttool", "get", "build-results",
@@ -141,14 +125,6 @@ extension BuildResultsDTO {
                 "--format", "json",
             ]
         )
-        guard let data = output.data(using: .utf8) else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(
-                    codingPath: [],
-                    debugDescription: "Failed to convert output to Data"
-                )
-            )
-        }
 
         Self.logger.debug("Parsing BuildResultsDTO")
         self = try JSONDecoder().decode(BuildResultsDTO.self, from: data)

--- a/Sources/PeekieSDK/Models/Report+Convenience.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience.swift
@@ -74,12 +74,29 @@ extension Report {
         includeTests: Bool = true,
         attachments: AttachmentPolicy = .skip
     ) async throws {
-        let testResultsDTO: TestResultsDTO? =
-            includeTests ? try await TestResultsDTO(from: xcresultPath) : nil
-        let buildResultsDTO: BuildResultsDTO? =
-            includeWarnings ? try await BuildResultsDTO(from: xcresultPath) : nil
-        let coverageReportDTO: CoverageReportDTO? =
-            includeCoverage ? try await CoverageReportDTO(from: xcresultPath) : nil
+        // Fire the three read-only `xcrun` subprocesses concurrently — each
+        // independently reads the same .xcresult bundle. The dominant cost
+        // (>90% wall-clock on real fixtures) lives in those processes, so
+        // overlapping them is the largest remaining win after Shell switched
+        // to `bytes(limit:)`.
+        //
+        // `xcresulttool export attachments` is sequenced AFTER `get
+        // test-results`: both commands mutate the bundle's internal
+        // sqlite cache and Apple's tool conflicts with itself when two
+        // instances race for the same xcresult (database.sqlite3 → bundle
+        // copy). The conflict is reproducible by parallel snapshot tests.
+        // Sequencing only this pair loses ~0.2-0.5s on the attachments path
+        // but keeps coverage/warnings overlap intact.
+        async let testResultsTask: TestResultsDTO? =
+            includeTests ? TestResultsDTO(from: xcresultPath) : nil
+        async let buildResultsTask: BuildResultsDTO? =
+            includeWarnings ? BuildResultsDTO(from: xcresultPath) : nil
+        async let coverageReportTask: CoverageReportDTO? =
+            includeCoverage ? CoverageReportDTO(from: xcresultPath) : nil
+
+        let testResultsDTO = try await testResultsTask
+        let buildResultsDTO = try await buildResultsTask
+        let coverageReportDTO = try await coverageReportTask
 
         let attachmentLookup: [AttachmentLookupKey: [Module.Suite.RepeatableTest.Test.Attachment]]
         if includeTests, case .extractTo(let outputDirectory, let testID) = attachments {

--- a/Sources/PeekieSDK/Shell.swift
+++ b/Sources/PeekieSDK/Shell.swift
@@ -7,8 +7,17 @@ import Subprocess
 enum Shell {
     // MARK: Internal
 
+    /// Runs `executable` with `arguments` and returns stdout as raw bytes.
+    ///
+    /// Uses `.bytes(limit: .max)` so stdout is delivered as `[UInt8]` and wrapped
+    /// in `Data`, never materialized as a Swift `String`. The previous
+    /// `.string(limit: .max)` path decoded every byte through `LazyMapSequence`
+    /// → metadata-cache lookups, which dominated wall-clock on the multi-hundred-MB
+    /// JSON `xcresulttool`/`xccov` emit on real `.xcresult` bundles.
+    ///
+    /// stderr stays a `String` — it's small and surfaced in `ShellError`.
     @discardableResult
-    static func execute(_ executable: String, arguments: [String] = []) async throws -> String {
+    static func execute(_ executable: String, arguments: [String] = []) async throws -> Data {
         logger.debug(
             "Executing command",
             metadata: [
@@ -20,7 +29,7 @@ enum Shell {
         let result = try await run(
             .name(executable),
             arguments: .init(arguments),
-            output: .string(limit: .max),
+            output: .bytes(limit: .max),
             error: .string(limit: .max)
         )
 
@@ -44,17 +53,15 @@ enum Shell {
             throw ShellError.processFailed(exitCode: result.terminationStatus, error: errorOutput)
         }
 
-        let output =
-            result.standardOutput?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-                ?? ""
+        let data = Data(result.standardOutput)
         logger.debug(
             "Command completed successfully",
             metadata: [
                 "executable": "\(executable)",
-                "outputLength": "\(output.count)",
+                "outputLength": "\(data.count)",
             ]
         )
-        return output
+        return data
     }
 
     // MARK: Private

--- a/Tests/PeekieTests/ShellTests.swift
+++ b/Tests/PeekieTests/ShellTests.swift
@@ -5,7 +5,10 @@ import Testing
 struct ShellTests {
     @Test
     func test() async throws {
-        let result = try await Shell.execute("which", arguments: ["swift"])
+        let data = try await Shell.execute("which", arguments: ["swift"])
+        let result =
+            String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
         #expect(result == "/usr/bin/swift")
     }
 }


### PR DESCRIPTION
## Summary

`peekie` was leaving a lot of wall-clock on the floor on real CI xcresult bundles. Profiling on a 234 MB merged unit-regress xcresult from the `dodobrands/dodo-mobile-ios` CI (`DodoPizzaTests-UnitsRegress-25561-1.xcresult`) showed that ~93% of `peekie coverage` in-process time was spent decoding stdout bytes into a Swift `String` before `JSONDecoder` ever ran. Replacing the `String` materialization with raw `Data`, plus fanning out the three read-only `xcrun` subprocesses inside `Report.init`, cuts wall-clock by 13-25% across `tests`, `coverage`, and `attachments` without any output drift.

|  Command       | Before | After  | Δ    |
|----------------|--------|--------|------|
| `coverage`     | 4.79 s | 3.67 s | -23% |
| `tests`        | 2.67 s | 2.29 s | -14% |
| `attachments`  | 3.26 s | 2.84 s | -13% |
| `warnings` / `errors` | 0.03 s | 0.03 s | – |

Numbers are medians of 3 release-build runs measured with `/usr/bin/time -l`. `warnings` / `errors` are flat because this fixture is a test-only run (`build-results.status == "notRequested"`), so there's no warning data to parse — the 30 ms is `xcrun` subprocess startup.

## Key Changes

* **`Sources/PeekieSDK/Shell.swift`** — `Shell.execute` switches Subprocess from `output: .string(limit: .max)` to `output: .bytes(limit: .max)` and returns `Data` instead of `String`. The previous path decoded every stdout byte through `OutputProtocol.captureOutput` → `StringOutput.init` → `String._fromNonContiguousUnsafeBitcastUTF8Repairing` → `LazyMapSequence.next`, hammering the Swift metadata cache for every byte (~3.4 s of CPU just to build the `String` for `xccov`'s 18 MB JSON, before any decoding started). stderr stays a `String` because it's small and surfaced in `ShellError` for non-zero exits.

* **`Sources/PeekieSDK/Models/DTO/DTO+Helpers.swift`** — the four DTO initializers (`TestResultsDTO`, `CoverageReportDTO`, `BuildResultsDTO`, `AttachmentsDTO`) feed the `Data` from `Shell.execute` straight into `JSONDecoder`, dropping the intermediate `String` and `.data(using: .utf8)` round-trip.

* **`Sources/PeekieSDK/Models/Report+Convenience.swift`** — `TestResultsDTO`, `BuildResultsDTO`, and `CoverageReportDTO` now fire concurrently via `async let`. They're independent reads of the same bundle, so overlapping them is safe; the dominant cost on real fixtures lives inside those subprocesses. `AttachmentsDTO` stays sequential after `TestResultsDTO` — when both run against the same xcresult bundle in parallel, `xcrun xcresulttool` races itself moving its internal `database.sqlite3` into a temporary `<uuid>.xcresult` and one of the two processes fails with "an item with the same name already exists". The parametrised `JSONFormatterSnapshotTests.jsonFormat_withAttachments_*` tests reproduced this reliably (8 fixture variants in parallel, all failing). Sequencing only this pair loses ~0.5 s on `peekie attachments` versus a hypothetical all-parallel version but keeps the test suite green. Every CLI subcommand already toggles off the DTOs it doesn't need, so this is a no-op for them; the win is for external SDK consumers (e.g. dodobrands code-metrics) that call `Report(default)` — sum-of-three drops to max-of-three.

* **`Tests/PeekieTests/ShellTests.swift`** — decodes the returned `Data` back to a `String` to keep the existing end-to-end assertion against `which swift`.

## Additional Changes

* **`AGENTS.md`** — extends the existing English-only rule (previously scoped to issues and PRs) to cover code identifiers, code comments, doc comments, commit messages, PR/issue review comments, and committed Markdown. Same rationale: searchability and accessibility for contributors and tooling (review bots, static analysis, grep).

* **`.gitignore`** — adds `bench/` so local benchmark harnesses and multi-hundred-MB xcresult fixtures don't accidentally land in the repo.

Local gate green: `swift test` (65 tests / 18 suites), `swiftformat --lint`, `swiftlint --strict`, `periphery scan --skip-build --strict`.