### PR TITLE
Tighten peekie skills based on eval audit

### DIFF
--- a/agent/skills/peekie-attachments/SKILL.md
+++ b/agent/skills/peekie-attachments/SKILL.md
@@ -79,7 +79,13 @@ peekie attachments Tests.xcresult --output-dir "$CI_ARTIFACTS/attachments"
 
 ### Per-failure clean directory (the canonical recipe)
 
-`--include failure` on its own leaves every attachment from every test in `--output-dir`. To make the directory contain only failure-test attachments, iterate over failing test IDs and let `--test-id` scope each extraction:
+`--include failure` on its own leaves every attachment from every test in `--output-dir`. To get a directory tree where each failing test has its own subdir of attachments, use the bundled helper script:
+
+```bash
+scripts/extract-failure-attachments.sh Tests.xcresult /tmp/failed-attachments
+```
+
+The script (in this skill's `scripts/` directory) iterates over failing test IDs, sanitizes each into a safe directory name, and runs `peekie attachments --test-id` per failure into its own subdirectory. Inline equivalent — useful if you want to inspect or adapt the loop:
 
 ```bash
 OUT=/tmp/failed-attachments
@@ -88,11 +94,16 @@ mkdir -p "$OUT"
 peekie tests Tests.xcresult --format json --include failure \
   | jq -r '.modules[].tests[].qualifiedName | split(" / ") | .[1:] | join("/")' \
   | while read -r id; do
-      peekie attachments Tests.xcresult --output-dir "$OUT" --test-id "$id" --format json >/dev/null
+      slug=$(printf '%s' "$id" | tr '/()' '___' | tr -s '_')
+      mkdir -p "$OUT/$slug"
+      peekie attachments Tests.xcresult --output-dir "$OUT/$slug" --test-id "$id" --format json >/dev/null
     done
 ```
 
-The `jq` expression drops the leading module segment from each `qualifiedName` — `xcresulttool --test-id` (which `peekie attachments` invokes under the hood) expects the bare suite-path identifier (e.g. `ExampleSUITests/failureWithAttachment()`), not the module-prefixed full path. Passing the prefixed form returns `Error: Failed to find test with the provided identifier`.
+Two non-obvious bits:
+
+- The `jq` expression drops the leading module segment from each `qualifiedName`. `xcresulttool --test-id` (which `peekie attachments` invokes under the hood) expects the bare suite-path identifier (e.g. `ExampleSUITests/failureWithAttachment()`), not the module-prefixed full path. Passing the prefixed form returns `Error: Failed to find test with the provided identifier`.
+- Each iteration writes its own `manifest.json` directly into `--output-dir`. Reusing one shared `$OUT` across iterations fails on the second `--test-id` with `Failed to generate manifest.json: file already exists` — that's why both the script and the inline loop create a per-test subdirectory.
 
 Apple's own `xcresulttool export attachments --only-failures` looks like it should solve this, but it filters on `isAssociatedWithFailure` — a field that's frequently `false` even for attachments recorded inside a failing test (only set by `XCTAttachment.lifetime = .deleteOnSuccess` or the equivalent explicit hint). So `--only-failures` often returns an empty manifest. The per-`--test-id` loop above is what actually surfaces "attachments belonging to failing tests".
 

--- a/agent/skills/peekie-attachments/scripts/extract-failure-attachments.sh
+++ b/agent/skills/peekie-attachments/scripts/extract-failure-attachments.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Extract attachments from failing tests only into per-test subdirectories.
+#
+# Usage:
+#   extract-failure-attachments.sh <xcresult-path> <output-dir>
+#
+# Why this exists: `peekie attachments --include failure` only filters the
+# printed manifest; it still writes every attachment to disk. The clean
+# per-failure layout requires iterating failing test IDs and scoping each
+# extraction with --test-id.
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <xcresult-path> <output-dir>" >&2
+  exit 64
+fi
+
+XCRESULT=$1
+OUT=$2
+mkdir -p "$OUT"
+
+# Pick up `peekie` from PATH; override with PEEKIE env var if needed.
+PEEKIE=${PEEKIE:-peekie}
+
+# `qualifiedName` is `Module / Suite / .../ test()`; xcresulttool --test-id
+# wants the bare suite-path (no module prefix), so drop the first segment.
+#
+# Each test gets its own subdirectory under $OUT — `peekie attachments` writes
+# `manifest.json` directly into --output-dir, so a shared $OUT collides on the
+# second invocation ("Failed to generate manifest.json: file already exists").
+"$PEEKIE" tests "$XCRESULT" --format json --include failure \
+  | jq -r '.modules[].tests[].qualifiedName | split(" / ") | .[1:] | join("/")' \
+  | while read -r id; do
+      # Sanitize id into a safe dirname (replace / and parens with _).
+      slug=$(printf '%s' "$id" | tr '/()' '___' | tr -s '_')
+      sub="$OUT/$slug"
+      mkdir -p "$sub"
+      "$PEEKIE" attachments "$XCRESULT" --output-dir "$sub" --test-id "$id" --format json >/dev/null
+    done

--- a/agent/skills/peekie-coverage/SKILL.md
+++ b/agent/skills/peekie-coverage/SKILL.md
@@ -70,15 +70,25 @@ Human-readable, indented by module → file. Good for terminal, not for piping.
 peekie coverage Tests.xcresult | jq '.coverage * 100 | floor'
 ```
 
+### Overall coverage with one decimal place
+
+```bash
+peekie coverage Tests.xcresult | jq '(.coverage * 1000 | floor) / 10'
+```
+
+`(.coverage * 1000 | floor) / 10` keeps it pure jq — no `bc`, no `printf`. For two decimals, use `* 10000 | floor) / 100`.
+
 ### Gate CI on a coverage threshold (≥ 70%)
 
 ```bash
-cov=$(peekie coverage Tests.xcresult | jq '.coverage')
-awk -v c="$cov" 'BEGIN { exit !(c >= 0.70) }' || {
-  echo "Coverage below 70% (got $(printf '%.1f' "$(echo "$cov * 100" | bc -l)")%)"
+if ! peekie coverage Tests.xcresult | jq -e '.coverage >= 0.70' >/dev/null; then
+  cov=$(peekie coverage Tests.xcresult | jq -r '(.coverage * 1000 | floor) / 10')
+  echo "Coverage below 70% (got ${cov}%)" >&2
   exit 1
-}
+fi
 ```
+
+`jq -e` exits non-zero when the expression is `false` — no `awk` / `bc` needed.
 
 ### Per-module summary table
 

--- a/agent/skills/peekie-tests/SKILL.md
+++ b/agent/skills/peekie-tests/SKILL.md
@@ -61,6 +61,16 @@ Human-readable. One line per test, grouped by module. Good for terminal scanning
 
 SonarQube generic-test report (XML). Requires `--tests-path`. Use only when feeding SonarQube directly.
 
+If the output is `<testExecutions version="1" />` (empty root, no `<file>` entries), Sonar's file-correlation matched nothing — `--tests-path` doesn't cover where the xcresult's source files actually live.
+
+Diagnose: peek at the suite class names with
+
+```bash
+peekie tests <xcresult> --format json | jq -r '.modules[].tests[].qualifiedName' | head
+```
+
+and `find` for a matching `<SuiteName>.swift` — point `--tests-path` at the directory that contains it.
+
 ### `--attachments export` JSON addition
 
 ```bash

--- a/agent/skills/peekie-warnings/SKILL.md
+++ b/agent/skills/peekie-warnings/SKILL.md
@@ -82,10 +82,12 @@ peekie warnings Build.xcresult \
 
 ### Triage `#warning(...)` markers separately from real warnings
 
+`type == "Swift Compiler Error"` IS the proxy for `#warning(...)` directives here (see the quirk above) — filter on `type` directly, the `#warning` substring is not in `.message`:
+
 ```bash
 peekie warnings Build.xcresult | jq '
-  group_by(.type == "Swift Compiler Error" and (.message | test("#warning")))
-  | map({kind: (if .[0].type == "Swift Compiler Error" and (.[0].message | test("#warning")) then "#warning markers" else "real warnings" end), count: length})
+  group_by(.type == "Swift Compiler Error")
+  | map({kind: (if .[0].type == "Swift Compiler Error" then "#warning markers" else "real warnings" end), count: length})
 '
 ```
 

--- a/agent/skills/peekie/SKILL.md
+++ b/agent/skills/peekie/SKILL.md
@@ -5,9 +5,17 @@ description: Route Xcode `.xcresult` parsing work to the right `peekie` subcomma
 
 # Peekie skill (umbrella)
 
-`peekie` is a CLI for Xcode `.xcresult` bundles. Five data-axis subcommands, each with its own dedicated skill. Reach for one of those instead of composing `xcrun xcresulttool` by hand.
+`peekie` is a CLI for Xcode `.xcresult` bundles. Five data-axis subcommands, each with its own dedicated skill.
 
 <!-- Last verified: 2026-06 against peekie post-#195 (attachments). Fixtures regenerated on Xcode 26.5. -->
+
+## Tooling invariant: peekie only
+
+Once any of these skills is in play, **route every read of the `.xcresult` through `peekie`**. Don't fall back to `xcrun xcresulttool`, `xcrun xccov`, `xcparse`, or hand-rolled JSON parsing — not even when peekie seems to be missing a feature. The whole point of these skills is that peekie already runs those tools under the hood and normalizes the output; reaching past peekie reintroduces the footguns it exists to hide (`--only-failures` returning empty, build-results JSON shape changing between Xcode versions, `xccov` returning the raw fraction the user has to convert by hand, and so on).
+
+If peekie genuinely can't do what's asked — say so and stop. Don't reinvent the data path through `xcrun`. The acceptable downstream tools are `jq` for filtering peekie's JSON and ordinary shell (`printf`, control flow). That's the whole vocabulary.
+
+If `peekie` isn't on `$PATH`, install it (see [Installation](#installation)). Don't substitute another tool.
 
 ## Subcommand → skill map
 


### PR DESCRIPTION
## Summary

Audited the 6 SKILL.md files (umbrella `peekie` + 5 sub-skills) by running 5 representative prompts twice — once with the skills loaded, once without. Fixed one real bug, two recipe gaps, and a fragile inline loop; added a top-level no-`xcrun`-fallback invariant. After the changes, with-skill agents land at 23/23 assertion passes (up from 22/23) and run ~17% faster than before, ~50% faster than the no-skill baseline at equal correctness.

## Key Changes

- **`peekie` (umbrella):** add a "peekie only, no `xcrun` fallback" invariant up front. The rule was already spread across per-skill "Don't" sections; lifting it to the umbrella makes it visible before any sub-skill is consulted.
- **`peekie-warnings`:** rewrite the `#warning(...)` triage recipe. The old jq filter used `.message | test("#warning")`, but the same skill explicitly states that the `#warning` substring isn't in `.message` — so the recipe always collapsed every entry into "real warnings". New recipe filters on `type == "Swift Compiler Error"` directly, matching the documented invariant.
- **`peekie-coverage`:** add a "one decimal place" recipe (`(.coverage * 1000 | floor) / 10`) and rewrite the CI threshold gate to use `jq -e` instead of `awk` + `bc` — no external dependencies.
- **`peekie-tests`:** explain the empty `<testExecutions version="1" />` case for `--format sonar`. Includes a diagnostic step using `qualifiedName` + `find` so the agent can locate the right `--tests-path` instead of giving up.
- **`peekie-attachments`:** ship `scripts/extract-failure-attachments.sh` and rewrite the canonical recipe around per-test subdirectories. The previous inline loop reused one `$OUT` across `--test-id` iterations, which fails on the second call with `manifest.json: file already exists` — peekie writes `manifest.json` directly into `--output-dir`. Both the script and the updated inline equivalent now create a per-test subdirectory.

## Additional Changes

None.