### PR TITLE
Module = thin handle; module-scoped data lives on Report

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,19 +34,62 @@ If you only use the CLI, jump to [CLI](#cli). If you embed `PeekieSDK`, read the
 
 ## SDK
 
-### Model: `Report` is reshaped around `File` ([#176](https://github.com/dodobrands/Peekie/pull/176))
+### Model: `Report` is reshaped around `File` ([#176](https://github.com/dodobrands/Peekie/pull/176), [#206](https://github.com/dodobrands/Peekie/pull/206))
 
-`Report.files` is now the primary index. `Report.modules` is a projection over it.
+`Report.files` is now the primary index. `Module` is a thin handle that just names a target; module-scoped data (files, coverage, suites, root-level tests) lives on `Report` itself and is reached via `…(in:)` lookups.
 
 | 4.x | 5.0 |
 |---|---|
-| `Report.modules: Set<Module>` | `Report.modules: [Module]` (projection — not every file appears here) |
+| `Report.modules: Set<Module>` | `Report.modules: [Module]` (one handle per identifiable target) |
 | _no analog_ | `Report.files: [File]` (source of truth) |
-| `Module.files: Set<File>` | `Module.files: [File]` (subset where `File.module == module.name`) |
+| `Module.files: Set<File>` | _removed; use `report.files(in: module)`_ |
+| `Module.coverage: Coverage?` | _removed; use `report.coverage(of: module)` and / or `report.coverageByModule[module.name]`_ |
+| `Module.suites: [Suite]` | _removed; use `report.suites(in: module)` and / or `report.suitesByModule[module.name]`_ |
+| `Module.rootLevelTests: Set<RepeatableTest>` | _removed; use `report.rootLevelTests(in: module)` and / or `report.rootLevelTestsByModule[module.name]`_ |
+| `Module.warnings` / `Module.errors` | _removed; use `report.warnings(in: module)` / `report.errors(in: module)`_ |
 | _no analog_ | `File.path: String?` (full path when available) |
 | _no analog_ | `File.module: String?` (target name; `nil` for test-less / project-level files) |
 
 Files in test-less targets and files known only from build issues (with no `producingTarget` in xcresult) used to be silently dropped. They now appear in `Report.files` with `module == nil` and their warnings/errors are preserved.
+
+#### Why `Module` collapsed to a handle
+
+The intermediate 5.0 design (still visible in [#176](https://github.com/dodobrands/Peekie/pull/176)) materialized `Module.files` / `coverage` / `suites` / `rootLevelTests` as stored properties on `Module`. The `files` array was a value-copy of the matching slice of `Report.files`, so every `File` struct existed twice in memory and twice in any dump — once at `Report` scope, once nested under its owning `Module`. Consequences:
+
+- `report.warnings + report.modules.flatMap(\.warnings)` double-counted every file whose `module != nil`. The two halves overlapped exactly on those.
+- Snapshots dumped every `File` twice. The duplicate subtrees are what motivated [#206](https://github.com/dodobrands/Peekie/pull/206).
+
+With the projection moved onto `Report`, each `File` value lives in exactly one place; module views are pure lookups. The double-count is no longer possible.
+
+#### `Report` storage and lookups added in 5.0
+
+```swift
+public struct Report {
+    // existing
+    public let files: [File]
+    public let modules: [Module]
+    public let coverage: Double?
+
+    // new in 5.0 — keyed by Module.name
+    public let coverageByModule: [String: Coverage]
+    public let suitesByModule: [String: [Module.Suite]]
+    public let rootLevelTestsByModule: [String: Set<Module.Suite.RepeatableTest>]
+
+    // new in 5.0 — sugared lookups over the above
+    public func files(in module: Module) -> [File]
+    public func coverage(of module: Module) -> Coverage?
+    public func suites(in module: Module) -> [Module.Suite]
+    public func rootLevelTests(in module: Module) -> Set<Module.Suite.RepeatableTest>
+    public func warnings(in module: Module) -> [File.Issue]
+    public func errors(in module: Module) -> [File.Issue]
+}
+```
+
+`Module.Suite`, `Module.Suite.RepeatableTest`, and the rest of the nested test types keep their names and layout; only the outer `Module` shrinks.
+
+#### Test helpers
+
+`Report.Module.testMake` collapses to `Report.Module.testMake(name:)`. `Report.testMake` gains optional `coverageByModule` / `suitesByModule` / `rootLevelTestsByModule` parameters; the prior `files / modules / coverage` call continues to work.
 
 ### Type renames ([#176](https://github.com/dodobrands/Peekie/pull/176))
 
@@ -102,7 +145,7 @@ public struct Location: Equatable, Sendable, Codable {
 
 ### New: `File.errors` ([#175](https://github.com/dodobrands/Peekie/pull/175))
 
-`Report`, `Report.Module`, and `Report.File` each expose an `errors` array symmetric to `warnings`:
+`Report` and `Report.File` each expose an `errors` array symmetric to `warnings`:
 
 ```swift
 public struct File: Hashable {
@@ -112,7 +155,7 @@ public struct File: Hashable {
 }
 ```
 
-`Report.errors` and `Module.errors` are computed (`files.flatMap(\.errors)`). Errors without `sourceURL` are dropped — same behavior as warnings; see #175 for the open question on a future `Report.unboundIssues` bucket.
+`Report.errors` is computed as `files.flatMap(\.errors)`; for a module-scoped slice use `report.errors(in: module)`. Errors without `sourceURL` are dropped — same behavior as warnings; see #175 for the open question on a future `Report.unboundIssues` bucket.
 
 ### New: `includeTests` flag on `Report.init` ([#179](https://github.com/dodobrands/Peekie/pull/179))
 
@@ -133,7 +176,7 @@ public init(
 ) async throws
 ```
 
-Setting `includeTests: false` skips `xcresulttool get test-results tests` — the slowest of the three subprocess calls. `Module.suites` is empty but `files`, `Module.files`, warnings, and errors stay populated.
+Setting `includeTests: false` skips `xcresulttool get test-results tests` — the slowest of the three subprocess calls. `report.suitesByModule` / `report.rootLevelTestsByModule` are empty but `files`, per-module file lookups, warnings, and errors stay populated.
 
 ### Internal: `TotalCoverageDTO` deleted ([#171](https://github.com/dodobrands/Peekie/pull/171))
 
@@ -182,87 +225,6 @@ If you snapshot-test against `Report` or any formatter output downstream, all sn
 | [#176](https://github.com/dodobrands/Peekie/pull/176) | [#168](https://github.com/dodobrands/Peekie/issues/168) | File-primary model |
 | [#179](https://github.com/dodobrands/Peekie/pull/179) | [#167](https://github.com/dodobrands/Peekie/issues/167) | CLI data-axis restructure |
 | [#183](https://github.com/dodobrands/Peekie/pull/183) | [#163](https://github.com/dodobrands/Peekie/issues/163), [#164](https://github.com/dodobrands/Peekie/issues/164) | Regenerated fixtures + regression asserts + normalizer audit |
-
----
-
-# Migration Guide: 5.x → 6.0
-
-6.0 keeps the CLI surface and most of the SDK shape introduced in 5.0. The single break is on `Report.Module`: it collapses to a thin handle (`{ name }`) and all module-scoped data moves onto `Report` itself, reached via `…(in:)` lookups. The 5.x design materialized `Module.files` as a stored array, which duplicated `File` values across `Report.files` and `Module.files`, made `report.warnings + modules.flatMap(\.warnings)` double-count, and burdened snapshots with two copies of every file's issues.
-
-## SDK — Module is a thin handle
-
-In 5.x, `Module` carried the projection inline:
-
-```swift
-public struct Module {
-    public let name: String
-    public let files: [File]
-    public let coverage: Coverage?
-    public let rootLevelTests: Set<Suite.RepeatableTest>
-    public let suites: [Suite]
-    public var warnings: [File.Issue] { files.flatMap(\.warnings) }
-    public var errors: [File.Issue] { files.flatMap(\.errors) }
-}
-```
-
-In 6.0, `Module` is just an identity:
-
-```swift
-public struct Module: Hashable {
-    public init(name: String)
-    public let name: String
-}
-```
-
-Module-scoped data lives on `Report`:
-
-```swift
-public struct Report {
-    // existing 5.x storage…
-    public let files: [File]
-    public let modules: [Module]
-    public let coverage: Double?
-
-    // new 6.0 storage — keyed by Module.name
-    public let coverageByModule: [String: Coverage]
-    public let suitesByModule: [String: [Module.Suite]]
-    public let rootLevelTestsByModule: [String: Set<Module.Suite.RepeatableTest>]
-
-    // new 6.0 lookups
-    public func files(in module: Module) -> [File]
-    public func coverage(of module: Module) -> Coverage?
-    public func suites(in module: Module) -> [Module.Suite]
-    public func rootLevelTests(in module: Module) -> Set<Module.Suite.RepeatableTest>
-    public func warnings(in module: Module) -> [File.Issue]
-    public func errors(in module: Module) -> [File.Issue]
-}
-```
-
-### Migration table
-
-| 5.x | 6.0 |
-|---|---|
-| `module.files` | `report.files(in: module)` |
-| `module.coverage` | `report.coverage(of: module)` |
-| `module.suites` | `report.suites(in: module)` |
-| `module.rootLevelTests` | `report.rootLevelTests(in: module)` |
-| `module.warnings` | `report.warnings(in: module)` |
-| `module.errors` | `report.errors(in: module)` |
-| `Module(name:, files:, coverage:, rootLevelTests:, suites:)` (5.x init) | `Module(name:)` — projection is on `Report` |
-
-`Module.Suite`, `Module.Suite.RepeatableTest`, and the rest of the nested test types keep their names and layout; only the outer `Module` shrinks.
-
-### Test helpers
-
-`Report.Module.testMake` collapses to `Report.Module.testMake(name:)`. `Report.testMake` gains optional `coverageByModule`, `suitesByModule`, `rootLevelTestsByModule` parameters; the prior memberwise call with `files / modules / coverage` continues to work.
-
-### Why
-
-`report.warnings.count` and `report.modules.flatMap(\.warnings).count` could diverge in 5.x — modules excluded files with `File.module == nil`, but had their own copy of warnings for files they did own. Adding the two without thinking double-counted. With 6.0 the `File` values live in exactly one place (`Report.files`); module-scoped views are pure projections.
-
-## Related landed PRs
-
-| PR | Issue | Summary |
-|---|---|---|
 | [#204](https://github.com/dodobrands/Peekie/pull/204) | n/a | Fix `pathsByBasename` dup-append when a file lives in multiple coverage targets (drops the multiplier on per-file warning/error counts) |
 | [#205](https://github.com/dodobrands/Peekie/pull/205) | n/a | Dedup Apple-emitted `#warning` twins inside `warnings[]` / `errors[]` (collapses paired records to the bucket-matching `IssueType`) |
+| [#206](https://github.com/dodobrands/Peekie/pull/206) | n/a | `Module` shrinks to `{ name }`; module-scoped data moves onto `Report` (removes the `Report.files` ↔ `Module.files` duplication) |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -182,3 +182,87 @@ If you snapshot-test against `Report` or any formatter output downstream, all sn
 | [#176](https://github.com/dodobrands/Peekie/pull/176) | [#168](https://github.com/dodobrands/Peekie/issues/168) | File-primary model |
 | [#179](https://github.com/dodobrands/Peekie/pull/179) | [#167](https://github.com/dodobrands/Peekie/issues/167) | CLI data-axis restructure |
 | [#183](https://github.com/dodobrands/Peekie/pull/183) | [#163](https://github.com/dodobrands/Peekie/issues/163), [#164](https://github.com/dodobrands/Peekie/issues/164) | Regenerated fixtures + regression asserts + normalizer audit |
+
+---
+
+# Migration Guide: 5.x → 6.0
+
+6.0 keeps the CLI surface and most of the SDK shape introduced in 5.0. The single break is on `Report.Module`: it collapses to a thin handle (`{ name }`) and all module-scoped data moves onto `Report` itself, reached via `…(in:)` lookups. The 5.x design materialized `Module.files` as a stored array, which duplicated `File` values across `Report.files` and `Module.files`, made `report.warnings + modules.flatMap(\.warnings)` double-count, and burdened snapshots with two copies of every file's issues.
+
+## SDK — Module is a thin handle
+
+In 5.x, `Module` carried the projection inline:
+
+```swift
+public struct Module {
+    public let name: String
+    public let files: [File]
+    public let coverage: Coverage?
+    public let rootLevelTests: Set<Suite.RepeatableTest>
+    public let suites: [Suite]
+    public var warnings: [File.Issue] { files.flatMap(\.warnings) }
+    public var errors: [File.Issue] { files.flatMap(\.errors) }
+}
+```
+
+In 6.0, `Module` is just an identity:
+
+```swift
+public struct Module: Hashable {
+    public init(name: String)
+    public let name: String
+}
+```
+
+Module-scoped data lives on `Report`:
+
+```swift
+public struct Report {
+    // existing 5.x storage…
+    public let files: [File]
+    public let modules: [Module]
+    public let coverage: Double?
+
+    // new 6.0 storage — keyed by Module.name
+    public let coverageByModule: [String: Coverage]
+    public let suitesByModule: [String: [Module.Suite]]
+    public let rootLevelTestsByModule: [String: Set<Module.Suite.RepeatableTest>]
+
+    // new 6.0 lookups
+    public func files(in module: Module) -> [File]
+    public func coverage(of module: Module) -> Coverage?
+    public func suites(in module: Module) -> [Module.Suite]
+    public func rootLevelTests(in module: Module) -> Set<Module.Suite.RepeatableTest>
+    public func warnings(in module: Module) -> [File.Issue]
+    public func errors(in module: Module) -> [File.Issue]
+}
+```
+
+### Migration table
+
+| 5.x | 6.0 |
+|---|---|
+| `module.files` | `report.files(in: module)` |
+| `module.coverage` | `report.coverage(of: module)` |
+| `module.suites` | `report.suites(in: module)` |
+| `module.rootLevelTests` | `report.rootLevelTests(in: module)` |
+| `module.warnings` | `report.warnings(in: module)` |
+| `module.errors` | `report.errors(in: module)` |
+| `Module(name:, files:, coverage:, rootLevelTests:, suites:)` (5.x init) | `Module(name:)` — projection is on `Report` |
+
+`Module.Suite`, `Module.Suite.RepeatableTest`, and the rest of the nested test types keep their names and layout; only the outer `Module` shrinks.
+
+### Test helpers
+
+`Report.Module.testMake` collapses to `Report.Module.testMake(name:)`. `Report.testMake` gains optional `coverageByModule`, `suitesByModule`, `rootLevelTestsByModule` parameters; the prior memberwise call with `files / modules / coverage` continues to work.
+
+### Why
+
+`report.warnings.count` and `report.modules.flatMap(\.warnings).count` could diverge in 5.x — modules excluded files with `File.module == nil`, but had their own copy of warnings for files they did own. Adding the two without thinking double-counted. With 6.0 the `File` values live in exactly one place (`Report.files`); module-scoped views are pure projections.
+
+## Related landed PRs
+
+| PR | Issue | Summary |
+|---|---|---|
+| [#204](https://github.com/dodobrands/Peekie/pull/204) | n/a | Fix `pathsByBasename` dup-append when a file lives in multiple coverage targets (drops the multiplier on per-file warning/error counts) |
+| [#205](https://github.com/dodobrands/Peekie/pull/205) | n/a | Dedup Apple-emitted `#warning` twins inside `warnings[]` / `errors[]` (collapses paired records to the bucket-matching `IssueType`) |

--- a/Sources/PeekieSDK/Formatters/AttachmentsFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/AttachmentsFormatter.swift
@@ -90,7 +90,7 @@ public final class AttachmentsFormatter {
     {
         var rows = [AttachmentRow]()
         for module in report.modules.sorted(by: { $0.name < $1.name }) {
-            let rootLevelTests = module.rootLevelTests
+            let rootLevelTests = report.rootLevelTests(in: module)
                 .filtered(testResults: include)
                 .flatMap { repeatableTest in
                     repeatableTest.mergedTests()
@@ -103,7 +103,7 @@ public final class AttachmentsFormatter {
                     into: &rows
                 )
             }
-            for suite in module.suites {
+            for suite in report.suites(in: module) {
                 collectRows(
                     from: suite,
                     modulePrefix: module.name,

--- a/Sources/PeekieSDK/Formatters/CoverageFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/CoverageFormatter.swift
@@ -25,7 +25,7 @@ public final class CoverageFormatter {
     public func list(_ report: Report) -> String {
         let rows = report.modules
             .compactMap { module -> Row? in
-                guard let coverage = module.coverage else {
+                guard let coverage = report.coverage(of: module) else {
                     return nil
                 }
 
@@ -71,7 +71,7 @@ public final class CoverageFormatter {
             coverage = report.coverage
             modules = report.modules
                 .sorted { $0.name < $1.name }
-                .map(ModuleSnapshot.init)
+                .map { ModuleSnapshot($0, in: report) }
         }
 
         // MARK: Internal
@@ -83,12 +83,13 @@ public final class CoverageFormatter {
     private struct ModuleSnapshot: Encodable {
         // MARK: Lifecycle
 
-        init(_ module: Report.Module) {
+        init(_ module: Report.Module, in report: Report) {
+            let moduleCoverage = report.coverage(of: module)
             name = module.name
-            coverage = module.coverage?.coverage
-            coveredLines = module.coverage?.coveredLines
-            totalLines = module.coverage?.totalLines
-            files = module.files
+            coverage = moduleCoverage?.coverage
+            coveredLines = moduleCoverage?.coveredLines
+            totalLines = moduleCoverage?.totalLines
+            files = report.files(in: module)
                 .sorted { $0.name < $1.name }
                 .compactMap { file -> FileSnapshot? in
                     guard let coverage = file.coverage else {

--- a/Sources/PeekieSDK/Formatters/JsonFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/JsonFormatter.swift
@@ -97,6 +97,7 @@ private struct JSONReport: Encodable {
             .map {
                 JSONModule(
                     from: $0,
+                    in: report,
                     include: include,
                     includeDeviceDetails: includeDeviceDetails
                 )
@@ -116,15 +117,16 @@ private struct JSONModule: Encodable {
 
     init(
         from module: Report.Module,
+        in report: Report,
         include: [Report.Module.Suite.RepeatableTest.Test.Status],
         includeDeviceDetails: Bool
     ) {
         name = module.name
-        coverage = module.coverage.map { JSONCoverage(from: $0) }
-        files = module.files
+        coverage = report.coverage(of: module).map { JSONCoverage(from: $0) }
+        files = report.files(in: module)
             .sorted { $0.name < $1.name }
             .map { JSONFile(from: $0) }
-        rootLevelTests = module.rootLevelTests
+        rootLevelTests = report.rootLevelTests(in: module)
             .filtered(testResults: include)
             .sorted { $0.name < $1.name }
             .flatMap { repeatableTest in
@@ -132,7 +134,7 @@ private struct JSONModule: Encodable {
                     .filter { include.contains($0.status) }
                     .map { JSONTest(from: $0) }
             }
-        suites = module.suites
+        suites = report.suites(in: module)
             .sorted { $0.fullPath < $1.fullPath }
             .map {
                 JSONSuite(
@@ -168,6 +170,7 @@ private struct JSONReportFlat: Encodable {
             .map {
                 JSONModuleFlat(
                     from: $0,
+                    in: report,
                     include: include,
                     includeDeviceDetails: includeDeviceDetails
                 )
@@ -187,18 +190,19 @@ private struct JSONModuleFlat: Encodable {
 
     init(
         from module: Report.Module,
+        in report: Report,
         include: [Report.Module.Suite.RepeatableTest.Test.Status],
         includeDeviceDetails: Bool
     ) {
         name = module.name
-        coverage = module.coverage.map { JSONCoverage(from: $0) }
-        files = module.files
+        coverage = report.coverage(of: module).map { JSONCoverage(from: $0) }
+        files = report.files(in: module)
             .sorted { $0.name < $1.name }
             .map { JSONFile(from: $0) }
 
         var collected = [JSONQualifiedTest]()
 
-        let rootLevelTests = module.rootLevelTests
+        let rootLevelTests = report.rootLevelTests(in: module)
             .filtered(testResults: include)
             .flatMap { repeatableTest in
                 repeatableTest.mergedTests(filterDevice: includeDeviceDetails == false)
@@ -213,7 +217,7 @@ private struct JSONModuleFlat: Encodable {
             )
         }
 
-        for suite in module.suites {
+        for suite in report.suites(in: module) {
             Self.collectTests(
                 from: suite,
                 modulePrefix: module.name,

--- a/Sources/PeekieSDK/Formatters/ListFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/ListFormatter.swift
@@ -127,7 +127,7 @@ public final class ListFormatter {
             // Root-level @Tests first (so the bundle's loose tests stay above the
             // suite hierarchy in the human-readable view).
             let rootTests = mergedTests(
-                from: module.rootLevelTests,
+                from: report.rootLevelTests(in: module),
                 include: include,
                 includeDeviceDetails: includeDeviceDetails
             )
@@ -139,7 +139,7 @@ public final class ListFormatter {
                 ))
             }
 
-            let suiteSections = module.suites
+            let suiteSections = report.suites(in: module)
                 .flatMap { collectSuiteSections(
                     suite: $0,
                     moduleName: module.name,

--- a/Sources/PeekieSDK/Formatters/SonarFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/SonarFormatter.swift
@@ -54,7 +54,7 @@ public final class SonarFormatter {
             // these tests in the XML output. They still appear in the List/JSON
             // formatters which don't require path resolution.
 
-            let flatSuites = module.suites.flatMap { Self.flatten($0) }
+            let flatSuites = report.suites(in: module).flatMap { Self.flatten($0) }
             for suite in flatSuites.sorted(by: { $0.fullPath < $1.fullPath }) {
                 guard suite.repeatableTests.isEmpty == false else {
                     continue

--- a/Sources/PeekieSDK/Models/Report+Convenience+Suites.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience+Suites.swift
@@ -384,65 +384,54 @@ extension Report {
         return aliases
     }
 
-    static func buildModules(
-        files: [File],
+    /// Collects every target name we have any signal about (coverage targets
+    /// + test-bundle names from `testNodesByModule`). Returns the union in
+    /// stable lexicographic order — this drives `Report.modules` order.
+    static func moduleNames(
+        files _: [File],
         testNodesByModule: [String: BundleTestNodes],
         coverageReportDTO: CoverageReportDTO?
     )
-        -> [Module]
+        -> [String]
     {
-        var moduleNames = Set<String>()
+        var names = Set<String>()
         if let coverageReportDTO {
-            moduleNames.formUnion(coverageReportDTO.targets.map(\.name))
+            names.formUnion(coverageReportDTO.targets.map(\.name))
         }
-        moduleNames.formUnion(testNodesByModule.keys)
+        names.formUnion(testNodesByModule.keys)
+        return names.sorted()
+    }
 
-        return moduleNames.sorted().map { name in
-            buildModule(
-                name: name,
-                files: files,
-                testNodes: testNodesByModule[name],
-                coverageReportDTO: coverageReportDTO
+    /// Builds `[targetName: Module.Coverage]` from the coverage DTO, dropping
+    /// targets with `executableLines == 0` to match the legacy
+    /// `Module.coverage == nil` shape. Only names listed in `moduleNames` are
+    /// considered — orphan coverage targets aren't expected since
+    /// ``moduleNames(files:testNodesByModule:coverageReportDTO:)`` already
+    /// unions them in.
+    static func coverageByModule(
+        for moduleNames: [String],
+        coverageReportDTO: CoverageReportDTO?
+    )
+        -> [String: Coverage]
+    {
+        guard let coverageReportDTO else {
+            return [:]
+        }
+
+        let nameSet = Set(moduleNames)
+        var result = [String: Coverage]()
+        for target in coverageReportDTO.targets where nameSet.contains(target.name) {
+            guard target.executableLines > 0 else {
+                continue
+            }
+
+            result[target.name] = Coverage(
+                coveredLines: target.coveredLines,
+                totalLines: target.executableLines,
+                coverage: target.lineCoverage
             )
         }
-    }
-
-    private static func buildModule(
-        name: String,
-        files: [File],
-        testNodes: BundleTestNodes?,
-        coverageReportDTO: CoverageReportDTO?
-    )
-        -> Module
-    {
-        let moduleFiles = files.filter { $0.module == name }
-        let moduleCoverage = moduleCoverage(for: name, coverageReportDTO: coverageReportDTO)
-        return Module(
-            name: name,
-            files: moduleFiles,
-            coverage: moduleCoverage,
-            rootLevelTests: testNodes?.rootLevelTests ?? [],
-            suites: testNodes?.suites ?? []
-        )
-    }
-
-    private static func moduleCoverage(
-        for name: String,
-        coverageReportDTO: CoverageReportDTO?
-    )
-        -> Coverage?
-    {
-        guard let target = coverageReportDTO?.targets.first(where: { $0.name == name }),
-              target.executableLines > 0
-        else {
-            return nil
-        }
-
-        return Coverage(
-            coveredLines: target.coveredLines,
-            totalLines: target.executableLines,
-            coverage: target.lineCoverage
-        )
+        return result
     }
 
     // MARK: - Total coverage

--- a/Sources/PeekieSDK/Models/Report+Convenience.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience.swift
@@ -49,11 +49,12 @@ extension Report {
     /// Initializes a new instance of the `Report` using the provided `xcresultPath`.
     ///
     /// `files` is built as the primary index — every file the bundle has any signal about
-    /// (coverage, warnings, errors) appears exactly once. `modules` is a projection: one
-    /// entry per known target name, files filtered by `File.module`, test suites
-    /// attached by target. Files belonging to test-less targets or to project-level
-    /// build issues with no module signal still appear in `files` (with `module == nil`),
-    /// so their warnings/errors are not silently lost.
+    /// (coverage, warnings, errors) appears exactly once. `modules` is a list of thin
+    /// handles — one entry per known target name. Module-scoped data (files, coverage,
+    /// suites, root-level tests) lives on the `Report` itself keyed by target name and
+    /// is reached via the `…(in:)` lookups. Files belonging to test-less targets or to
+    /// project-level build issues with no module signal still appear in `files` (with
+    /// `module == nil`), so their warnings/errors are not silently lost.
     ///
     /// - Parameters:
     ///   - xcresultPath: The file URL of the `.xcresult` file to parse.
@@ -61,8 +62,9 @@ extension Report {
     ///   - includeWarnings: Whether to parse and include build warnings/errors. Defaults to `true`.
     ///   - includeTests: Whether to parse and include test results (suites/cases).
     ///     Defaults to `true`. Disabling skips the slowest `xcresulttool` call and is
-    ///     useful for warnings-only flows; in that case `Module.suites` is empty but
-    ///     `files`, `Module.files`, and warnings/errors remain populated.
+    ///     useful for warnings-only flows; in that case `suitesByModule` /
+    ///     `rootLevelTestsByModule` are empty but `files`, per-module file lookups,
+    ///     and warnings/errors remain populated.
     ///   - attachments: Whether to extract test attachments to disk and surface them
     ///     on `Test.attachments`. Defaults to `.skip`. Implies `includeTests == true`
     ///     to have anything to attach to; passing `.extractTo(_)` with
@@ -75,48 +77,21 @@ extension Report {
         includeTests: Bool = true,
         attachments: AttachmentPolicy = .skip
     ) async throws {
-        // Fire the three read-only `xcrun` subprocesses concurrently — each
-        // independently reads the same .xcresult bundle. The dominant cost
-        // (>90% wall-clock on real fixtures) lives in those processes, so
-        // overlapping them is the largest remaining win after Shell switched
-        // to `bytes(limit:)`.
-        //
-        // `xcresulttool export attachments` is sequenced AFTER `get
-        // test-results`: both commands mutate the bundle's internal
-        // sqlite cache and Apple's tool conflicts with itself when two
-        // instances race for the same xcresult (database.sqlite3 → bundle
-        // copy). The conflict is reproducible by parallel snapshot tests.
-        // Sequencing only this pair loses ~0.2-0.5s on the attachments path
-        // but keeps coverage/warnings overlap intact.
-        async let testResultsTask: TestResultsDTO? =
-            includeTests ? TestResultsDTO(from: xcresultPath) : nil
-        async let buildResultsTask: BuildResultsDTO? =
-            includeWarnings ? BuildResultsDTO(from: xcresultPath) : nil
-        async let coverageReportTask: CoverageReportDTO? =
-            includeCoverage ? CoverageReportDTO(from: xcresultPath) : nil
+        let dtos = try await Self.loadDTOs(
+            xcresultPath: xcresultPath,
+            includeTests: includeTests,
+            includeWarnings: includeWarnings,
+            includeCoverage: includeCoverage
+        )
+        let testResultsDTO = dtos.testResults
+        let buildResultsDTO = dtos.buildResults
+        let coverageReportDTO = dtos.coverage
 
-        let testResultsDTO = try await testResultsTask
-        let buildResultsDTO = try await buildResultsTask
-        let coverageReportDTO = try await coverageReportTask
-
-        let attachmentLookup: [AttachmentLookupKey: [Module.Suite.RepeatableTest.Test.Attachment]]
-        if includeTests, case .extractTo(let outputDirectory, let testID) = attachments {
-            try FileManager.default.createDirectory(
-                at: outputDirectory,
-                withIntermediateDirectories: true
-            )
-            let dto = try await AttachmentsDTO(
-                from: xcresultPath,
-                outputDirectory: outputDirectory,
-                testID: testID
-            )
-            attachmentLookup = Self.buildAttachmentLookup(
-                dto: dto,
-                outputDirectory: outputDirectory
-            )
-        } else {
-            attachmentLookup = [:]
-        }
+        let attachmentLookup = try await Self.resolveAttachmentLookup(
+            xcresultPath: xcresultPath,
+            includeTests: includeTests,
+            attachments: attachments
+        )
 
         let (warningsByFileName, errorsByFileName) = await Self
             .parseIssueMaps(from: buildResultsDTO)
@@ -134,11 +109,18 @@ extension Report {
         )
 
         self.files = files
-        modules = Self.buildModules(
+        let moduleNames = Self.moduleNames(
             files: files,
             testNodesByModule: testNodesByModule,
             coverageReportDTO: coverageReportDTO
         )
+        modules = moduleNames.map { Module(name: $0) }
+        coverageByModule = Self.coverageByModule(
+            for: moduleNames,
+            coverageReportDTO: coverageReportDTO
+        )
+        suitesByModule = testNodesByModule.mapValues(\.suites)
+        rootLevelTestsByModule = testNodesByModule.mapValues(\.rootLevelTests)
         coverage = Self.computeTotalCoverage(
             includeCoverage: includeCoverage,
             coverageReportDTO: coverageReportDTO,
@@ -146,7 +128,82 @@ extension Report {
         )
     }
 
+    // MARK: - DTO loading
+
+    /// Loads the three read-only `xcrun` outputs concurrently. Each subprocess
+    /// independently reads the same `.xcresult` bundle, and the dominant cost
+    /// (>90% wall-clock on real fixtures) lives in those processes — so
+    /// overlapping them is the largest remaining win after `Shell` switched to
+    /// `bytes(limit:)`. `xcresulttool export attachments` is sequenced AFTER
+    /// `get test-results` separately in
+    /// ``resolveAttachmentLookup(xcresultPath:includeTests:attachments:)``:
+    /// both commands mutate the bundle's internal `sqlite` cache and Apple's
+    /// tool conflicts with itself when two instances race for the same
+    /// xcresult (`database.sqlite3` → bundle copy). Sequencing only that pair
+    /// loses 0.2-0.5s on the attachments path but keeps coverage/warnings
+    /// overlap intact.
+    private struct LoadedDTOs {
+        let testResults: TestResultsDTO?
+        let buildResults: BuildResultsDTO?
+        let coverage: CoverageReportDTO?
+    }
+
+    private static func loadDTOs(
+        xcresultPath: URL,
+        includeTests: Bool,
+        includeWarnings: Bool,
+        includeCoverage: Bool
+    ) async throws
+        -> LoadedDTOs
+    {
+        async let testResultsTask: TestResultsDTO? =
+            includeTests ? TestResultsDTO(from: xcresultPath) : nil
+        async let buildResultsTask: BuildResultsDTO? =
+            includeWarnings ? BuildResultsDTO(from: xcresultPath) : nil
+        async let coverageReportTask: CoverageReportDTO? =
+            includeCoverage ? CoverageReportDTO(from: xcresultPath) : nil
+
+        return try await LoadedDTOs(
+            testResults: testResultsTask,
+            buildResults: buildResultsTask,
+            coverage: coverageReportTask
+        )
+    }
+
     // MARK: - Attachment lookup
+
+    /// Resolves the `(testIdentifierURL, repetitionNumber) → [Attachment]` map
+    /// the rest of the parse joins against. Returns an empty map when the
+    /// caller chose `.skip` or `includeTests == false`; otherwise creates the
+    /// output directory, runs `xcresulttool export attachments`, and folds the
+    /// manifest via ``buildAttachmentLookup(dto:outputDirectory:)``.
+    private static func resolveAttachmentLookup(
+        xcresultPath: URL,
+        includeTests: Bool,
+        attachments: AttachmentPolicy
+    ) async throws
+        -> [AttachmentLookupKey: [Module.Suite.RepeatableTest.Test.Attachment]]
+    {
+        guard includeTests,
+              case .extractTo(let outputDirectory, let testID) = attachments
+        else {
+            return [:]
+        }
+
+        try FileManager.default.createDirectory(
+            at: outputDirectory,
+            withIntermediateDirectories: true
+        )
+        let dto = try await AttachmentsDTO(
+            from: xcresultPath,
+            outputDirectory: outputDirectory,
+            testID: testID
+        )
+        return buildAttachmentLookup(
+            dto: dto,
+            outputDirectory: outputDirectory
+        )
+    }
 
     /// Folds the flat manifest from `xcresulttool export attachments` into a
     /// `(testIdentifierURL, repetitionNumber) → [Attachment]` map. Entries

--- a/Sources/PeekieSDK/Models/Report.swift
+++ b/Sources/PeekieSDK/Models/Report.swift
@@ -6,11 +6,13 @@ import Foundation
 ///
 /// `files` is the primary index — every file we have any signal about (coverage,
 /// warnings, errors) lives here exactly once, regardless of which target it
-/// belongs to. `modules` is a projection over `files` for the subset where a
-/// target name is known. Build issues with no module signal (`xcresulttool`
-/// doesn't currently surface `producingTarget` for them) still surface — they
-/// appear in `files` with `File.module == nil` and are reachable via
-/// `Report.warnings` / `Report.errors`.
+/// belongs to. `modules` is a thin handle list: one ``Module`` per identifiable
+/// target name. Module-scoped data (files, coverage, suites, root-level tests)
+/// lives on `Report` keyed by target name and is reached via the `…(in:)`
+/// lookups. Build issues with no module signal (`xcresulttool` doesn't currently
+/// surface `producingTarget` for them) still surface — they appear in `files`
+/// with `File.module == nil` and are reachable via `Report.warnings` /
+/// `Report.errors`.
 public struct Report {
     // MARK: Lifecycle
 
@@ -20,11 +22,17 @@ public struct Report {
     public init(
         files: [File],
         modules: [Module],
-        coverage: Double?
+        coverage: Double?,
+        coverageByModule: [String: Coverage] = [:],
+        suitesByModule: [String: [Module.Suite]] = [:],
+        rootLevelTestsByModule: [String: Set<Module.Suite.RepeatableTest>] = [:]
     ) {
         self.files = files
         self.modules = modules
         self.coverage = coverage
+        self.coverageByModule = coverageByModule
+        self.suitesByModule = suitesByModule
+        self.rootLevelTestsByModule = rootLevelTestsByModule
     }
 
     // MARK: Public
@@ -32,14 +40,29 @@ public struct Report {
     /// Every file the bundle has any signal about (coverage, warnings, errors).
     public let files: [File]
 
-    /// Module projection — one entry per target name we could identify
-    /// (from coverage or from tests). Files whose target is unknown are
-    /// **not** represented here; reach them via `files`.
+    /// One handle per identifiable target name (from coverage or from tests).
+    /// Files whose target is unknown are **not** represented here; reach them
+    /// via `files`. Module-scoped data is on `Report` — see ``files(in:)``,
+    /// ``coverage(of:)``, ``suites(in:)``, ``rootLevelTests(in:)``.
     public let modules: [Module]
 
     /// Total code coverage percentage (0.0 to 1.0).
     /// - Note: Read directly from xcresult coverage data (not calculated from files).
     public let coverage: Double?
+
+    /// Target-level aggregate coverage keyed by ``Module/name``. Empty entries
+    /// are omitted (a target with `executableLines == 0` is dropped at parse
+    /// time, matching the legacy `Module.coverage == nil` shape).
+    public let coverageByModule: [String: Coverage]
+
+    /// Top-level test suites keyed by ``Module/name``. Empty list = the target
+    /// had no tests (or `includeTests: false` at parse time).
+    public let suitesByModule: [String: [Module.Suite]]
+
+    /// Swift Testing root-level `@Test` functions keyed by ``Module/name``.
+    /// Empty set = no `@Test`s declared outside `@Suite` types (or
+    /// `includeTests: false`).
+    public let rootLevelTestsByModule: [String: Set<Module.Suite.RepeatableTest>]
 
     /// All warnings from all files in this report.
     public var warnings: [File.Issue] {
@@ -49,6 +72,46 @@ public struct Report {
     /// All errors from all files in this report.
     public var errors: [File.Issue] {
         files.flatMap(\.errors)
+    }
+
+    /// Files whose ``File/module`` matches the given module's `name`.
+    /// Order matches `files` (sorted by path-or-name at parse time).
+    public func files(in module: Module) -> [File] {
+        files.filter { $0.module == module.name }
+    }
+
+    /// Target-level aggregate coverage for the given module, when xcresult
+    /// reported one. Returns `nil` for targets with no executable lines, or
+    /// for handles whose name isn't in the report (callers shouldn't see
+    /// orphan handles in practice — `modules` is built only from names we
+    /// observe).
+    public func coverage(of module: Module) -> Coverage? {
+        coverageByModule[module.name]
+    }
+
+    /// Top-level test suites this target ran. Nested suites live inside their
+    /// parents via ``Module/Suite/nestedSuites`` — only the outermost suites
+    /// appear here.
+    public func suites(in module: Module) -> [Module.Suite] {
+        suitesByModule[module.name] ?? []
+    }
+
+    /// Swift Testing `@Test` functions declared at the bundle root, i.e.
+    /// outside any `@Suite` type. Empty for legacy `XCTest`-only bundles,
+    /// where every test is wrapped in an `XCTestCase` subclass that surfaces
+    /// as a `Test Suite` node.
+    public func rootLevelTests(in module: Module) -> Set<Module.Suite.RepeatableTest> {
+        rootLevelTestsByModule[module.name] ?? []
+    }
+
+    /// All warnings from files belonging to the given module.
+    public func warnings(in module: Module) -> [File.Issue] {
+        files(in: module).flatMap(\.warnings)
+    }
+
+    /// All errors from files belonging to the given module.
+    public func errors(in module: Module) -> [File.Issue] {
+        files(in: module).flatMap(\.errors)
     }
 }
 
@@ -110,64 +173,31 @@ public extension Report {
         }
     }
 
-    /// Projection over `Report.files` grouped by target name.
+    /// Thin handle to a target named by xcresult (coverage or test bundle).
     ///
-    /// `Module` is built from coverage targets and test bundles — the two data
-    /// sources xcresult emits that name a target. A module's `files` slice is
-    /// every `Report.files` entry whose `File.module` matches; `suites` is the
-    /// tests xcresult reported for that target.
+    /// `Module` carries only the target name. File listings, target-level
+    /// coverage, suites and root-level tests live on ``Report`` as dictionaries
+    /// keyed by `name`. Use the report-side lookups to reach them:
+    /// ``Report/files(in:)``, ``Report/coverage(of:)``, ``Report/suites(in:)``,
+    /// ``Report/rootLevelTests(in:)``, ``Report/warnings(in:)``,
+    /// ``Report/errors(in:)``.
+    ///
+    /// This shape replaces the 5.x `Module` that materialized `files` etc. as
+    /// stored properties — that design duplicated `File` values across
+    /// `Report.files` and `Module.files`, made `report.warnings +
+    /// modules.flatMap(\.warnings)` double-count, and burdened snapshots with
+    /// two copies of every file's issues.
     struct Module: Hashable {
         // MARK: Lifecycle
 
-        public init(
-            name: String,
-            files: [File] = [],
-            coverage: Coverage? = nil,
-            rootLevelTests: Set<Suite.RepeatableTest> = [],
-            suites: [Suite] = []
-        ) {
+        public init(name: String) {
             self.name = name
-            self.files = files
-            self.coverage = coverage
-            self.rootLevelTests = rootLevelTests
-            self.suites = suites
         }
 
         // MARK: Public
 
         /// Target name (e.g., "Bonuses", "PeekieTests").
         public let name: String
-
-        /// Files in this report whose `File.module == self.name`.
-        public let files: [File]
-
-        /// Target-level coverage when xcresult reported one.
-        public let coverage: Coverage?
-
-        /// Swift Testing `@Test` functions declared at the bundle root, i.e. outside
-        /// any `@Suite` type. These appear in xcresult JSON as `Test Case` nodes
-        /// directly under the `Unit test bundle` node. Empty for legacy `XCTest`-only
-        /// bundles, where every test is wrapped in an `XCTestCase` subclass that
-        /// surfaces as a `Test Suite` node.
-        public let rootLevelTests: Set<Suite.RepeatableTest>
-
-        /// Top-level test suites this target ran. Nested suites live inside their
-        /// parents via `Suite.nestedSuites` — only the outermost suites appear here.
-        public let suites: [Suite]
-
-        /// All warnings from all files in this module.
-        public var warnings: [File.Issue] {
-            files.flatMap(\.warnings)
-        }
-
-        /// All errors from all files in this module.
-        public var errors: [File.Issue] {
-            files.flatMap(\.errors)
-        }
-
-        public static func ==(lhs: Self, rhs: Self) -> Bool {
-            lhs.name == rhs.name
-        }
 
         public func hash(into hasher: inout Hasher) {
             hasher.combine(name)

--- a/Sources/PeekieTestHelpers/Report+TestHelpers.swift
+++ b/Sources/PeekieTestHelpers/Report+TestHelpers.swift
@@ -7,7 +7,10 @@ public extension Report {
     static func testMake(
         files: [File] = [],
         modules: [Module] = [],
-        coverage: Double? = nil
+        coverage: Double? = nil,
+        coverageByModule: [String: Coverage] = [:],
+        suitesByModule: [String: [Module.Suite]] = [:],
+        rootLevelTestsByModule: [String: Set<Module.Suite.RepeatableTest>] = [:]
     )
         -> Self
     {
@@ -32,28 +35,17 @@ public extension Report {
         return .init(
             files: files,
             modules: modules,
-            coverage: calculatedCoverage
+            coverage: calculatedCoverage,
+            coverageByModule: coverageByModule,
+            suitesByModule: suitesByModule,
+            rootLevelTestsByModule: rootLevelTestsByModule
         )
     }
 }
 
 public extension Report.Module {
-    static func testMake(
-        name: String = "",
-        files: [Report.File] = [],
-        coverage: Report.Coverage? = nil,
-        rootLevelTests: Set<Suite.RepeatableTest> = [],
-        suites: [Suite] = []
-    )
-        -> Self
-    {
-        .init(
-            name: name,
-            files: files,
-            coverage: coverage,
-            rootLevelTests: rootLevelTests,
-            suites: suites
-        )
+    static func testMake(name: String = "") -> Self {
+        .init(name: name)
     }
 }
 

--- a/Tests/PeekieTests/ReportIncludeTestsFlagTests.swift
+++ b/Tests/PeekieTests/ReportIncludeTestsFlagTests.swift
@@ -17,7 +17,7 @@ struct ReportIncludeTestsFlagTests {
             includeTests: false
         )
 
-        let suitesTotal = report.modules.reduce(0) { $0 + $1.suites.count }
+        let suitesTotal = report.modules.reduce(0) { $0 + report.suites(in: $1).count }
         #expect(suitesTotal == 0, "expected zero suites when includeTests is false")
 
         // For fixtures that have coverage data, modules and files are still populated.
@@ -40,8 +40,8 @@ struct ReportIncludeTestsFlagTests {
         // Coverage is nil
         #expect(report.coverage == nil)
         // Modules with suites are absent (no tests parsed)
-        // swiftformat:disable:next preferKeyPath
-        #expect(report.modules.allSatisfy { $0.suites.isEmpty })
+        let suitesEmpty = report.suitesByModule.values.allSatisfy(\.isEmpty)
+        #expect(suitesEmpty)
         // Files only show up if the fixture has build warnings; not all fixtures do,
         // but the call must succeed and return a well-formed Report.
         _ = report.files

--- a/Tests/PeekieTests/SonarFormatterSnapshotTests.swift
+++ b/Tests/PeekieTests/SonarFormatterSnapshotTests.swift
@@ -65,8 +65,8 @@ struct SonarFormatterSnapshotTests {
         // the full suite tree so nested suites (e.g. `InnerSuite` inside
         // `OuterSuite`) also get a backing file for path resolution.
         let testSuites = Set(
-            report.modules.flatMap {
-                $0.suites
+            report.modules.flatMap { module in
+                report.suites(in: module)
                     .flatMap { Self.flattenSuites($0) }
                     .filter { $0.repeatableTests.isEmpty == false }
                     .map(\.name)

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-iOS.txt
@@ -1,6 +1,19 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6564748201438849
+  ▿ coverageByModule: 2 key/value pairs
+    ▿ (2 elements)
+      - key: "Calculator"
+      ▿ value: Coverage
+        - coverage: 0.1509433962264151
+        - coveredLines: 16
+        - totalLines: 106
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: Coverage
+        - coverage: 0.7755555555555556
+        - coveredLines: 349
+        - totalLines: 450
   ▿ files: 6 elements
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -232,233 +245,15 @@
           - type: IssueType.swiftCompilerWarning
   ▿ modules: 3 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.1509433962264151
-          - coveredLines: 16
-          - totalLines: 106
-      - files: 0 elements
       - name: "Calculator"
-      - rootLevelTests: 0 members
-      - suites: 0 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.7755555555555556
-          - coveredLines: 349
-          - totalLines: 450
-      ▿ files: 5 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.47058823529411764
-              - coveredLines: 16
-              - totalLines: 34
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "Calculator.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "NumberHelper.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "WarningsCatalog.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/WarningsCatalog.swift"
-          ▿ warnings: 8 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 22
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 22
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 23
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 23
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 24
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 24
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 40
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 40
-              - message: "Code after \'return\' will never be executed"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 49
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 49
-              - message: "Result of call to \'unusedResultProducer()\' is unused"
-              - type: IssueType.noUsage
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 14
-                  ▿ endLine: Optional<Int>
-                    - some: 56
-                  ▿ startColumn: Optional<Int>
-                    - some: 14
-                  - startLine: 56
-              - message: "String interpolation produces a debug description for an optional value; did you mean to make this explicit?"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 13
-                  ▿ endLine: Optional<Int>
-                    - some: 65
-                  ▿ startColumn: Optional<Int>
-                    - some: 13
-                  - startLine: 65
-              - message: "Conditional cast from \'Bar\' to \'Foo\' always succeeds"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 8
-                  ▿ endLine: Optional<Int>
-                    - some: 89
-                  ▿ startColumn: Optional<Int>
-                    - some: 8
-                  - startLine: 89
-              - message: "No calls to throwing functions occur within \'try\' expression"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9456521739130435
-              - coveredLines: 174
-              - totalLines: 184
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "SwiftTestingTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.99375
-              - coveredLines: 159
-              - totalLines: 160
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "XCTestTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 19
-                  ▿ endLine: Optional<Int>
-                    - some: 113
-                  ▿ startColumn: Optional<Int>
-                    - some: 19
-                  - startLine: 113
-              - message: "Call to main actor-isolated class method \'runActivity(named:block:)\' in a synchronous nonisolated context"
-              - type: IssueType.actorIsolatedCall
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
-      ▿ rootLevelTests: 10 members
+    ▿ Module
+      - name: "StringUtils"
+  ▿ rootLevelTestsByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: 10 members
         ▿ RepeatableTest
           - name: "2 + 3 = 5"
           ▿ tests: 3 elements
@@ -1065,7 +860,10 @@
                   - type: NodeType.repetition
               - skipMessage: Optional<String>.none
               - status: Status.success
-      ▿ suites: 3 elements
+  ▿ suitesByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: 3 elements
         ▿ Suite
           - fullPath: "XCTestTests"
           - name: "XCTestTests"
@@ -2884,9 +2682,3 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-    ▿ Module
-      - coverage: Optional<Coverage>.none
-      - files: 0 elements
-      - name: "StringUtils"
-      - rootLevelTests: 0 members
-      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-macOS.txt
@@ -1,6 +1,19 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6564748201438849
+  ▿ coverageByModule: 2 key/value pairs
+    ▿ (2 elements)
+      - key: "Calculator"
+      ▿ value: Coverage
+        - coverage: 0.1509433962264151
+        - coveredLines: 16
+        - totalLines: 106
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: Coverage
+        - coverage: 0.7755555555555556
+        - coveredLines: 349
+        - totalLines: 450
   ▿ files: 6 elements
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -232,233 +245,15 @@
           - type: IssueType.swiftCompilerWarning
   ▿ modules: 3 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.1509433962264151
-          - coveredLines: 16
-          - totalLines: 106
-      - files: 0 elements
       - name: "Calculator"
-      - rootLevelTests: 0 members
-      - suites: 0 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.7755555555555556
-          - coveredLines: 349
-          - totalLines: 450
-      ▿ files: 5 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.47058823529411764
-              - coveredLines: 16
-              - totalLines: 34
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "Calculator.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "NumberHelper.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "WarningsCatalog.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/WarningsCatalog.swift"
-          ▿ warnings: 8 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 22
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 22
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 23
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 23
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 24
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 24
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 40
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 40
-              - message: "Code after \'return\' will never be executed"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 49
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 49
-              - message: "Result of call to \'unusedResultProducer()\' is unused"
-              - type: IssueType.noUsage
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 14
-                  ▿ endLine: Optional<Int>
-                    - some: 56
-                  ▿ startColumn: Optional<Int>
-                    - some: 14
-                  - startLine: 56
-              - message: "String interpolation produces a debug description for an optional value; did you mean to make this explicit?"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 13
-                  ▿ endLine: Optional<Int>
-                    - some: 65
-                  ▿ startColumn: Optional<Int>
-                    - some: 13
-                  - startLine: 65
-              - message: "Conditional cast from \'Bar\' to \'Foo\' always succeeds"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 8
-                  ▿ endLine: Optional<Int>
-                    - some: 89
-                  ▿ startColumn: Optional<Int>
-                    - some: 8
-                  - startLine: 89
-              - message: "No calls to throwing functions occur within \'try\' expression"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9456521739130435
-              - coveredLines: 174
-              - totalLines: 184
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "SwiftTestingTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.99375
-              - coveredLines: 159
-              - totalLines: 160
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "XCTestTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 19
-                  ▿ endLine: Optional<Int>
-                    - some: 113
-                  ▿ startColumn: Optional<Int>
-                    - some: 19
-                  - startLine: 113
-              - message: "Call to main actor-isolated class method \'runActivity(named:block:)\' in a synchronous nonisolated context"
-              - type: IssueType.actorIsolatedCall
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
-      ▿ rootLevelTests: 10 members
+    ▿ Module
+      - name: "StringUtils"
+  ▿ rootLevelTestsByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: 10 members
         ▿ RepeatableTest
           - name: "2 + 3 = 5"
           ▿ tests: 3 elements
@@ -1065,7 +860,10 @@
                   - type: NodeType.repetition
               - skipMessage: Optional<String>.none
               - status: Status.success
-      ▿ suites: 3 elements
+  ▿ suitesByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: 3 elements
         ▿ Suite
           - fullPath: "XCTestTests"
           - name: "XCTestTests"
@@ -2884,9 +2682,3 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-    ▿ Module
-      - coverage: Optional<Coverage>.none
-      - files: 0 elements
-      - name: "StringUtils"
-      - rootLevelTests: 0 members
-      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-tvOS.txt
@@ -1,6 +1,19 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6564748201438849
+  ▿ coverageByModule: 2 key/value pairs
+    ▿ (2 elements)
+      - key: "Calculator"
+      ▿ value: Coverage
+        - coverage: 0.1509433962264151
+        - coveredLines: 16
+        - totalLines: 106
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: Coverage
+        - coverage: 0.7755555555555556
+        - coveredLines: 349
+        - totalLines: 450
   ▿ files: 6 elements
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -232,233 +245,15 @@
           - type: IssueType.swiftCompilerWarning
   ▿ modules: 3 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.1509433962264151
-          - coveredLines: 16
-          - totalLines: 106
-      - files: 0 elements
       - name: "Calculator"
-      - rootLevelTests: 0 members
-      - suites: 0 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.7755555555555556
-          - coveredLines: 349
-          - totalLines: 450
-      ▿ files: 5 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.47058823529411764
-              - coveredLines: 16
-              - totalLines: 34
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "Calculator.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "NumberHelper.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "WarningsCatalog.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/WarningsCatalog.swift"
-          ▿ warnings: 8 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 22
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 22
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 23
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 23
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 24
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 24
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 40
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 40
-              - message: "Code after \'return\' will never be executed"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 49
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 49
-              - message: "Result of call to \'unusedResultProducer()\' is unused"
-              - type: IssueType.noUsage
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 14
-                  ▿ endLine: Optional<Int>
-                    - some: 56
-                  ▿ startColumn: Optional<Int>
-                    - some: 14
-                  - startLine: 56
-              - message: "String interpolation produces a debug description for an optional value; did you mean to make this explicit?"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 13
-                  ▿ endLine: Optional<Int>
-                    - some: 65
-                  ▿ startColumn: Optional<Int>
-                    - some: 13
-                  - startLine: 65
-              - message: "Conditional cast from \'Bar\' to \'Foo\' always succeeds"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 8
-                  ▿ endLine: Optional<Int>
-                    - some: 89
-                  ▿ startColumn: Optional<Int>
-                    - some: 8
-                  - startLine: 89
-              - message: "No calls to throwing functions occur within \'try\' expression"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9456521739130435
-              - coveredLines: 174
-              - totalLines: 184
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "SwiftTestingTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.99375
-              - coveredLines: 159
-              - totalLines: 160
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "XCTestTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 19
-                  ▿ endLine: Optional<Int>
-                    - some: 113
-                  ▿ startColumn: Optional<Int>
-                    - some: 19
-                  - startLine: 113
-              - message: "Call to main actor-isolated class method \'runActivity(named:block:)\' in a synchronous nonisolated context"
-              - type: IssueType.actorIsolatedCall
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
-      ▿ rootLevelTests: 10 members
+    ▿ Module
+      - name: "StringUtils"
+  ▿ rootLevelTestsByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: 10 members
         ▿ RepeatableTest
           - name: "2 + 3 = 5"
           ▿ tests: 3 elements
@@ -1065,7 +860,10 @@
                   - type: NodeType.repetition
               - skipMessage: Optional<String>.none
               - status: Status.success
-      ▿ suites: 3 elements
+  ▿ suitesByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: 3 elements
         ▿ Suite
           - fullPath: "XCTestTests"
           - name: "XCTestTests"
@@ -2884,9 +2682,3 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-    ▿ Module
-      - coverage: Optional<Coverage>.none
-      - files: 0 elements
-      - name: "StringUtils"
-      - rootLevelTests: 0 members
-      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-visionOS.txt
@@ -1,6 +1,19 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6564748201438849
+  ▿ coverageByModule: 2 key/value pairs
+    ▿ (2 elements)
+      - key: "Calculator"
+      ▿ value: Coverage
+        - coverage: 0.1509433962264151
+        - coveredLines: 16
+        - totalLines: 106
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: Coverage
+        - coverage: 0.7755555555555556
+        - coveredLines: 349
+        - totalLines: 450
   ▿ files: 6 elements
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -232,233 +245,15 @@
           - type: IssueType.swiftCompilerWarning
   ▿ modules: 3 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.1509433962264151
-          - coveredLines: 16
-          - totalLines: 106
-      - files: 0 elements
       - name: "Calculator"
-      - rootLevelTests: 0 members
-      - suites: 0 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.7755555555555556
-          - coveredLines: 349
-          - totalLines: 450
-      ▿ files: 5 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.47058823529411764
-              - coveredLines: 16
-              - totalLines: 34
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "Calculator.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "NumberHelper.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "WarningsCatalog.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/WarningsCatalog.swift"
-          ▿ warnings: 8 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 22
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 22
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 23
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 23
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 24
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 24
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 40
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 40
-              - message: "Code after \'return\' will never be executed"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 49
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 49
-              - message: "Result of call to \'unusedResultProducer()\' is unused"
-              - type: IssueType.noUsage
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 14
-                  ▿ endLine: Optional<Int>
-                    - some: 56
-                  ▿ startColumn: Optional<Int>
-                    - some: 14
-                  - startLine: 56
-              - message: "String interpolation produces a debug description for an optional value; did you mean to make this explicit?"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 13
-                  ▿ endLine: Optional<Int>
-                    - some: 65
-                  ▿ startColumn: Optional<Int>
-                    - some: 13
-                  - startLine: 65
-              - message: "Conditional cast from \'Bar\' to \'Foo\' always succeeds"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 8
-                  ▿ endLine: Optional<Int>
-                    - some: 89
-                  ▿ startColumn: Optional<Int>
-                    - some: 8
-                  - startLine: 89
-              - message: "No calls to throwing functions occur within \'try\' expression"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9456521739130435
-              - coveredLines: 174
-              - totalLines: 184
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "SwiftTestingTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.99375
-              - coveredLines: 159
-              - totalLines: 160
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "XCTestTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 19
-                  ▿ endLine: Optional<Int>
-                    - some: 113
-                  ▿ startColumn: Optional<Int>
-                    - some: 19
-                  - startLine: 113
-              - message: "Call to main actor-isolated class method \'runActivity(named:block:)\' in a synchronous nonisolated context"
-              - type: IssueType.actorIsolatedCall
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
-      ▿ rootLevelTests: 10 members
+    ▿ Module
+      - name: "StringUtils"
+  ▿ rootLevelTestsByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: 10 members
         ▿ RepeatableTest
           - name: "2 + 3 = 5"
           ▿ tests: 3 elements
@@ -1065,7 +860,10 @@
                   - type: NodeType.repetition
               - skipMessage: Optional<String>.none
               - status: Status.success
-      ▿ suites: 3 elements
+  ▿ suitesByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: 3 elements
         ▿ Suite
           - fullPath: "XCTestTests"
           - name: "XCTestTests"
@@ -2884,9 +2682,3 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-    ▿ Module
-      - coverage: Optional<Coverage>.none
-      - files: 0 elements
-      - name: "StringUtils"
-      - rootLevelTests: 0 members
-      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.SPM-watchOS.txt
@@ -1,6 +1,19 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.6564748201438849
+  ▿ coverageByModule: 2 key/value pairs
+    ▿ (2 elements)
+      - key: "Calculator"
+      ▿ value: Coverage
+        - coverage: 0.1509433962264151
+        - coveredLines: 16
+        - totalLines: 106
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: Coverage
+        - coverage: 0.7755555555555556
+        - coveredLines: 349
+        - totalLines: 450
   ▿ files: 6 elements
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -232,233 +245,15 @@
           - type: IssueType.swiftCompilerWarning
   ▿ modules: 3 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.1509433962264151
-          - coveredLines: 16
-          - totalLines: 106
-      - files: 0 elements
       - name: "Calculator"
-      - rootLevelTests: 0 members
-      - suites: 0 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.7755555555555556
-          - coveredLines: 349
-          - totalLines: 450
-      ▿ files: 5 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.47058823529411764
-              - coveredLines: 16
-              - totalLines: 34
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "Calculator.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/Calculator.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "NumberHelper.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "WarningsCatalog.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Sources/Calculator/WarningsCatalog.swift"
-          ▿ warnings: 8 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 22
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 22
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 23
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 23
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 24
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 24
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 40
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 40
-              - message: "Code after \'return\' will never be executed"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 49
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 49
-              - message: "Result of call to \'unusedResultProducer()\' is unused"
-              - type: IssueType.noUsage
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 14
-                  ▿ endLine: Optional<Int>
-                    - some: 56
-                  ▿ startColumn: Optional<Int>
-                    - some: 14
-                  - startLine: 56
-              - message: "String interpolation produces a debug description for an optional value; did you mean to make this explicit?"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 13
-                  ▿ endLine: Optional<Int>
-                    - some: 65
-                  ▿ startColumn: Optional<Int>
-                    - some: 13
-                  - startLine: 65
-              - message: "Conditional cast from \'Bar\' to \'Foo\' always succeeds"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 8
-                  ▿ endLine: Optional<Int>
-                    - some: 89
-                  ▿ startColumn: Optional<Int>
-                    - some: 8
-                  - startLine: 89
-              - message: "No calls to throwing functions occur within \'try\' expression"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9456521739130435
-              - coveredLines: 174
-              - totalLines: 184
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "SwiftTestingTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/SwiftTestingTests.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.99375
-              - coveredLines: 159
-              - totalLines: 160
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "ExamplesTests"
-          - name: "XCTestTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/SPM/Tests/ExamplesTests/XCTestTests.swift"
-          ▿ warnings: 2 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 19
-                  ▿ endLine: Optional<Int>
-                    - some: 113
-                  ▿ startColumn: Optional<Int>
-                    - some: 19
-                  - startLine: 113
-              - message: "Call to main actor-isolated class method \'runActivity(named:block:)\' in a synchronous nonisolated context"
-              - type: IssueType.actorIsolatedCall
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
       - name: "ExamplesTests"
-      ▿ rootLevelTests: 10 members
+    ▿ Module
+      - name: "StringUtils"
+  ▿ rootLevelTestsByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: 10 members
         ▿ RepeatableTest
           - name: "2 + 3 = 5"
           ▿ tests: 3 elements
@@ -1065,7 +860,10 @@
                   - type: NodeType.repetition
               - skipMessage: Optional<String>.none
               - status: Status.success
-      ▿ suites: 3 elements
+  ▿ suitesByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "ExamplesTests"
+      ▿ value: 3 elements
         ▿ Suite
           - fullPath: "XCTestTests"
           - name: "XCTestTests"
@@ -2884,9 +2682,3 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-    ▿ Module
-      - coverage: Optional<Coverage>.none
-      - files: 0 elements
-      - name: "StringUtils"
-      - rootLevelTests: 0 members
-      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-iOS.txt
@@ -1,6 +1,25 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.7453798767967146
+  ▿ coverageByModule: 3 key/value pairs
+    ▿ (2 elements)
+      - key: "XcodeprojExample.app"
+      ▿ value: Coverage
+        - coverage: 0.35714285714285715
+        - coveredLines: 30
+        - totalLines: 84
+    ▿ (2 elements)
+      - key: "XcodeprojExampleFramework.framework"
+      ▿ value: Coverage
+        - coverage: 0.0
+        - coveredLines: 0
+        - totalLines: 59
+    ▿ (2 elements)
+      - key: "XcodeprojExampleTests.xctest"
+      ▿ value: Coverage
+        - coverage: 0.9680232558139535
+        - coveredLines: 333
+        - totalLines: 344
   ▿ files: 7 elements
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -323,65 +342,15 @@
           - type: IssueType.swiftCompilerWarning
   ▿ modules: 3 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.35714285714285715
-          - coveredLines: 30
-          - totalLines: 84
-      ▿ files: 3 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.47058823529411764
-              - coveredLines: 16
-              - totalLines: 34
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExample.app"
-          - name: "Calculator.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExample.app"
-          - name: "NumberHelper.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 1.0
-              - coveredLines: 14
-              - totalLines: 14
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExample.app"
-          - name: "XcodeprojExampleApp.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
-          - warnings: 0 elements
       - name: "XcodeprojExample.app"
-      ▿ rootLevelTests: 10 members
+    ▿ Module
+      - name: "XcodeprojExampleFramework.framework"
+    ▿ Module
+      - name: "XcodeprojExampleTests.xctest"
+  ▿ rootLevelTestsByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "XcodeprojExample.app"
+      ▿ value: 10 members
         ▿ RepeatableTest
           - name: "2 + 3 = 5"
           ▿ tests: 3 elements
@@ -988,7 +957,10 @@
                   - type: NodeType.repetition
               - skipMessage: Optional<String>.none
               - status: Status.success
-      ▿ suites: 3 elements
+  ▿ suitesByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "XcodeprojExample.app"
+      ▿ value: 3 elements
         ▿ Suite
           - fullPath: "XCTestTests"
           - name: "XCTestTests"
@@ -2807,291 +2779,3 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-    ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.0
-          - coveredLines: 0
-          - totalLines: 59
-      ▿ files: 2 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 23
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleFramework.framework"
-          - name: "TextProcessor.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleFramework.framework"
-          - name: "WarningsCatalog.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/WarningsCatalog.swift"
-          ▿ warnings: 8 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 22
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 22
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 23
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 23
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 24
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 24
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 40
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 40
-              - message: "Code after \'return\' will never be executed"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 49
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 49
-              - message: "Result of call to \'unusedResultProducer()\' is unused"
-              - type: IssueType.noUsage
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 14
-                  ▿ endLine: Optional<Int>
-                    - some: 56
-                  ▿ startColumn: Optional<Int>
-                    - some: 14
-                  - startLine: 56
-              - message: "String interpolation produces a debug description for an optional value; did you mean to make this explicit?"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 13
-                  ▿ endLine: Optional<Int>
-                    - some: 65
-                  ▿ startColumn: Optional<Int>
-                    - some: 13
-                  - startLine: 65
-              - message: "Conditional cast from \'Bar\' to \'Foo\' always succeeds"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 8
-                  ▿ endLine: Optional<Int>
-                    - some: 89
-                  ▿ startColumn: Optional<Int>
-                    - some: 8
-                  - startLine: 89
-              - message: "No calls to throwing functions occur within \'try\' expression"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleFramework.framework"
-      - rootLevelTests: 0 members
-      - suites: 0 elements
-    ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.9680232558139535
-          - coveredLines: 333
-          - totalLines: 344
-      ▿ files: 2 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9456521739130435
-              - coveredLines: 174
-              - totalLines: 184
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleTests.xctest"
-          - name: "SwiftTestingTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
-          ▿ warnings: 5 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 25
-                  ▿ endLine: Optional<Int>
-                    - some: 72
-                  ▿ startColumn: Optional<Int>
-                    - some: 25
-                  - startLine: 72
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 32
-                  ▿ endLine: Optional<Int>
-                    - some: 75
-                  ▿ startColumn: Optional<Int>
-                    - some: 32
-                  - startLine: 75
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 21
-                  ▿ endLine: Optional<Int>
-                    - some: 183
-                  ▿ startColumn: Optional<Int>
-                    - some: 21
-                  - startLine: 183
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 28
-                  ▿ endLine: Optional<Int>
-                    - some: 185
-                  ▿ startColumn: Optional<Int>
-                    - some: 28
-                  - startLine: 185
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.99375
-              - coveredLines: 159
-              - totalLines: 160
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleTests.xctest"
-          - name: "XCTestTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
-          ▿ warnings: 4 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 25
-                  ▿ endLine: Optional<Int>
-                    - some: 50
-                  ▿ startColumn: Optional<Int>
-                    - some: 25
-                  - startLine: 50
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 32
-                  ▿ endLine: Optional<Int>
-                    - some: 53
-                  ▿ startColumn: Optional<Int>
-                    - some: 32
-                  - startLine: 53
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 36
-                  ▿ endLine: Optional<Int>
-                    - some: 64
-                  ▿ startColumn: Optional<Int>
-                    - some: 36
-                  - startLine: 64
-              - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleTests.xctest"
-      - rootLevelTests: 0 members
-      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-macOS.txt
@@ -1,6 +1,25 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.7453798767967146
+  ▿ coverageByModule: 3 key/value pairs
+    ▿ (2 elements)
+      - key: "XcodeprojExample.app"
+      ▿ value: Coverage
+        - coverage: 0.35714285714285715
+        - coveredLines: 30
+        - totalLines: 84
+    ▿ (2 elements)
+      - key: "XcodeprojExampleFramework.framework"
+      ▿ value: Coverage
+        - coverage: 0.0
+        - coveredLines: 0
+        - totalLines: 59
+    ▿ (2 elements)
+      - key: "XcodeprojExampleTests.xctest"
+      ▿ value: Coverage
+        - coverage: 0.9680232558139535
+        - coveredLines: 333
+        - totalLines: 344
   ▿ files: 7 elements
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -323,65 +342,15 @@
           - type: IssueType.swiftCompilerWarning
   ▿ modules: 3 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.35714285714285715
-          - coveredLines: 30
-          - totalLines: 84
-      ▿ files: 3 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.47058823529411764
-              - coveredLines: 16
-              - totalLines: 34
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExample.app"
-          - name: "Calculator.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExample.app"
-          - name: "NumberHelper.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 1.0
-              - coveredLines: 14
-              - totalLines: 14
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExample.app"
-          - name: "XcodeprojExampleApp.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
-          - warnings: 0 elements
       - name: "XcodeprojExample.app"
-      ▿ rootLevelTests: 10 members
+    ▿ Module
+      - name: "XcodeprojExampleFramework.framework"
+    ▿ Module
+      - name: "XcodeprojExampleTests.xctest"
+  ▿ rootLevelTestsByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "XcodeprojExample.app"
+      ▿ value: 10 members
         ▿ RepeatableTest
           - name: "2 + 3 = 5"
           ▿ tests: 3 elements
@@ -988,7 +957,10 @@
                   - type: NodeType.repetition
               - skipMessage: Optional<String>.none
               - status: Status.success
-      ▿ suites: 3 elements
+  ▿ suitesByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "XcodeprojExample.app"
+      ▿ value: 3 elements
         ▿ Suite
           - fullPath: "XCTestTests"
           - name: "XCTestTests"
@@ -2807,291 +2779,3 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-    ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.0
-          - coveredLines: 0
-          - totalLines: 59
-      ▿ files: 2 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 23
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleFramework.framework"
-          - name: "TextProcessor.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleFramework.framework"
-          - name: "WarningsCatalog.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/WarningsCatalog.swift"
-          ▿ warnings: 8 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 22
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 22
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 23
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 23
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 24
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 24
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 40
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 40
-              - message: "Code after \'return\' will never be executed"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 49
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 49
-              - message: "Result of call to \'unusedResultProducer()\' is unused"
-              - type: IssueType.noUsage
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 14
-                  ▿ endLine: Optional<Int>
-                    - some: 56
-                  ▿ startColumn: Optional<Int>
-                    - some: 14
-                  - startLine: 56
-              - message: "String interpolation produces a debug description for an optional value; did you mean to make this explicit?"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 13
-                  ▿ endLine: Optional<Int>
-                    - some: 65
-                  ▿ startColumn: Optional<Int>
-                    - some: 13
-                  - startLine: 65
-              - message: "Conditional cast from \'Bar\' to \'Foo\' always succeeds"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 8
-                  ▿ endLine: Optional<Int>
-                    - some: 89
-                  ▿ startColumn: Optional<Int>
-                    - some: 8
-                  - startLine: 89
-              - message: "No calls to throwing functions occur within \'try\' expression"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleFramework.framework"
-      - rootLevelTests: 0 members
-      - suites: 0 elements
-    ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.9680232558139535
-          - coveredLines: 333
-          - totalLines: 344
-      ▿ files: 2 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9456521739130435
-              - coveredLines: 174
-              - totalLines: 184
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleTests.xctest"
-          - name: "SwiftTestingTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
-          ▿ warnings: 5 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 25
-                  ▿ endLine: Optional<Int>
-                    - some: 72
-                  ▿ startColumn: Optional<Int>
-                    - some: 25
-                  - startLine: 72
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 32
-                  ▿ endLine: Optional<Int>
-                    - some: 75
-                  ▿ startColumn: Optional<Int>
-                    - some: 32
-                  - startLine: 75
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 21
-                  ▿ endLine: Optional<Int>
-                    - some: 183
-                  ▿ startColumn: Optional<Int>
-                    - some: 21
-                  - startLine: 183
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 28
-                  ▿ endLine: Optional<Int>
-                    - some: 185
-                  ▿ startColumn: Optional<Int>
-                    - some: 28
-                  - startLine: 185
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.99375
-              - coveredLines: 159
-              - totalLines: 160
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleTests.xctest"
-          - name: "XCTestTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
-          ▿ warnings: 4 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 25
-                  ▿ endLine: Optional<Int>
-                    - some: 50
-                  ▿ startColumn: Optional<Int>
-                    - some: 25
-                  - startLine: 50
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 32
-                  ▿ endLine: Optional<Int>
-                    - some: 53
-                  ▿ startColumn: Optional<Int>
-                    - some: 32
-                  - startLine: 53
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 36
-                  ▿ endLine: Optional<Int>
-                    - some: 64
-                  ▿ startColumn: Optional<Int>
-                    - some: 36
-                  - startLine: 64
-              - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleTests.xctest"
-      - rootLevelTests: 0 members
-      - suites: 0 elements

--- a/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
+++ b/Tests/PeekieTests/__Snapshots__/ReportSnapshotTests/reportSnapshots-_.Xcworkspace-visionOS.txt
@@ -1,6 +1,25 @@
 ▿ Report
   ▿ coverage: Optional<Double>
     - some: 0.7453798767967146
+  ▿ coverageByModule: 3 key/value pairs
+    ▿ (2 elements)
+      - key: "XcodeprojExample.app"
+      ▿ value: Coverage
+        - coverage: 0.35714285714285715
+        - coveredLines: 30
+        - totalLines: 84
+    ▿ (2 elements)
+      - key: "XcodeprojExampleFramework.framework"
+      ▿ value: Coverage
+        - coverage: 0.0
+        - coveredLines: 0
+        - totalLines: 59
+    ▿ (2 elements)
+      - key: "XcodeprojExampleTests.xctest"
+      ▿ value: Coverage
+        - coverage: 0.9680232558139535
+        - coveredLines: 333
+        - totalLines: 344
   ▿ files: 7 elements
     ▿ File
       ▿ coverage: Optional<Coverage>
@@ -323,65 +342,15 @@
           - type: IssueType.swiftCompilerWarning
   ▿ modules: 3 elements
     ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.35714285714285715
-          - coveredLines: 30
-          - totalLines: 84
-      ▿ files: 3 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.47058823529411764
-              - coveredLines: 16
-              - totalLines: 34
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExample.app"
-          - name: "Calculator.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/Calculator.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 17
-                  ▿ endLine: Optional<Int>
-                    - some: 7
-                  ▿ startColumn: Optional<Int>
-                    - some: 17
-                  - startLine: 7
-              - message: "Some warning from Calculator"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExample.app"
-          - name: "NumberHelper.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/NumberHelper.swift"
-          - warnings: 0 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 1.0
-              - coveredLines: 14
-              - totalLines: 14
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExample.app"
-          - name: "XcodeprojExampleApp.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExample/XcodeprojExampleApp.swift"
-          - warnings: 0 elements
       - name: "XcodeprojExample.app"
-      ▿ rootLevelTests: 10 members
+    ▿ Module
+      - name: "XcodeprojExampleFramework.framework"
+    ▿ Module
+      - name: "XcodeprojExampleTests.xctest"
+  ▿ rootLevelTestsByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "XcodeprojExample.app"
+      ▿ value: 10 members
         ▿ RepeatableTest
           - name: "2 + 3 = 5"
           ▿ tests: 3 elements
@@ -988,7 +957,10 @@
                   - type: NodeType.repetition
               - skipMessage: Optional<String>.none
               - status: Status.success
-      ▿ suites: 3 elements
+  ▿ suitesByModule: 1 key/value pair
+    ▿ (2 elements)
+      - key: "XcodeprojExample.app"
+      ▿ value: 3 elements
         ▿ Suite
           - fullPath: "XCTestTests"
           - name: "XCTestTests"
@@ -2807,291 +2779,3 @@
                       - type: NodeType.repetition
                   - skipMessage: Optional<String>.none
                   - status: Status.success
-    ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.0
-          - coveredLines: 0
-          - totalLines: 59
-      ▿ files: 2 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 23
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleFramework.framework"
-          - name: "TextProcessor.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/TextProcessor.swift"
-          ▿ warnings: 1 element
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 13
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 13
-              - message: "Some warning from StringUtils"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.0
-              - coveredLines: 0
-              - totalLines: 36
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleFramework.framework"
-          - name: "WarningsCatalog.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExampleFramework/XcodeprojExampleFramework/WarningsCatalog.swift"
-          ▿ warnings: 8 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 22
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 22
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 23
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 23
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 26
-                  ▿ endLine: Optional<Int>
-                    - some: 24
-                  ▿ startColumn: Optional<Int>
-                    - some: 26
-                  - startLine: 24
-              - message: "\'oldFoo()\' is deprecated: use newFoo()"
-              - type: IssueType.deprecatedDeclaration
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 40
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 40
-              - message: "Code after \'return\' will never be executed"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 4
-                  ▿ endLine: Optional<Int>
-                    - some: 49
-                  ▿ startColumn: Optional<Int>
-                    - some: 4
-                  - startLine: 49
-              - message: "Result of call to \'unusedResultProducer()\' is unused"
-              - type: IssueType.noUsage
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 14
-                  ▿ endLine: Optional<Int>
-                    - some: 56
-                  ▿ startColumn: Optional<Int>
-                    - some: 14
-                  - startLine: 56
-              - message: "String interpolation produces a debug description for an optional value; did you mean to make this explicit?"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 13
-                  ▿ endLine: Optional<Int>
-                    - some: 65
-                  ▿ startColumn: Optional<Int>
-                    - some: 13
-                  - startLine: 65
-              - message: "Conditional cast from \'Bar\' to \'Foo\' always succeeds"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 8
-                  ▿ endLine: Optional<Int>
-                    - some: 89
-                  ▿ startColumn: Optional<Int>
-                    - some: 8
-                  - startLine: 89
-              - message: "No calls to throwing functions occur within \'try\' expression"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleFramework.framework"
-      - rootLevelTests: 0 members
-      - suites: 0 elements
-    ▿ Module
-      ▿ coverage: Optional<Coverage>
-        ▿ some: Coverage
-          - coverage: 0.9680232558139535
-          - coveredLines: 333
-          - totalLines: 344
-      ▿ files: 2 elements
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.9456521739130435
-              - coveredLines: 174
-              - totalLines: 184
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleTests.xctest"
-          - name: "SwiftTestingTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/SwiftTestingTests.swift"
-          ▿ warnings: 5 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 25
-                  ▿ endLine: Optional<Int>
-                    - some: 72
-                  ▿ startColumn: Optional<Int>
-                    - some: 25
-                  - startLine: 72
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 32
-                  ▿ endLine: Optional<Int>
-                    - some: 75
-                  ▿ startColumn: Optional<Int>
-                    - some: 32
-                  - startLine: 75
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 140
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 140
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 21
-                  ▿ endLine: Optional<Int>
-                    - some: 183
-                  ▿ startColumn: Optional<Int>
-                    - some: 21
-                  - startLine: 183
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 28
-                  ▿ endLine: Optional<Int>
-                    - some: 185
-                  ▿ startColumn: Optional<Int>
-                    - some: 28
-                  - startLine: 185
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-        ▿ File
-          ▿ coverage: Optional<Coverage>
-            ▿ some: Coverage
-              - coverage: 0.99375
-              - coveredLines: 159
-              - totalLines: 160
-          - errors: 0 elements
-          ▿ module: Optional<String>
-            - some: "XcodeprojExampleTests.xctest"
-          - name: "XCTestTests.swift"
-          ▿ path: Optional<String>
-            - some: "/Users/alldmeat/Developer/swift-tests-example/Xcworkspace/XcodeprojExample/XcodeprojExampleTests/XCTestTests.swift"
-          ▿ warnings: 4 elements
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 25
-                  ▿ endLine: Optional<Int>
-                    - some: 50
-                  ▿ startColumn: Optional<Int>
-                    - some: 25
-                  - startLine: 50
-              - message: "Main actor-isolated initializer \'init()\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 32
-                  ▿ endLine: Optional<Int>
-                    - some: 53
-                  ▿ startColumn: Optional<Int>
-                    - some: 32
-                  - startLine: 53
-              - message: "Main actor-isolated instance method \'add\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 36
-                  ▿ endLine: Optional<Int>
-                    - some: 64
-                  ▿ startColumn: Optional<Int>
-                    - some: 36
-                  - startLine: 64
-              - message: "Main actor-isolated instance method \'multiply\' cannot be called from outside of the actor; this is an error in the Swift 6 language mode"
-              - type: IssueType.swiftCompilerWarning
-            ▿ Issue
-              ▿ location: Optional<Location>
-                ▿ some: Location
-                  ▿ endColumn: Optional<Int>
-                    - some: 9
-                  ▿ endLine: Optional<Int>
-                    - some: 173
-                  ▿ startColumn: Optional<Int>
-                    - some: 9
-                  - startLine: 173
-              - message: "Some warning from ExampleSUITests"
-              - type: IssueType.swiftCompilerWarning
-      - name: "XcodeprojExampleTests.xctest"
-      - rootLevelTests: 0 members
-      - suites: 0 elements


### PR DESCRIPTION
## Summary

The intermediate 5.0 design (still on `main` as of this PR's base) materialized `Module.files` / `Module.coverage` / `Module.suites` / `Module.rootLevelTests` as stored properties on `Module` itself. The `files` array was a value-copy of the matching slice of `Report.files`, so every `File` struct existed twice in memory and twice in any dump. Two visible consequences:

- `report.warnings + report.modules.flatMap(\.warnings)` double-counted every file whose `module != nil` — the two halves overlapped exactly on those.
- Snapshots dumped every `File` twice — once under `Report.files`, once nested under `Report.modules[].files`. That's the duplication that surfaced when we audited the snapshots and the third source the dedup roadmap planned to close (after `pathsByBasename` in #204 and Apple-twin `#warning` in #205).

This PR collapses `Module` to a thin handle (`{ name }`) and moves the projection storage onto `Report` itself. Each `File` value lives in exactly one place; module-scoped views become pure lookups. This is still part of the upcoming 5.0 — the latest published tag is `4.1.0`, and 5.0 hasn't shipped yet.

## Key Changes

### Model

- `Report.Module` shrinks to `public struct Module: Hashable { public let name: String }`. No `files`, `coverage`, `suites`, `rootLevelTests`, `warnings`, `errors` left.
- `Report` gains three storage maps keyed by `Module.name`:
  - `coverageByModule: [String: Coverage]`
  - `suitesByModule: [String: [Module.Suite]]`
  - `rootLevelTestsByModule: [String: Set<Module.Suite.RepeatableTest>]`
- New lookups on `Report`: `files(in:)`, `coverage(of:)`, `suites(in:)`, `rootLevelTests(in:)`, `warnings(in:)`, `errors(in:)`. They take a `Module` (the handle) and return the projection.

### Parser

- `Report.init(xcresultPath:…)` now feeds `coverageByModule` / `suitesByModule` / `rootLevelTestsByModule` instead of building per-`Module` payloads. `moduleNames(_:_:_:)` returns the sorted name list, `coverageByModule(_:_:)` produces the coverage map; `suites` / `rootLevelTests` maps come straight from `testNodesByModule.mapValues`.
- The async DTO loading and attachment lookup blocks are factored out into `loadDTOs` / `resolveAttachmentLookup` so `init` stays inside the SwiftLint `function_body_length` limit.

### Formatters

- JSON, Coverage, List, Sonar, and Attachments formatters now pull module-scoped data via `report.X(in: module)` instead of `module.X`. Output shape unchanged.

### Tests / fixtures

- `Report.Module.testMake` collapses to `testMake(name:)`. `Report.testMake` gains optional `coverageByModule` / `suitesByModule` / `rootLevelTestsByModule` parameters; the prior `files / modules / coverage` call still works.
- Two callsites in the test suite migrated to the new lookups (`ReportIncludeTestsFlagTests`, `SonarFormatterSnapshotTests`).
- Snapshots re-recorded — `Report.modules[]` entries no longer dump nested `File` subtrees, cutting ~2 000 lines across the eight `ReportSnapshotTests` fixtures.

### Docs

- `MIGRATION.md` extends the existing "Model: `Report` is reshaped around `File`" section with the new lookups, removed `Module.X` properties, and the "why the projection moved off `Module`" note. The 4.x → 5.0 guide stays the single canonical migration document — there's no 6.0 yet.

## Why

`Report.files` is the single source of truth for file identity. `Module` was the only place where that invariant leaked — its `files` slice was a stored array, not a view. By making the projection a function on `Report`, the dump shape and the consumer ergonomics line up with the doc comment that already promised `modules` is "a projection over `files`."

## Related landed PRs

- [#204](https://github.com/dodobrands/Peekie/pull/204) — `pathsByBasename` dedup
- [#205](https://github.com/dodobrands/Peekie/pull/205) — Apple `#warning` twin dedup