### PR TITLE
Dedup Apple-emitted #warning twins within warnings/errors bucket

### DIFF
--- a/Sources/PeekieSDK/Models/Report+Warnings.swift
+++ b/Sources/PeekieSDK/Models/Report+Warnings.swift
@@ -124,20 +124,13 @@ extension Report {
         -> [File.Issue]
     {
         var result = [File.Issue]()
-        var indexByKey = [TwinKey: Int]()
+        var indexByKey = [String: Int]()
         for issue in issues {
-            guard let loc = issue.location else {
+            guard let key = twinKey(for: issue) else {
                 result.append(issue)
                 continue
             }
 
-            let key = TwinKey(
-                startLine: loc.startLine,
-                startColumn: loc.startColumn,
-                endLine: loc.endLine,
-                endColumn: loc.endColumn,
-                message: issue.message
-            )
             if let existingIdx = indexByKey[key] {
                 let existing = result[existingIdx]
                 if existing.type != preferredType, issue.type == preferredType {
@@ -151,15 +144,30 @@ extension Report {
         return result
     }
 
-    /// Hashable key for ``dedupTwins(_:preferring:)`` covering the four
+    /// String key for ``dedupTwins(_:preferring:)`` covering the four
     /// `Location` coordinates plus the normalized message. Path is implicit:
-    /// this struct is keyed inside `mapValues` over a per-file group.
-    private struct TwinKey: Hashable {
-        let startLine: Int
-        let startColumn: Int?
-        let endLine: Int?
-        let endColumn: Int?
-        let message: String
+    /// this helper is called inside `mapValues` over a per-file group.
+    ///
+    /// Returns `nil` for issues without a `Location` — those records are
+    /// not dedup-eligible (see `dedupTwins`).
+    ///
+    /// Concatenated `String` is used instead of a custom `Hashable` struct
+    /// to avoid the cross-tool dance between SwiftLint's
+    /// `unused_declaration`, Periphery, and SwiftFormat's
+    /// `redundantEquatable` when stored properties exist solely as Hashable
+    /// inputs.
+    private static func twinKey(for issue: File.Issue) -> String? {
+        guard let loc = issue.location else {
+            return nil
+        }
+
+        return [
+            String(loc.startLine),
+            loc.startColumn.map(String.init) ?? "_",
+            loc.endLine.map(String.init) ?? "_",
+            loc.endColumn.map(String.init) ?? "_",
+            issue.message,
+        ].joined(separator: "\u{1F}")
     }
 
     /// Normalizes a warning message by removing duplicate patterns and cleaning up formatting

--- a/Sources/PeekieSDK/Models/Report+Warnings.swift
+++ b/Sources/PeekieSDK/Models/Report+Warnings.swift
@@ -15,7 +15,7 @@ extension Report {
     ) async
         -> [String: [File.Issue]]
     {
-        await parseIssues(buildResultsDTO.warnings)
+        await parseIssues(buildResultsDTO.warnings, severity: .warning)
     }
 
     /// Parses errors from BuildResultsDTO and returns a map of file names to their issues.
@@ -27,11 +27,21 @@ extension Report {
     ) async
         -> [String: [File.Issue]]
     {
-        await parseIssues(buildResultsDTO.errors)
+        await parseIssues(buildResultsDTO.errors, severity: .error)
+    }
+
+    /// Severity of the source bucket an `[BuildResultsDTO.Issue]` was drawn from.
+    /// Used by ``parseIssues(_:severity:)`` to pick the surviving record when
+    /// xcresulttool double-emits a diagnostic with two `issueType` values (see
+    /// ``dedupTwins(_:preferring:)`` for the policy).
+    enum IssueSeverity {
+        case warning
+        case error
     }
 
     private static func parseIssues(
-        _ dtoIssues: [BuildResultsDTO.Issue]
+        _ dtoIssues: [BuildResultsDTO.Issue],
+        severity: IssueSeverity
     ) async
         -> [String: [File.Issue]]
     {
@@ -56,11 +66,15 @@ extension Report {
             )
         }
 
+        let preferredType: File.Issue.IssueType = severity == .warning
+            ? .swiftCompilerWarning
+            : .swiftCompilerError
+
         let grouped = Dictionary(grouping: parsed) { $0.0 }
         // Sort issues within each file deterministically — concurrentCompactMap
         // doesn't guarantee order, and snapshot tests are sensitive to it.
         return grouped.mapValues { pairs in
-            pairs.map(\.1).sorted { lhs, rhs in
+            let sorted = pairs.map(\.1).sorted { lhs, rhs in
                 let lhsLine = lhs.location?.startLine ?? .max
                 let rhsLine = rhs.location?.startLine ?? .max
                 if lhsLine != rhsLine {
@@ -76,7 +90,76 @@ extension Report {
                 }
                 return lhs.message < rhs.message
             }
+            return dedupTwins(sorted, preferring: preferredType)
         }
+    }
+
+    /// Collapses pairs of `Issue`s that share `(location, message)` — Apple's
+    /// xcresulttool emits a `#warning("…")` (and friends) twice in the same
+    /// bucket, once with `issueType: "Swift Compiler Error"` and once with
+    /// `"Swift Compiler Warning"`. The two records have identical full
+    /// `Location` (start/end line + column) and, after
+    /// `normalizeWarningMessage`, identical `message` — differing only in
+    /// `issueType`.
+    ///
+    /// When a key collides, the surviving record is the one whose `type`
+    /// matches `preferredType` (typically the issue type that matches the
+    /// bucket severity — `.swiftCompilerWarning` inside `warnings[]`,
+    /// `.swiftCompilerError` inside `errors[]`). If neither side matches —
+    /// or both do — the first-seen record wins (sort order is already
+    /// deterministic).
+    ///
+    /// Records with `location == nil` are not eligible for dedup: without a
+    /// source location we have no spatial proof that two `nil`-located
+    /// diagnostics describe the same underlying record. They pass through.
+    ///
+    /// Unlike `#174` (which dropped a per-`message` dedup), this collapse
+    /// keys on **full** `Location`. The `#174` regression case — the same
+    /// `'oldFoo() is deprecated'` message on lines 4, 5, 12 — keeps all three
+    /// records because their `startLine` values differ.
+    private static func dedupTwins(
+        _ issues: [File.Issue],
+        preferring preferredType: File.Issue.IssueType
+    )
+        -> [File.Issue]
+    {
+        var result = [File.Issue]()
+        var indexByKey = [TwinKey: Int]()
+        for issue in issues {
+            guard let loc = issue.location else {
+                result.append(issue)
+                continue
+            }
+
+            let key = TwinKey(
+                startLine: loc.startLine,
+                startColumn: loc.startColumn,
+                endLine: loc.endLine,
+                endColumn: loc.endColumn,
+                message: issue.message
+            )
+            if let existingIdx = indexByKey[key] {
+                let existing = result[existingIdx]
+                if existing.type != preferredType, issue.type == preferredType {
+                    result[existingIdx] = issue
+                }
+            } else {
+                indexByKey[key] = result.count
+                result.append(issue)
+            }
+        }
+        return result
+    }
+
+    /// Hashable key for ``dedupTwins(_:preferring:)`` covering the four
+    /// `Location` coordinates plus the normalized message. Path is implicit:
+    /// this struct is keyed inside `mapValues` over a per-file group.
+    private struct TwinKey: Hashable {
+        let startLine: Int
+        let startColumn: Int?
+        let endLine: Int?
+        let endColumn: Int?
+        let message: String
     }
 
     /// Normalizes a warning message by removing duplicate patterns and cleaning up formatting

--- a/Tests/PeekieTests/IssueTypeRegressionTests.swift
+++ b/Tests/PeekieTests/IssueTypeRegressionTests.swift
@@ -32,10 +32,14 @@ struct IssueTypeRegressionTests {
             warnings.contains { $0.type == .swiftCompilerWarning },
             "expected at least one .swiftCompilerWarning"
         )
-        #expect(
-            warnings.contains { $0.type == .swiftCompilerError },
-            "expected at least one .swiftCompilerError (from #warning(\"…\") caret)"
-        )
+        // `.swiftCompilerError` no longer appears inside the warnings bucket:
+        // xcresulttool used to double-emit `#warning(...)` directives — once
+        // with `issueType: "Swift Compiler Error"` and once with `"Swift
+        // Compiler Warning"`. Both shared the same Location and message. We
+        // now collapse such twins to a single record with the bucket-matching
+        // severity (`.swiftCompilerWarning` in `warnings[]`). The
+        // `.swiftCompilerError` rawValue is still mapped correctly — see
+        // `IssueTypeTests` for the unit-level proof.
         #expect(
             warnings.contains { $0.type == .deprecatedDeclaration },
             "expected at least one .deprecatedDeclaration (from @available(*, deprecated))"

--- a/Tests/PeekieTests/ParseIssuesTwinDedupTests.swift
+++ b/Tests/PeekieTests/ParseIssuesTwinDedupTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+@testable import PeekieSDK
+
+/// Apple's xcresulttool emits a single Swift `#warning("…")` directive as two
+/// records in the `warnings[]` bucket: one with `issueType: "Swift Compiler
+/// Error"` and one with `"Swift Compiler Warning"`. Both records share the
+/// same `sourceURL` (full Location) and, after `normalizeWarningMessage`,
+/// the same `message`. We collapse such twins into a single record whose
+/// `IssueType` matches the bucket severity.
+///
+/// Asymmetric to ``ParseWarningsDedupTests`` (which guards #174): that test
+/// fixed dedup on `message` alone — distinct lines lost data. Our key
+/// includes the full Location, so #174's scenario is preserved.
+struct ParseIssuesTwinDedupTests {
+    @Test
+    func warningBucketTwinCollapsesToSwiftCompilerWarning() async {
+        let dto = BuildResultsDTO(warnings: [
+            .init(
+                issueType: "Swift Compiler Error",
+                message: """
+                Some warning from Calculator
+                        #warning("Some warning from Calculator")
+                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                """,
+                sourceURL: "file:///Calculator.swift#EndingColumnNumber=17&EndingLineNumber=7&StartingColumnNumber=17&StartingLineNumber=7"
+            ),
+            .init(
+                issueType: "Swift Compiler Warning",
+                message: "Some warning from Calculator",
+                sourceURL: "file:///Calculator.swift#EndingColumnNumber=17&EndingLineNumber=7&StartingColumnNumber=17&StartingLineNumber=7"
+            ),
+        ])
+
+        let result = await Report.parseWarnings(from: dto)
+        let issues = try? #require(result["Calculator.swift"])
+        #expect(issues?.count == 1)
+        #expect(issues?.first?.type == .swiftCompilerWarning)
+        #expect(issues?.first?.message == "Some warning from Calculator")
+    }
+
+    @Test
+    func errorBucketTwinCollapsesToSwiftCompilerError() async {
+        let dto = BuildResultsDTO(errors: [
+            .init(
+                issueType: "Swift Compiler Warning",
+                message: "Boom",
+                sourceURL: "file:///Boom.swift#EndingColumnNumber=9&EndingLineNumber=42&StartingColumnNumber=9&StartingLineNumber=42"
+            ),
+            .init(
+                issueType: "Swift Compiler Error",
+                message: "Boom",
+                sourceURL: "file:///Boom.swift#EndingColumnNumber=9&EndingLineNumber=42&StartingColumnNumber=9&StartingLineNumber=42"
+            ),
+        ])
+
+        let result = await Report.parseErrors(from: dto)
+        let issues = try? #require(result["Boom.swift"])
+        #expect(issues?.count == 1)
+        #expect(issues?.first?.type == .swiftCompilerError)
+    }
+
+    @Test
+    func sameMessageOnDifferentLinesIsPreserved() async {
+        // Guards #174: distinct startLine → distinct TwinKey → no collapse.
+        let dto = BuildResultsDTO(warnings: [
+            .init(
+                issueType: "DeprecatedDeclaration",
+                message: "'oldFoo()' is deprecated: use bar",
+                sourceURL: "file:///Foo.swift#StartingLineNumber=4"
+            ),
+            .init(
+                issueType: "DeprecatedDeclaration",
+                message: "'oldFoo()' is deprecated: use bar",
+                sourceURL: "file:///Foo.swift#StartingLineNumber=5"
+            ),
+            .init(
+                issueType: "DeprecatedDeclaration",
+                message: "'oldFoo()' is deprecated: use bar",
+                sourceURL: "file:///Foo.swift#StartingLineNumber=12"
+            ),
+        ])
+
+        let result = await Report.parseWarnings(from: dto)
+        let issues = try? #require(result["Foo.swift"])
+        #expect(issues?.count == 3)
+        #expect(issues?.compactMap { $0.location?.startLine }.sorted() == [4, 5, 12])
+    }
+
+    @Test
+    func twinWithMismatchingEndColumnIsNotCollapsed() async {
+        // Distinct endColumn → distinct TwinKey → both kept. Documents
+        // the strictness of our key: any of the four coordinates differing
+        // is enough to disqualify dedup.
+        let dto = BuildResultsDTO(warnings: [
+            .init(
+                issueType: "Swift Compiler Error",
+                message: "x",
+                sourceURL: "file:///A.swift#EndingColumnNumber=10&EndingLineNumber=1&StartingColumnNumber=1&StartingLineNumber=1"
+            ),
+            .init(
+                issueType: "Swift Compiler Warning",
+                message: "x",
+                sourceURL: "file:///A.swift#EndingColumnNumber=20&EndingLineNumber=1&StartingColumnNumber=1&StartingLineNumber=1"
+            ),
+        ])
+
+        let result = await Report.parseWarnings(from: dto)
+        let issues = try? #require(result["A.swift"])
+        #expect(issues?.count == 2)
+    }
+
+    @Test
+    func issuesWithNilLocationArePassedThrough() async {
+        // Without a Location we have no spatial proof two records are the
+        // same diagnostic; pass through.
+        let dto = BuildResultsDTO(warnings: [
+            .init(
+                issueType: "Swift Compiler Warning",
+                message: "general",
+                sourceURL: "file:///Z.swift"
+            ),
+            .init(
+                issueType: "Swift Compiler Error",
+                message: "general",
+                sourceURL: "file:///Z.swift"
+            ),
+        ])
+
+        let result = await Report.parseWarnings(from: dto)
+        let issues = try? #require(result["Z.swift"])
+        #expect(issues?.count == 2)
+    }
+}

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-iOS_json_all.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-macOS_json_all.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-tvOS_json_all.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-visionOS_json_all.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.SPM-watchOS_json_all.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-iOS_json_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -397,16 +387,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -559,16 +539,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -633,16 +603,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-macOS_json_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -397,16 +387,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -559,16 +539,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -633,16 +603,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_allStatuses-_.Xcworkspace-visionOS_json_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -397,16 +387,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -559,16 +539,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -633,16 +603,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-iOS_json_failure.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-macOS_json_failure.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-tvOS_json_failure.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-visionOS_json_failure.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.SPM-watchOS_json_failure.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-iOS_json_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -205,16 +195,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -367,16 +347,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -441,16 +411,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-macOS_json_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -205,16 +195,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -367,16 +347,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -441,16 +411,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_failureOnly-_.Xcworkspace-visionOS_json_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -205,16 +195,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -367,16 +347,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -441,16 +411,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.SPM-iOS_json_fq_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.SPM-iOS_json_fq_all.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.SPM-macOS_json_fq_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.SPM-macOS_json_fq_all.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.SPM-tvOS_json_fq_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.SPM-tvOS_json_fq_all.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.SPM-visionOS_json_fq_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.SPM-visionOS_json_fq_all.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.SPM-watchOS_json_fq_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.SPM-watchOS_json_fq_all.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.Xcworkspace-iOS_json_fq_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.Xcworkspace-iOS_json_fq_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -352,16 +342,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -511,16 +491,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -585,16 +555,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.Xcworkspace-macOS_json_fq_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.Xcworkspace-macOS_json_fq_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -352,16 +342,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -511,16 +491,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -585,16 +555,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.Xcworkspace-visionOS_json_fq_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_allStatuses-_.Xcworkspace-visionOS_json_fq_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -352,16 +342,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -511,16 +491,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -585,16 +555,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.SPM-iOS_json_fq_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.SPM-iOS_json_fq_failure.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.SPM-macOS_json_fq_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.SPM-macOS_json_fq_failure.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.SPM-tvOS_json_fq_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.SPM-tvOS_json_fq_failure.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.SPM-visionOS_json_fq_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.SPM-visionOS_json_fq_failure.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.SPM-watchOS_json_fq_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.SPM-watchOS_json_fq_failure.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.Xcworkspace-iOS_json_fq_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.Xcworkspace-iOS_json_fq_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -152,16 +142,6 @@
           ],
           "name" : "TextProcessor.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -319,16 +299,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -393,16 +363,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.Xcworkspace-macOS_json_fq_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.Xcworkspace-macOS_json_fq_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -152,16 +142,6 @@
           ],
           "name" : "TextProcessor.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -319,16 +299,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -393,16 +363,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.Xcworkspace-visionOS_json_fq_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_failureOnly-_.Xcworkspace-visionOS_json_fq_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -152,16 +142,6 @@
           ],
           "name" : "TextProcessor.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -319,16 +299,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -393,16 +363,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.SPM-iOS_json_fq_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.SPM-iOS_json_fq_attachments_all.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.SPM-macOS_json_fq_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.SPM-macOS_json_fq_attachments_all.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.SPM-tvOS_json_fq_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.SPM-tvOS_json_fq_attachments_all.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.SPM-visionOS_json_fq_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.SPM-visionOS_json_fq_attachments_all.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.SPM-watchOS_json_fq_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.SPM-watchOS_json_fq_attachments_all.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.Xcworkspace-iOS_json_fq_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.Xcworkspace-iOS_json_fq_attachments_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -599,16 +589,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -758,16 +738,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -832,16 +802,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.Xcworkspace-macOS_json_fq_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.Xcworkspace-macOS_json_fq_attachments_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -599,16 +589,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -758,16 +738,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -832,16 +802,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.Xcworkspace-visionOS_json_fq_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_allStatuses-_.Xcworkspace-visionOS_json_fq_attachments_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -599,16 +589,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -758,16 +738,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -832,16 +802,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.SPM-iOS_json_fq_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.SPM-iOS_json_fq_attachments_failure.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.SPM-macOS_json_fq_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.SPM-macOS_json_fq_attachments_failure.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.SPM-tvOS_json_fq_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.SPM-tvOS_json_fq_attachments_failure.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.SPM-visionOS_json_fq_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.SPM-visionOS_json_fq_attachments_failure.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.SPM-watchOS_json_fq_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.SPM-watchOS_json_fq_attachments_failure.txt
@@ -41,16 +41,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -80,16 +70,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -215,16 +195,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.Xcworkspace-iOS_json_fq_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.Xcworkspace-iOS_json_fq_attachments_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -200,16 +190,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -359,16 +339,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -433,16 +403,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.Xcworkspace-macOS_json_fq_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.Xcworkspace-macOS_json_fq_attachments_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -200,16 +190,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -359,16 +339,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -433,16 +403,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.Xcworkspace-visionOS_json_fq_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_fullyQualified_withAttachments_failureOnly-_.Xcworkspace-visionOS_json_fq_attachments_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -200,16 +190,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -359,16 +339,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -433,16 +403,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.SPM-iOS_json_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.SPM-iOS_json_attachments_all.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.SPM-macOS_json_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.SPM-macOS_json_attachments_all.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.SPM-tvOS_json_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.SPM-tvOS_json_attachments_all.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.SPM-visionOS_json_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.SPM-visionOS_json_attachments_all.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.SPM-watchOS_json_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.SPM-watchOS_json_attachments_all.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.Xcworkspace-iOS_json_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.Xcworkspace-iOS_json_attachments_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -644,16 +634,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -806,16 +786,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -880,16 +850,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.Xcworkspace-macOS_json_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.Xcworkspace-macOS_json_attachments_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -644,16 +634,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -806,16 +786,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -880,16 +850,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.Xcworkspace-visionOS_json_attachments_all.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_allStatuses-_.Xcworkspace-visionOS_json_attachments_all.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -644,16 +634,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -806,16 +786,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -880,16 +850,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.SPM-iOS_json_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.SPM-iOS_json_attachments_failure.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.SPM-macOS_json_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.SPM-macOS_json_attachments_failure.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.SPM-tvOS_json_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.SPM-tvOS_json_attachments_failure.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.SPM-visionOS_json_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.SPM-visionOS_json_attachments_failure.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.SPM-watchOS_json_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.SPM-watchOS_json_attachments_failure.txt
@@ -44,16 +44,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -83,16 +73,6 @@
           ],
           "name" : "SwiftTestingTests.swift",
           "warnings" : [
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
             {
               "location" : {
                 "endColumn" : 9,
@@ -218,16 +198,6 @@
               },
               "message" : "Call to main actor-isolated class method 'runActivity(named:block:)' in a synchronous nonisolated context",
               "type" : "ActorIsolatedCall"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.Xcworkspace-iOS_json_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.Xcworkspace-iOS_json_attachments_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -245,16 +235,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -407,16 +387,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -481,16 +451,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.Xcworkspace-macOS_json_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.Xcworkspace-macOS_json_attachments_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -245,16 +235,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -407,16 +387,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -481,16 +451,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.Xcworkspace-visionOS_json_attachments_failure.txt
+++ b/Tests/PeekieTests/__Snapshots__/JsonFormatterSnapshotTests/jsonFormat_withAttachments_failureOnly-_.Xcworkspace-visionOS_json_attachments_failure.txt
@@ -27,16 +27,6 @@
                 "startLine" : 7
               },
               "message" : "Some warning from Calculator",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 17,
-                "endLine" : 7,
-                "startColumn" : 17,
-                "startLine" : 7
-              },
-              "message" : "Some warning from Calculator",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -245,16 +235,6 @@
                 "startLine" : 13
               },
               "message" : "Some warning from StringUtils",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 13,
-                "startColumn" : 9,
-                "startLine" : 13
-              },
-              "message" : "Some warning from StringUtils",
               "type" : "Swift Compiler Warning"
             }
           ]
@@ -407,16 +387,6 @@
                 "startLine" : 140
               },
               "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 140,
-                "startColumn" : 9,
-                "startLine" : 140
-              },
-              "message" : "Some warning from ExampleSUITests",
               "type" : "Swift Compiler Warning"
             },
             {
@@ -481,16 +451,6 @@
               },
               "message" : "Main actor-isolated instance method 'multiply' cannot be called from outside of the actor; this is an error in the Swift 6 language mode",
               "type" : "Swift Compiler Warning"
-            },
-            {
-              "location" : {
-                "endColumn" : 9,
-                "endLine" : 173,
-                "startColumn" : 9,
-                "startLine" : 173
-              },
-              "message" : "Some warning from ExampleSUITests",
-              "type" : "Swift Compiler Error"
             },
             {
               "location" : {

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
@@ -14,19 +14,7 @@
       - name: "Calculator.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 17
-              ▿ endLine: Optional<Int>
-                - some: 7
-              ▿ startColumn: Optional<Int>
-                - some: 17
-              - startLine: 7
-          - message: "Some warning from Calculator"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -173,19 +161,7 @@
       - name: "SwiftTestingTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 140
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 140
-          - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -210,7 +186,7 @@
       - name: "XCTestTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-      ▿ warnings: 3 elements
+      ▿ warnings: 2 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -234,18 +210,6 @@
                 - some: 9
               - startLine: 173
           - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 173
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 173
-          - message: "Some warning from ExampleSUITests"
           - type: IssueType.swiftCompilerWarning
     ▿ File
       - coverage: Optional<Coverage>.none
@@ -253,19 +217,7 @@
       - module: Optional<String>.none
       - name: "TextProcessor.swift"
       - path: Optional<String>.none
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 13
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 13
-          - message: "Some warning from StringUtils"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -308,19 +260,7 @@
           - name: "Calculator.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -467,19 +407,7 @@
           - name: "SwiftTestingTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -504,7 +432,7 @@
           - name: "XCTestTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-          ▿ warnings: 3 elements
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -517,18 +445,6 @@
                   - startLine: 113
               - message: "Call to main actor-isolated class method \'runActivity(named:block:)\' in a synchronous nonisolated context"
               - type: IssueType.actorIsolatedCall
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
@@ -14,19 +14,7 @@
       - name: "Calculator.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 17
-              ▿ endLine: Optional<Int>
-                - some: 7
-              ▿ startColumn: Optional<Int>
-                - some: 17
-              - startLine: 7
-          - message: "Some warning from Calculator"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -173,19 +161,7 @@
       - name: "SwiftTestingTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 140
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 140
-          - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -210,7 +186,7 @@
       - name: "XCTestTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-      ▿ warnings: 3 elements
+      ▿ warnings: 2 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -234,18 +210,6 @@
                 - some: 9
               - startLine: 173
           - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 173
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 173
-          - message: "Some warning from ExampleSUITests"
           - type: IssueType.swiftCompilerWarning
     ▿ File
       - coverage: Optional<Coverage>.none
@@ -253,19 +217,7 @@
       - module: Optional<String>.none
       - name: "TextProcessor.swift"
       - path: Optional<String>.none
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 13
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 13
-          - message: "Some warning from StringUtils"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -308,19 +260,7 @@
           - name: "Calculator.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -467,19 +407,7 @@
           - name: "SwiftTestingTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -504,7 +432,7 @@
           - name: "XCTestTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-          ▿ warnings: 3 elements
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -517,18 +445,6 @@
                   - startLine: 113
               - message: "Call to main actor-isolated class method \'runActivity(named:block:)\' in a synchronous nonisolated context"
               - type: IssueType.actorIsolatedCall
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
@@ -14,19 +14,7 @@
       - name: "Calculator.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 17
-              ▿ endLine: Optional<Int>
-                - some: 7
-              ▿ startColumn: Optional<Int>
-                - some: 17
-              - startLine: 7
-          - message: "Some warning from Calculator"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -173,19 +161,7 @@
       - name: "SwiftTestingTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 140
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 140
-          - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -210,7 +186,7 @@
       - name: "XCTestTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-      ▿ warnings: 3 elements
+      ▿ warnings: 2 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -234,18 +210,6 @@
                 - some: 9
               - startLine: 173
           - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 173
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 173
-          - message: "Some warning from ExampleSUITests"
           - type: IssueType.swiftCompilerWarning
     ▿ File
       - coverage: Optional<Coverage>.none
@@ -253,19 +217,7 @@
       - module: Optional<String>.none
       - name: "TextProcessor.swift"
       - path: Optional<String>.none
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 13
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 13
-          - message: "Some warning from StringUtils"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -308,19 +260,7 @@
           - name: "Calculator.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -467,19 +407,7 @@
           - name: "SwiftTestingTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -504,7 +432,7 @@
           - name: "XCTestTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-          ▿ warnings: 3 elements
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -517,18 +445,6 @@
                   - startLine: 113
               - message: "Call to main actor-isolated class method \'runActivity(named:block:)\' in a synchronous nonisolated context"
               - type: IssueType.actorIsolatedCall
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
@@ -14,19 +14,7 @@
       - name: "Calculator.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 17
-              ▿ endLine: Optional<Int>
-                - some: 7
-              ▿ startColumn: Optional<Int>
-                - some: 17
-              - startLine: 7
-          - message: "Some warning from Calculator"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -173,19 +161,7 @@
       - name: "SwiftTestingTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 140
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 140
-          - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -210,7 +186,7 @@
       - name: "XCTestTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-      ▿ warnings: 3 elements
+      ▿ warnings: 2 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -234,18 +210,6 @@
                 - some: 9
               - startLine: 173
           - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 173
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 173
-          - message: "Some warning from ExampleSUITests"
           - type: IssueType.swiftCompilerWarning
     ▿ File
       - coverage: Optional<Coverage>.none
@@ -253,19 +217,7 @@
       - module: Optional<String>.none
       - name: "TextProcessor.swift"
       - path: Optional<String>.none
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 13
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 13
-          - message: "Some warning from StringUtils"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -308,19 +260,7 @@
           - name: "Calculator.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -467,19 +407,7 @@
           - name: "SwiftTestingTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -504,7 +432,7 @@
           - name: "XCTestTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-          ▿ warnings: 3 elements
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -517,18 +445,6 @@
                   - startLine: 113
               - message: "Call to main actor-isolated class method \'runActivity(named:block:)\' in a synchronous nonisolated context"
               - type: IssueType.actorIsolatedCall
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
@@ -14,19 +14,7 @@
       - name: "Calculator.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 17
-              ▿ endLine: Optional<Int>
-                - some: 7
-              ▿ startColumn: Optional<Int>
-                - some: 17
-              - startLine: 7
-          - message: "Some warning from Calculator"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -173,19 +161,7 @@
       - name: "SwiftTestingTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 140
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 140
-          - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -210,7 +186,7 @@
       - name: "XCTestTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-      ▿ warnings: 3 elements
+      ▿ warnings: 2 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -234,18 +210,6 @@
                 - some: 9
               - startLine: 173
           - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 173
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 173
-          - message: "Some warning from ExampleSUITests"
           - type: IssueType.swiftCompilerWarning
     ▿ File
       - coverage: Optional<Coverage>.none
@@ -253,19 +217,7 @@
       - module: Optional<String>.none
       - name: "TextProcessor.swift"
       - path: Optional<String>.none
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 13
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 13
-          - message: "Some warning from StringUtils"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -308,19 +260,7 @@
           - name: "Calculator.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -467,19 +407,7 @@
           - name: "SwiftTestingTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -504,7 +432,7 @@
           - name: "XCTestTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-          ▿ warnings: 3 elements
+          ▿ warnings: 2 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -517,18 +445,6 @@
                   - startLine: 113
               - message: "Call to main actor-isolated class method \'runActivity(named:block:)\' in a synchronous nonisolated context"
               - type: IssueType.actorIsolatedCall
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
@@ -14,19 +14,7 @@
       - name: "Calculator.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 17
-              ▿ endLine: Optional<Int>
-                - some: 7
-              ▿ startColumn: Optional<Int>
-                - some: 17
-              - startLine: 7
-          - message: "Some warning from Calculator"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -77,7 +65,7 @@
       - name: "SwiftTestingTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
-      ▿ warnings: 6 elements
+      ▿ warnings: 5 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -102,18 +90,6 @@
               - startLine: 75
           - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
           - type: IssueType.swiftCompilerWarning
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 140
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 140
-          - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -162,7 +138,7 @@
       - name: "XCTestTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
-      ▿ warnings: 5 elements
+      ▿ warnings: 4 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -210,18 +186,6 @@
                 - some: 9
               - startLine: 173
           - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 173
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 173
-          - message: "Some warning from ExampleSUITests"
           - type: IssueType.swiftCompilerWarning
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -235,19 +199,7 @@
       - name: "TextProcessor.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 13
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 13
-          - message: "Some warning from StringUtils"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -389,19 +341,7 @@
           - name: "Calculator.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -2886,19 +2826,7 @@
           - name: "TextProcessor.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3042,7 +2970,7 @@
           - name: "SwiftTestingTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
-          ▿ warnings: 6 elements
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3067,18 +2995,6 @@
                   - startLine: 75
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3127,7 +3043,7 @@
           - name: "XCTestTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
-          ▿ warnings: 5 elements
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3164,18 +3080,6 @@
                   - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
@@ -14,19 +14,7 @@
       - name: "Calculator.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 17
-              ▿ endLine: Optional<Int>
-                - some: 7
-              ▿ startColumn: Optional<Int>
-                - some: 17
-              - startLine: 7
-          - message: "Some warning from Calculator"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -77,7 +65,7 @@
       - name: "SwiftTestingTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
-      ▿ warnings: 6 elements
+      ▿ warnings: 5 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -102,18 +90,6 @@
               - startLine: 75
           - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
           - type: IssueType.swiftCompilerWarning
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 140
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 140
-          - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -162,7 +138,7 @@
       - name: "XCTestTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
-      ▿ warnings: 5 elements
+      ▿ warnings: 4 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -210,18 +186,6 @@
                 - some: 9
               - startLine: 173
           - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 173
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 173
-          - message: "Some warning from ExampleSUITests"
           - type: IssueType.swiftCompilerWarning
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -235,19 +199,7 @@
       - name: "TextProcessor.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 13
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 13
-          - message: "Some warning from StringUtils"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -389,19 +341,7 @@
           - name: "Calculator.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -2886,19 +2826,7 @@
           - name: "TextProcessor.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3042,7 +2970,7 @@
           - name: "SwiftTestingTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
-          ▿ warnings: 6 elements
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3067,18 +2995,6 @@
                   - startLine: 75
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3127,7 +3043,7 @@
           - name: "XCTestTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
-          ▿ warnings: 5 elements
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3164,18 +3080,6 @@
                   - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
@@ -14,19 +14,7 @@
       - name: "Calculator.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 17
-              ▿ endLine: Optional<Int>
-                - some: 7
-              ▿ startColumn: Optional<Int>
-                - some: 17
-              - startLine: 7
-          - message: "Some warning from Calculator"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -77,7 +65,7 @@
       - name: "SwiftTestingTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
-      ▿ warnings: 6 elements
+      ▿ warnings: 5 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -102,18 +90,6 @@
               - startLine: 75
           - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
           - type: IssueType.swiftCompilerWarning
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 140
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 140
-          - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -162,7 +138,7 @@
       - name: "XCTestTests.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
-      ▿ warnings: 5 elements
+      ▿ warnings: 4 elements
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -210,18 +186,6 @@
                 - some: 9
               - startLine: 173
           - message: "Some warning from ExampleSUITests"
-          - type: IssueType.swiftCompilerError
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 173
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 173
-          - message: "Some warning from ExampleSUITests"
           - type: IssueType.swiftCompilerWarning
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -235,19 +199,7 @@
       - name: "TextProcessor.swift"
       ▿ path: Optional<String>
         - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
-      ▿ warnings: 2 elements
-        ▿ Issue
-          ▿ location: Optional<Location>
-            ▿ some: Location
-              ▿ endColumn: Optional<Int>
-                - some: 9
-              ▿ endLine: Optional<Int>
-                - some: 13
-              ▿ startColumn: Optional<Int>
-                - some: 9
-              - startLine: 13
-          - message: "Some warning from StringUtils"
-          - type: IssueType.swiftCompilerError
+      ▿ warnings: 1 element
         ▿ Issue
           ▿ location: Optional<Location>
             ▿ some: Location
@@ -389,19 +341,7 @@
           - name: "Calculator.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -2886,19 +2826,7 @@
           - name: "TextProcessor.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerError
+          ▿ warnings: 1 element
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3042,7 +2970,7 @@
           - name: "SwiftTestingTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
-          ▿ warnings: 6 elements
+          ▿ warnings: 5 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3067,18 +2995,6 @@
                   - startLine: 75
               - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3127,7 +3043,7 @@
           - name: "XCTestTests.swift"
           ▿ path: Optional<String>
             - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
-          ▿ warnings: 5 elements
+          ▿ warnings: 4 elements
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location
@@ -3164,18 +3080,6 @@
                   - startLine: 64
               - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
               - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerError
             ▿ Issue
               ▿ location: Optional<Location>
                 ▿ some: Location


### PR DESCRIPTION
## Summary

`xcresulttool` double-emits a Swift `#warning("…")` directive in the `warnings[]` bucket: one record with `issueType: "Swift Compiler Error"`, one with `"Swift Compiler Warning"`. After `normalizeWarningMessage` they share an identical message and an identical full `Location` — they differ only in `issueType`. Consumers saw two near-identical `Issue` records per directive, and the typed-enum side of `IssueType` made it look like `file.warnings` legitimately contained `.swiftCompilerError`-typed records.

Reproduces on every 26.5 fixture: 4 `#warning` directives across `Calculator.swift`, `TextProcessor.swift`, `SwiftTestingTests.swift`, `XCTestTests.swift`, each surfaced twice.

This is the second of three planned dedup PRs (see #204 for path-by-basename dedup, future PR for the `Module.files` projection refactor).

## Key Changes

- `Report.parseIssues` now takes a `severity: IssueSeverity` parameter and calls `dedupTwins` after the per-file sort. Collapse key: `(startLine, startColumn, endLine, endColumn, normalized_message)`. When a key collides, the record whose `IssueType` matches the bucket severity wins (`.swiftCompilerWarning` in `warnings[]`, `.swiftCompilerError` in `errors[]`); otherwise the first-seen record wins. Records with `nil` Location pass through.
- `Report.IssueSeverity` (internal): two-case enum exposing the bucket severity to `parseIssues`/`dedupTwins`.
- `ParseIssuesTwinDedupTests` (new, 5 cases): the Calculator twin → 1 record / `.swiftCompilerWarning`; symmetric case in errors bucket; same-message-different-lines is preserved (guards #174); endColumn mismatch disqualifies dedup; `nil` Location passes through.
- `IssueTypeRegressionTests.fixtureSurfacesEveryTypedIssueType` drops the `.swiftCompilerError`-in-warnings expectation. That assertion was relying on the twin emission we now collapse; the rawValue → typed mapping is still proven at unit level (`IssueTypeTests`).
- Snapshot fallout: every `#warning` directive in the fixture catalog goes from two records to one.

## Diff from #174

`#174` removed a per-`message` dedup that was dropping the same `'oldFoo()' is deprecated` message at lines 4/5/12. Our key includes **full** `Location`, so those three records have distinct keys and stay. `sameMessageOnDifferentLinesIsPreserved` test covers exactly that scenario.

## Additional Changes

_None._