### PR TITLE
Add Allure 2 export format to peekie tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Other options: [Homebrew tap](https://github.com/dodobrands/homebrew-tap) (comin
 Five data-axis subcommands. Each runs only the `xcrun` calls it needs.
 
 ```
-peekie tests        <xcresult>  [--format json|list|sonar]  default: list
+peekie tests        <xcresult>  [--format json|list|sonar|allure]  default: list
 peekie warnings     <xcresult>  [--format json|list]        default: json
 peekie errors       <xcresult>  [--format json|list]        default: json
 peekie coverage     <xcresult>  [--format json|list]        default: json
@@ -51,7 +51,7 @@ peekie attachments  <xcresult>  --output-dir <dir> [--format json|list]  default
 
 ### `peekie tests`
 
-Test results, with status filtering and SonarQube export.
+Test results, with status filtering, SonarQube and Allure export.
 
 ```bash
 # Human-readable, all statuses
@@ -65,9 +65,12 @@ peekie tests Tests.xcresult --format json > tests.json
 
 # SonarQube generic test execution XML
 peekie tests Tests.xcresult --format sonar --tests-path Tests > sonar-tests.xml
+
+# Allure 2 results directory, ready for `allurectl upload` / `allure generate`
+peekie tests Tests.xcresult --format allure --output-dir allure-results
 ```
 
-**Options:** `--include` (comma-separated statuses), `--include-device-details`, `--tests-path` (required with `--format sonar`), `--attachments skip|export` + `--attachments-to <dir>` (embeds attachment metadata into each test in the JSON output; required together when exporting).
+**Options:** `--include` (comma-separated statuses), `--include-device-details`, `--tests-path` (required with `--format sonar`), `--output-dir` (required with `--format allure`), `--attachments skip|export` + `--attachments-to <dir>` (embeds attachment metadata into each test in the JSON output; required together when exporting).
 
 ### `peekie warnings`
 

--- a/Sources/Peekie/Tests.swift
+++ b/Sources/Peekie/Tests.swift
@@ -13,6 +13,7 @@ public struct Tests: AsyncParsableCommand {
         case json
         case list
         case sonar
+        case allure
     }
 
     public enum AttachmentsMode: String, ExpressibleByArgument, CaseIterable {
@@ -42,6 +43,12 @@ public struct Tests: AsyncParsableCommand {
     @Option(help: "Path to test sources (required with --format sonar).")
     public var testsPath: String?
 
+    @Option(
+        name: .customLong("output-dir"),
+        help: "Output directory for Allure results. Required with --format allure."
+    )
+    public var outputDir: String?
+
     @Option(help: "Attachments handling: skip (default) or export.")
     public var attachments = AttachmentsMode.skip
 
@@ -58,16 +65,11 @@ public struct Tests: AsyncParsableCommand {
         LoggingSetup.setup(verbose: verbose)
         let xcresultPath = URL(fileURLWithPath: xcresultPath)
 
-        let attachmentsPolicy: AttachmentPolicy
-        switch attachments {
-        case .skip:
-            attachmentsPolicy = .skip
-        case .export:
-            guard let attachmentsTo else {
-                throw ValidationError("--attachments-to is required when --attachments export")
+        let (attachmentsPolicy, temporaryAttachmentsDirectory) = try makeAttachmentsPolicy()
+        defer {
+            if let temporaryAttachmentsDirectory {
+                try? FileManager.default.removeItem(at: temporaryAttachmentsDirectory)
             }
-
-            attachmentsPolicy = .extractTo(URL(fileURLWithPath: attachmentsTo))
         }
 
         let report = try await Report(
@@ -109,6 +111,56 @@ public struct Tests: AsyncParsableCommand {
                     report: report, testsPath: URL(fileURLWithPath: testsPath)
                 )
             )
+
+        case .allure:
+            guard let outputDir else {
+                throw ValidationError("--output-dir is required when --format allure")
+            }
+
+            try exportAllure(report: report, outputDir: outputDir)
         }
+    }
+
+    // MARK: Private
+
+    /// Resolves the attachment extraction policy from the CLI flags. The Allure
+    /// format needs attachment files even when the user didn't ask for them
+    /// explicitly, so it falls back to a temporary directory — returned as the
+    /// second tuple element for the caller to clean up.
+    private func makeAttachmentsPolicy() throws -> (AttachmentPolicy, URL?) {
+        switch attachments {
+        case .skip:
+            guard format == .allure else {
+                return (.skip, nil)
+            }
+
+            let directory = FileManager.default
+                .temporaryDirectory
+                .appendingPathComponent("peekie-allure-attachments-\(UUID().uuidString)")
+            return (.extractTo(directory), directory)
+
+        case .export:
+            guard let attachmentsTo else {
+                throw ValidationError("--attachments-to is required when --attachments export")
+            }
+
+            return (.extractTo(URL(fileURLWithPath: attachmentsTo)), nil)
+        }
+    }
+
+    private func exportAllure(report: Report, outputDir: String) throws {
+        let formatter = PeekieSDK.AllureFormatter()
+        let summary = try formatter.write(
+            report: report,
+            to: URL(fileURLWithPath: outputDir)
+        )
+        let counts = summary.resultCountsByStatus
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key): \($0.value)" }
+            .joined(separator: ", ")
+        print(
+            "Exported \(summary.resultsTotal) Allure results (\(counts)), "
+                + "\(summary.attachmentsTotal) attachments to \(outputDir)"
+        )
     }
 }

--- a/Sources/PeekieSDK/Formatters/AllureFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/AllureFormatter.swift
@@ -1,0 +1,389 @@
+import Foundation
+
+// MARK: - AllureTestResult
+
+/// A single Allure 2 test result, one `<uuid>-result.json` file worth of data.
+///
+/// Field set follows the [Allure 2 result
+/// schema](https://allurereport.org/docs/how-it-works-test-result-file/)
+/// as produced by the de-facto standard xcresult exporter
+/// [eroshenkoam/xcresults](https://github.com/eroshenkoam/xcresults), so migrating
+/// to Peekie preserves test identity in Allure TestOps:
+/// - `fullName` is the legacy xcresult test identifier, e.g. ``Suite/`display name`()``;
+/// - `historyId` is `<target>/<fullName>`;
+/// - a result is emitted per execution (repetition × device × arguments), and executions
+///   of one test are chained on the timeline so retry resolution picks the final attempt.
+public struct AllureTestResult: Encodable {
+    // MARK: Public
+
+    public struct Label: Encodable {
+        public let name: String
+        public let value: String
+    }
+
+    public struct Parameter: Encodable {
+        public let name: String
+        public let value: String
+    }
+
+    public struct StatusDetails: Encodable {
+        public let message: String
+    }
+
+    public struct Attachment: Encodable {
+        // MARK: Public
+
+        /// Human-readable attachment name as set in test code.
+        public let name: String
+
+        /// File name inside the allure-results directory (`<uuid>-attachment.<ext>`).
+        public let source: String
+
+        /// MIME type when known.
+        public let type: String?
+
+        // MARK: Internal
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case source
+            case type
+        }
+
+        /// Where the exported file currently lives on disk; used by
+        /// ``AllureFormatter/write(report:to:startedAt:makeUUID:)`` to copy the
+        /// file next to the result JSONs. Not part of the Allure schema.
+        let originalPath: URL
+    }
+
+    public let uuid: String
+    public let historyID: String
+    public let fullName: String
+    public let name: String
+    public let status: String
+    public let stage: String
+    public let start: Int
+    public let stop: Int
+    public let labels: [Label]
+    public let parameters: [Parameter]
+    public let statusDetails: StatusDetails?
+    public let attachments: [Attachment]
+
+    // MARK: Internal
+
+    /// The Allure 2 schema spells the key `historyId`; the property follows
+    /// Swift acronym casing, so the mapping is explicit.
+    enum CodingKeys: String, CodingKey {
+        case uuid
+        case historyID = "historyId"
+        case fullName
+        case name
+        case status
+        case stage
+        case start
+        case stop
+        case labels
+        case parameters
+        case statusDetails
+        case attachments
+    }
+}
+
+// MARK: - AllureFormatter
+
+/// Formatter that emits test results in Allure 2 format.
+///
+/// The produced directory is ready for `allurectl upload` (Allure TestOps) or
+/// `allure generate` (Allure Report): one `<uuid>-result.json` per test execution
+/// plus attachment files referenced from the results.
+///
+/// Unlike exporters built on the legacy `xcresulttool get object` API (one process
+/// per test — minutes on large bundles), this formatter reuses the already-parsed
+/// ``Report``, so the only cost on top of `Report(xcresultPath:)` is writing files.
+public final class AllureFormatter {
+    // MARK: Lifecycle
+
+    /// Creates a new Allure formatter instance.
+    public init() {}
+
+    // MARK: Public
+
+    /// Totals of a completed ``write(report:to:startedAt:makeUUID:)`` call.
+    public struct WriteSummary {
+        /// Number of result files written, keyed by Allure status.
+        public let resultCountsByStatus: [String: Int]
+
+        /// Total number of result files written.
+        public let resultsTotal: Int
+
+        /// Total number of attachment files copied.
+        public let attachmentsTotal: Int
+    }
+
+    /// Builds Allure results from a report. Pure transform: deterministic given
+    /// `startedAt` and `makeUUID`.
+    ///
+    /// Executions of one test are chained back-to-back starting at `startedAt`
+    /// so that consumers resolving retries by the latest `stop` (Allure TestOps,
+    /// Allure Report) pick the final attempt — the same order real per-attempt
+    /// timestamps would produce.
+    ///
+    /// - Parameters:
+    ///   - report: Parsed report; build it with `attachments: .extractTo(_)` if
+    ///     attachment files should be referenced.
+    ///   - startedAt: Timeline origin for the emitted results.
+    ///   - makeUUID: UUID source; inject a deterministic one in tests.
+    public func results(
+        report: Report,
+        startedAt: Date,
+        makeUUID: () -> UUID = UUID.init
+    )
+        -> [AllureTestResult]
+    {
+        var results = [AllureTestResult]()
+        let baseStartMs = Int((startedAt.timeIntervalSince1970 * 1000).rounded())
+
+        for module in report.modules.sorted(by: { $0.name < $1.name }) {
+            let suites = report.suites(in: module).flatMap { Self.flatten($0) }
+            for suite in suites.sorted(by: { $0.fullPath < $1.fullPath }) {
+                let prefix = Self.suiteIdentifierPrefix(from: suite.nodeIdentifierURL)
+                for repeatableTest in suite.repeatableTests.sorted(by: { $0.name < $1.name }) {
+                    append(
+                        repeatableTest,
+                        module: module,
+                        suitePrefix: prefix,
+                        baseStartMs: baseStartMs,
+                        makeUUID: makeUUID,
+                        into: &results
+                    )
+                }
+            }
+
+            let rootLevelTests = report.rootLevelTests(in: module)
+            for repeatableTest in rootLevelTests.sorted(by: { $0.name < $1.name }) {
+                append(
+                    repeatableTest,
+                    module: module,
+                    suitePrefix: nil,
+                    baseStartMs: baseStartMs,
+                    makeUUID: makeUUID,
+                    into: &results
+                )
+            }
+        }
+
+        return results
+    }
+
+    /// Writes Allure results and their attachment files into `outputDirectory`,
+    /// creating it when missing.
+    @discardableResult
+    public func write(
+        report: Report,
+        to outputDirectory: URL,
+        startedAt: Date = Date(),
+        makeUUID: () -> UUID = UUID.init
+    ) throws
+        -> WriteSummary
+    {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+
+        let items = results(report: report, startedAt: startedAt, makeUUID: makeUUID)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
+        var countsByStatus = [String: Int]()
+        var attachmentsTotal = 0
+
+        for item in items {
+            countsByStatus[item.status, default: 0] += 1
+
+            for attachment in item.attachments {
+                let destination = outputDirectory.appendingPathComponent(attachment.source)
+                do {
+                    try fileManager.copyItem(at: attachment.originalPath, to: destination)
+                    attachmentsTotal += 1
+                } catch {
+                    // A missing attachment file should not sink the whole export:
+                    // results are the valuable part, attachments are extras.
+                    continue
+                }
+            }
+
+            let fileURL = outputDirectory.appendingPathComponent("\(item.uuid)-result.json")
+            try encoder.encode(item).write(to: fileURL)
+        }
+
+        return WriteSummary(
+            resultCountsByStatus: countsByStatus,
+            resultsTotal: items.count,
+            attachmentsTotal: attachmentsTotal
+        )
+    }
+
+    // MARK: Internal
+
+    /// Last component of a test identifier — the test's own name without the
+    /// suite path. A `/` inside backticks is part of a Swift Testing display
+    /// name, not a path separator: ``Suite/`When A/B enabled`()`` →
+    /// `` `When A/B enabled`() ``.
+    static func testName(fromIdentifier identifier: String) -> String {
+        var insideBackticks = false
+        var lastSlash: String.Index?
+        var index = identifier.startIndex
+        while index < identifier.endIndex {
+            let character = identifier[index]
+            if character == "`" {
+                insideBackticks.toggle()
+            } else if character == "/", insideBackticks == false {
+                lastSlash = index
+            }
+            index = identifier.index(after: index)
+        }
+        guard let slash = lastSlash else {
+            return identifier
+        }
+
+        return String(identifier[identifier.index(after: slash)...])
+    }
+
+    /// Fallback legacy identifier component built from a display name, for
+    /// reports parsed before `nodeIdentifier` was captured (e.g. constructed
+    /// in tests via helpers).
+    ///
+    /// Plain function references (`test_example()`, `someTest()`) are already in
+    /// legacy form. Swift Testing display names are backtick-wrapped with a `()`
+    /// suffix — `` `Given A/B, then works`() `` — matching `nodeIdentifier` as
+    /// emitted by `xcresulttool`. Parameterized tests cannot be reconstructed
+    /// this way (their identifier is the function signature), which is exactly
+    /// why ``Report/Module/Suite/RepeatableTest/nodeIdentifier`` exists.
+    static func legacyTestName(_ name: String) -> String {
+        if isPlainFunctionName(name) {
+            return name
+        }
+        return "`\(name)`()"
+    }
+
+    /// Suite path prefix of the legacy test identifier, extracted from the suite's
+    /// `nodeIdentifierURL`.
+    ///
+    /// `test://com.apple.xcode/<Module>/<Bundle>/<Outer>/<Inner>` → `Outer/Inner`.
+    /// Components are split on the raw URL before percent-decoding, so decoded
+    /// names containing `/` don't break the structure.
+    static func suiteIdentifierPrefix(from nodeIdentifierURL: String) -> String? {
+        let scheme = "test://com.apple.xcode/"
+        guard nodeIdentifierURL.hasPrefix(scheme) else {
+            return nil
+        }
+
+        let rawComponents = nodeIdentifierURL.dropFirst(scheme.count)
+            .components(separatedBy: "/")
+        guard rawComponents.count > 2 else {
+            return nil
+        }
+
+        return rawComponents.dropFirst(2)
+            .map { $0.removingPercentEncoding ?? $0 }
+            .joined(separator: "/")
+    }
+
+    // MARK: Private
+
+    private static func flatten(_ suite: Report.Module.Suite) -> [Report.Module.Suite] {
+        [suite] + suite.nestedSuites.flatMap { flatten($0) }
+    }
+
+    private static func isPlainFunctionName(_ name: String) -> Bool {
+        guard name.hasSuffix("()") else {
+            return false
+        }
+
+        let base = name.dropLast(2)
+        return base.isEmpty == false
+            && base.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+    }
+
+    private static func allureStatus(
+        _ status: Report.Module.Suite.RepeatableTest.Test.Status
+    )
+        -> String
+    {
+        switch status {
+        case .success, .expectedFailure:
+            "passed"
+        case .failure, .mixed:
+            "failed"
+        case .skipped:
+            "skipped"
+        case .unknown:
+            "unknown"
+        }
+    }
+
+    private func append(
+        _ repeatableTest: Report.Module.Suite.RepeatableTest,
+        module: Report.Module,
+        suitePrefix: String?,
+        baseStartMs: Int,
+        makeUUID: () -> UUID,
+        into results: inout [AllureTestResult]
+    ) {
+        let fullName: String
+        if let identifier = repeatableTest.nodeIdentifier {
+            fullName = identifier
+        } else {
+            let testName = Self.legacyTestName(repeatableTest.name)
+            fullName = suitePrefix.map { "\($0)/\(testName)" } ?? testName
+        }
+        let name = Self.testName(fromIdentifier: fullName)
+        let historyID = "\(module.name)/\(fullName)"
+
+        // Executions run back-to-back on the timeline; see `results(report:...)`.
+        var cursor = baseStartMs
+        for test in repeatableTest.tests {
+            let durationMs = Int(test.duration.converted(to: .milliseconds).value.rounded())
+            let start = cursor
+            let stop = start + durationMs
+            cursor = stop + 1
+
+            var labels = [AllureTestResult.Label(name: "suite", value: module.name)]
+            if let device = test.path.first(where: { $0.type == .device }) {
+                labels.append(.init(name: "runDestination", value: device.name))
+            }
+
+            let parameters = test.path
+                .filter { $0.type == .arguments }
+                .map { AllureTestResult.Parameter(name: "arguments", value: $0.name) }
+
+            let attachments = test.attachments.map { attachment in
+                let fileExtension = (attachment.exportedFileName as NSString).pathExtension
+                let suffix = fileExtension.isEmpty ? "" : ".\(fileExtension)"
+                return AllureTestResult.Attachment(
+                    name: attachment.name,
+                    source: "\(makeUUID().uuidString.lowercased())-attachment\(suffix)",
+                    type: attachment.contentType,
+                    originalPath: attachment.path
+                )
+            }
+
+            results.append(
+                AllureTestResult(
+                    uuid: makeUUID().uuidString.lowercased(),
+                    historyID: historyID,
+                    fullName: fullName,
+                    name: name,
+                    status: Self.allureStatus(test.status),
+                    stage: "finished",
+                    start: start,
+                    stop: stop,
+                    labels: labels,
+                    parameters: parameters,
+                    statusDetails: test.message.map { .init(message: $0) },
+                    attachments: attachments
+                )
+            )
+        }
+    }
+}

--- a/Sources/PeekieSDK/Models/DTO/TestResultsDTO.swift
+++ b/Sources/PeekieSDK/Models/DTO/TestResultsDTO.swift
@@ -8,9 +8,32 @@ struct TestResultsDTO: Decodable {
 
 extension TestResultsDTO {
     struct TestNode: Decodable {
+        // MARK: Lifecycle
+
+        init(
+            children: [Self]?,
+            durationInSeconds: Double?,
+            name: String,
+            nodeIdentifierURL: String?,
+            nodeType: NodeType,
+            result: Result?,
+            nodeIdentifier: String? = nil
+        ) {
+            self.children = children
+            self.durationInSeconds = durationInSeconds
+            self.name = name
+            self.nodeIdentifier = nodeIdentifier
+            self.nodeIdentifierURL = nodeIdentifierURL
+            self.nodeType = nodeType
+            self.result = result
+        }
+
+        // MARK: Internal
+
         let children: [Self]?
         let durationInSeconds: Double?
         let name: String
+        let nodeIdentifier: String?
         let nodeIdentifierURL: String?
         let nodeType: NodeType
         let result: Result?

--- a/Sources/PeekieSDK/Models/Report+Convenience+Suites.swift
+++ b/Sources/PeekieSDK/Models/Report+Convenience+Suites.swift
@@ -137,7 +137,11 @@ extension Report {
     )
         -> Module.Suite.RepeatableTest
     {
-        var repeatable = Module.Suite.RepeatableTest(name: testCase.name, tests: [])
+        var repeatable = Module.Suite.RepeatableTest(
+            name: testCase.name,
+            tests: [],
+            nodeIdentifier: testCase.nodeIdentifier
+        )
 
         // xcresulttool's attachment manifest tags each entry with a 1-indexed
         // `repetitionNumber` that maps to the DFS-order encounter of a

--- a/Sources/PeekieSDK/Models/Report+Suite.swift
+++ b/Sources/PeekieSDK/Models/Report+Suite.swift
@@ -6,12 +6,31 @@ public extension Report.Module.Suite {
     /// A test that can be run multiple times (e.g., with retries, different devices, or
     /// parameterized inputs)
     struct RepeatableTest: Hashable {
+        // MARK: Lifecycle
+
+        init(name: String, tests: [Test], nodeIdentifier: String? = nil) {
+            self.name = name
+            self.tests = tests
+            self.nodeIdentifier = nodeIdentifier
+        }
+
+        // MARK: Public
+
         /// Name of the test (e.g., "test_example()")
         public let name: String
 
         /// Array of test executions (multiple entries if test was retried or run with different
         /// parameters)
         public internal(set) var tests: [Test]
+
+        /// Canonical test identifier from the test-case node in xcresult JSON, e.g.
+        /// `"SuiteTests/test_example()"` or ``"SuiteTests/`display name`()"``.
+        /// Unlike `name` (a display name for Swift Testing tests), the identifier is
+        /// stable — for parameterized tests it is the function signature
+        /// (`getValue(input:expected:)`), which no display-name heuristic can
+        /// reconstruct. Exporters that need stable test identity (e.g.
+        /// ``AllureFormatter``) rely on it.
+        public let nodeIdentifier: String?
 
         public static func ==(lhs: Self, rhs: Self) -> Bool {
             lhs.name == rhs.name
@@ -20,6 +39,23 @@ public extension Report.Module.Suite {
         public func hash(into hasher: inout Hasher) {
             hasher.combine(name)
         }
+    }
+}
+
+// MARK: - Report.Module.Suite.RepeatableTest + CustomReflectable
+
+extension Report.Module.Suite.RepeatableTest: CustomReflectable {
+    /// Omits `nodeIdentifier` from `Mirror`-based dumps (e.g. `swift-snapshot-testing`'s
+    /// `.dump` strategy). The identifier is exporter plumbing that duplicates `name`
+    /// for most tests; hiding it keeps snapshots recorded before the field existed
+    /// byte-for-byte stable, so adding it is non-breaking for downstream consumers
+    /// that snapshot `Report`.
+    public var customMirror: Mirror {
+        let children: [Mirror.Child] = [
+            ("name", name),
+            ("tests", tests),
+        ]
+        return Mirror(self, children: children, displayStyle: .struct)
     }
 }
 

--- a/Tests/PeekieTests/AllureFormatterSnapshotTests.swift
+++ b/Tests/PeekieTests/AllureFormatterSnapshotTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import PeekieTestHelpers
+import SnapshotTesting
+import Testing
+@testable import PeekieSDK
+
+// MARK: - AllureFormatterSnapshotTests
+
+struct AllureFormatterSnapshotTests {
+    // MARK: Internal
+
+    let formatter = AllureFormatter()
+
+    @Test(arguments: Constants.testsReportFileNames)
+    func results_allBundles(_ fileName: String) async throws {
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+        }
+        let report = try await Report(xcresultPath: reportPath)
+
+        let results = formatter.results(
+            report: report,
+            startedAt: Date(timeIntervalSince1970: 0),
+            makeUUID: Self.makeSequentialUUID()
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let json = try String(decoding: encoder.encode(results), as: UTF8.self)
+
+        assertSnapshot(
+            of: json,
+            as: .lines,
+            named: "\(snapshotName(from: fileName))_allure"
+        )
+    }
+
+    @Test(arguments: Constants.testsReportFileNames)
+    func write_producesResultFilesAndAttachments(_ fileName: String) async throws {
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        let attachmentsDir = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("PeekieAllureAttachments-\(UUID().uuidString)")
+        let outputDir = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("PeekieAllureResults-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+            try? FileManager.default.removeItem(at: attachmentsDir)
+            try? FileManager.default.removeItem(at: outputDir)
+        }
+
+        let report = try await Report(
+            xcresultPath: reportPath,
+            includeCoverage: false,
+            includeWarnings: false,
+            attachments: .extractTo(attachmentsDir)
+        )
+
+        let summary = try formatter.write(report: report, to: outputDir)
+
+        let files = try FileManager.default.contentsOfDirectory(atPath: outputDir.path)
+        let resultFiles = files.filter { $0.hasSuffix("-result.json") }
+        let attachmentFiles = files.filter { $0.contains("-attachment") }
+
+        #expect(summary.resultsTotal > 0)
+        #expect(resultFiles.count == summary.resultsTotal)
+        #expect(attachmentFiles.count == summary.attachmentsTotal)
+        #expect(summary.resultCountsByStatus.values.reduce(0, +) == summary.resultsTotal)
+    }
+
+    // MARK: Private
+
+    /// Deterministic UUID source for stable snapshots: 00000000-0000-0000-0000-000000000001, …
+    private static func makeSequentialUUID() -> () -> UUID {
+        var counter = 0
+        return {
+            counter += 1
+            let suffix = String(format: "%012d", counter)
+            guard let uuid = UUID(uuidString: "00000000-0000-0000-0000-\(suffix)") else {
+                fatalError("Invalid sequential UUID for counter \(counter)")
+            }
+
+            return uuid
+        }
+    }
+}
+
+// MARK: - AllureFormatterIdentifierTests
+
+struct AllureFormatterIdentifierTests {
+    @Test
+    func nameFromPlainIdentifier() {
+        #expect(
+            AllureFormatter.testName(fromIdentifier: "SuiteTests/test_example()")
+                == "test_example()"
+        )
+    }
+
+    @Test
+    func nameFromParameterizedIdentifier() {
+        #expect(
+            AllureFormatter.testName(
+                fromIdentifier: "ParserTests/getOpenedTo(schedule:date:expected:)"
+            ) == "getOpenedTo(schedule:date:expected:)"
+        )
+    }
+
+    @Test
+    func nameFromNestedSuiteIdentifier() {
+        #expect(
+            AllureFormatter.testName(fromIdentifier: "Outer/Inner/`display name`()")
+                == "`display name`()"
+        )
+    }
+
+    @Test
+    func nameKeepsSlashInsideBackticks() {
+        #expect(
+            AllureFormatter.testName(
+                fromIdentifier: "CartTests/`When A/B enabled, should show icon`()"
+            ) == "`When A/B enabled, should show icon`()"
+        )
+    }
+
+    @Test
+    func plainFunctionNameStaysAsIs() {
+        #expect(AllureFormatter.legacyTestName("test_example()") == "test_example()")
+        #expect(AllureFormatter.legacyTestName("someTest123()") == "someTest123()")
+    }
+
+    @Test
+    func displayNameIsBacktickWrapped() {
+        #expect(
+            AllureFormatter.legacyTestName("Given empty cart, then no removals")
+                == "`Given empty cart, then no removals`()"
+        )
+    }
+
+    @Test
+    func displayNameWithSlashIsBacktickWrapped() {
+        #expect(
+            AllureFormatter.legacyTestName("When A/B enabled, should show icon")
+                == "`When A/B enabled, should show icon`()"
+        )
+    }
+
+    @Test
+    func suitePrefixFromTopLevelSuite() {
+        #expect(
+            AllureFormatter.suiteIdentifierPrefix(
+                from: "test://com.apple.xcode/Module/ModuleTests/SuiteTests"
+            ) == "SuiteTests"
+        )
+    }
+
+    @Test
+    func suitePrefixFromNestedSuite() {
+        #expect(
+            AllureFormatter.suiteIdentifierPrefix(
+                from: "test://com.apple.xcode/Module/ModuleTests/OuterSuite/InnerSuite"
+            ) == "OuterSuite/InnerSuite"
+        )
+    }
+
+    @Test
+    func suitePrefixDecodesPercentEncoding() {
+        #expect(
+            AllureFormatter.suiteIdentifierPrefix(
+                from: "test://com.apple.xcode/Module/ModuleTests/%60Display%20suite%60"
+            ) == "`Display suite`"
+        )
+    }
+
+    @Test
+    func suitePrefixForBundleURLIsNil() {
+        #expect(
+            AllureFormatter.suiteIdentifierPrefix(
+                from: "test://com.apple.xcode/Module/ModuleTests"
+            ) == nil
+        )
+    }
+}

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-iOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-iOS_allure.txt
@@ -1,0 +1,2745 @@
+[
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000001"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 17,
+    "status" : "passed",
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000002"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 30,
+    "status" : "passed",
+    "stop" : 42,
+    "uuid" : "00000000-0000-0000-0000-000000000003"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000004"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000005"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000006"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000007"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000008"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000009"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000010"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000011"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000012"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 13591,
+    "uuid" : "00000000-0000-0000-0000-000000000013"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13592,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 27925,
+    "uuid" : "00000000-0000-0000-0000-000000000014"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 27926,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 42362,
+    "uuid" : "00000000-0000-0000-0000-000000000015"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000016"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000017"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000018"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000019"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000020"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000021"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000022"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000023"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000024"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000025"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000026"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000027"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000028"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000029"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000030"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000031"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000032"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000033"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000034"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000035"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000036"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000037"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000038"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000039"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000040"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000041"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000042"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000043"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000044"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000045"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000046"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000047"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000048"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000049"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000050"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000051"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000052"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000053"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000054"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000055"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000056"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000057"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000058"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000059"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000060"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000061"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000062"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000063"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000064"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000065"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000066"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_async()",
+    "historyId" : "ExamplesTests/XCTestTests/test_async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000067"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_asyncWithExpectation()",
+    "historyId" : "ExamplesTests/XCTestTests/test_asyncWithExpectation()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_asyncWithExpectation()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 60,
+    "uuid" : "00000000-0000-0000-0000-000000000068"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_attachmentInsideActivity()",
+    "historyId" : "ExamplesTests/XCTestTests/test_attachmentInsideActivity()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_attachmentInsideActivity()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000069"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_expectedFailure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 612,
+    "uuid" : "00000000-0000-0000-0000-000000000070"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000071"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000072"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000073"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000074"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000075"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 22,
+    "uuid" : "00000000-0000-0000-0000-000000000076"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "ExamplesTests/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000077"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "ExamplesTests/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000078"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_performance()",
+    "historyId" : "ExamplesTests/XCTestTests/test_performance()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_performance()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 258,
+    "uuid" : "00000000-0000-0000-0000-000000000079"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_skip()",
+    "historyId" : "ExamplesTests/XCTestTests/test_skip()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_skip()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Skip message"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000080"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_success()",
+    "historyId" : "ExamplesTests/XCTestTests/test_success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000081"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000082"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000083"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000084"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000085"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withMultipleAttachments()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000086"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withPNGAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000087"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withWarning()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withWarning()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withWarning()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000088"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000089"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000090"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000091"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000092"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000093"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000094"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000095"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000096"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000097"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000098"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000099"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000100"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000101"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 18,
+    "status" : "passed",
+    "stop" : 31,
+    "uuid" : "00000000-0000-0000-0000-000000000102"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 32,
+    "status" : "passed",
+    "stop" : 44,
+    "uuid" : "00000000-0000-0000-0000-000000000103"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000104"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000105"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000106"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000107"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000108"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000109"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000110"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000111"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000112"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000113"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000114"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000115"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000116"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000117"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000118"
+  }
+]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-macOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-macOS_allure.txt
@@ -1,0 +1,2745 @@
+[
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000001"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 20,
+    "status" : "passed",
+    "stop" : 49,
+    "uuid" : "00000000-0000-0000-0000-000000000002"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 50,
+    "status" : "passed",
+    "stop" : 80,
+    "uuid" : "00000000-0000-0000-0000-000000000003"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000004"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000005"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000006"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000007"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 20,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 35,
+    "uuid" : "00000000-0000-0000-0000-000000000008"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 36,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 63,
+    "uuid" : "00000000-0000-0000-0000-000000000009"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000010"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 23,
+    "uuid" : "00000000-0000-0000-0000-000000000011"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 24,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 51,
+    "uuid" : "00000000-0000-0000-0000-000000000012"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000013"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 25,
+    "uuid" : "00000000-0000-0000-0000-000000000014"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 26,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 53,
+    "uuid" : "00000000-0000-0000-0000-000000000015"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000016"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 23,
+    "uuid" : "00000000-0000-0000-0000-000000000017"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 24,
+    "status" : "passed",
+    "stop" : 51,
+    "uuid" : "00000000-0000-0000-0000-000000000018"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000019"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000020"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000021"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000022"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 17,
+    "status" : "passed",
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000023"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 18,
+    "status" : "passed",
+    "stop" : 18,
+    "uuid" : "00000000-0000-0000-0000-000000000024"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000025"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 22,
+    "uuid" : "00000000-0000-0000-0000-000000000026"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 23,
+    "status" : "passed",
+    "stop" : 50,
+    "uuid" : "00000000-0000-0000-0000-000000000027"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000028"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 23,
+    "uuid" : "00000000-0000-0000-0000-000000000029"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 24,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 51,
+    "uuid" : "00000000-0000-0000-0000-000000000030"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000031"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 20,
+    "status" : "passed",
+    "stop" : 35,
+    "uuid" : "00000000-0000-0000-0000-000000000032"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 36,
+    "status" : "passed",
+    "stop" : 63,
+    "uuid" : "00000000-0000-0000-0000-000000000033"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000034"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 23,
+    "uuid" : "00000000-0000-0000-0000-000000000035"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 24,
+    "status" : "passed",
+    "stop" : 51,
+    "uuid" : "00000000-0000-0000-0000-000000000036"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000037"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 20,
+    "status" : "passed",
+    "stop" : 35,
+    "uuid" : "00000000-0000-0000-0000-000000000038"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 36,
+    "status" : "passed",
+    "stop" : 62,
+    "uuid" : "00000000-0000-0000-0000-000000000039"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000040"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 20,
+    "status" : "passed",
+    "stop" : 35,
+    "uuid" : "00000000-0000-0000-0000-000000000041"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 36,
+    "status" : "passed",
+    "stop" : 63,
+    "uuid" : "00000000-0000-0000-0000-000000000042"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000043"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 21,
+    "uuid" : "00000000-0000-0000-0000-000000000044"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 22,
+    "status" : "passed",
+    "stop" : 48,
+    "uuid" : "00000000-0000-0000-0000-000000000045"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000046"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000047"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 33,
+    "uuid" : "00000000-0000-0000-0000-000000000048"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000049"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 24,
+    "uuid" : "00000000-0000-0000-0000-000000000050"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 25,
+    "status" : "passed",
+    "stop" : 35,
+    "uuid" : "00000000-0000-0000-0000-000000000051"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000052"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 20,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 35,
+    "uuid" : "00000000-0000-0000-0000-000000000053"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 36,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 45,
+    "uuid" : "00000000-0000-0000-0000-000000000054"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000055"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000056"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000057"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000058"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 27,
+    "uuid" : "00000000-0000-0000-0000-000000000059"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 28,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000060"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000061"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 27,
+    "uuid" : "00000000-0000-0000-0000-000000000062"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 28,
+    "status" : "passed",
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000063"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000064"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 27,
+    "uuid" : "00000000-0000-0000-0000-000000000065"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 28,
+    "status" : "passed",
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000066"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_async()",
+    "historyId" : "ExamplesTests/XCTestTests/test_async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000067"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_asyncWithExpectation()",
+    "historyId" : "ExamplesTests/XCTestTests/test_asyncWithExpectation()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_asyncWithExpectation()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000068"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_attachmentInsideActivity()",
+    "historyId" : "ExamplesTests/XCTestTests/test_attachmentInsideActivity()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_attachmentInsideActivity()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000069"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_expectedFailure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 343,
+    "uuid" : "00000000-0000-0000-0000-000000000070"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000071"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000072"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000073"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000074"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000075"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000076"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "ExamplesTests/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000077"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "ExamplesTests/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000078"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_performance()",
+    "historyId" : "ExamplesTests/XCTestTests/test_performance()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_performance()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 261,
+    "uuid" : "00000000-0000-0000-0000-000000000079"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_skip()",
+    "historyId" : "ExamplesTests/XCTestTests/test_skip()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_skip()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Skip message"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000080"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_success()",
+    "historyId" : "ExamplesTests/XCTestTests/test_success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000081"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000082"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000083"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000084"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000085"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withMultipleAttachments()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000086"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withPNGAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000087"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withWarning()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withWarning()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withWarning()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000088"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000089"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 21,
+    "uuid" : "00000000-0000-0000-0000-000000000090"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 22,
+    "status" : "passed",
+    "stop" : 40,
+    "uuid" : "00000000-0000-0000-0000-000000000091"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000092"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 20,
+    "uuid" : "00000000-0000-0000-0000-000000000093"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 21,
+    "status" : "passed",
+    "stop" : 38,
+    "uuid" : "00000000-0000-0000-0000-000000000094"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000095"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 20,
+    "uuid" : "00000000-0000-0000-0000-000000000096"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 21,
+    "status" : "passed",
+    "stop" : 38,
+    "uuid" : "00000000-0000-0000-0000-000000000097"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000098"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 21,
+    "uuid" : "00000000-0000-0000-0000-000000000099"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 22,
+    "status" : "passed",
+    "stop" : 49,
+    "uuid" : "00000000-0000-0000-0000-000000000100"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 24,
+    "uuid" : "00000000-0000-0000-0000-000000000101"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 25,
+    "status" : "passed",
+    "stop" : 40,
+    "uuid" : "00000000-0000-0000-0000-000000000102"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 41,
+    "status" : "passed",
+    "stop" : 68,
+    "uuid" : "00000000-0000-0000-0000-000000000103"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000104"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 27,
+    "uuid" : "00000000-0000-0000-0000-000000000105"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 28,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 46,
+    "uuid" : "00000000-0000-0000-0000-000000000106"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000107"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 21,
+    "uuid" : "00000000-0000-0000-0000-000000000108"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 22,
+    "status" : "passed",
+    "stop" : 40,
+    "uuid" : "00000000-0000-0000-0000-000000000109"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000110"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 21,
+    "uuid" : "00000000-0000-0000-0000-000000000111"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 22,
+    "status" : "passed",
+    "stop" : 40,
+    "uuid" : "00000000-0000-0000-0000-000000000112"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000113"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 20,
+    "uuid" : "00000000-0000-0000-0000-000000000114"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 21,
+    "status" : "passed",
+    "stop" : 39,
+    "uuid" : "00000000-0000-0000-0000-000000000115"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000116"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 26,
+    "uuid" : "00000000-0000-0000-0000-000000000117"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 27,
+    "status" : "passed",
+    "stop" : 45,
+    "uuid" : "00000000-0000-0000-0000-000000000118"
+  }
+]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-tvOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-tvOS_allure.txt
@@ -1,0 +1,2745 @@
+[
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000001"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "passed",
+    "stop" : 25,
+    "uuid" : "00000000-0000-0000-0000-000000000002"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 26,
+    "status" : "passed",
+    "stop" : 38,
+    "uuid" : "00000000-0000-0000-0000-000000000003"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000004"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000005"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000006"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000007"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000008"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000009"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000010"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000011"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000012"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 374,
+    "uuid" : "00000000-0000-0000-0000-000000000013"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 375,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 823,
+    "uuid" : "00000000-0000-0000-0000-000000000014"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 824,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1312,
+    "uuid" : "00000000-0000-0000-0000-000000000015"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000016"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000017"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000018"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000019"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000020"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000021"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000022"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000023"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000024"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000025"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000026"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000027"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000028"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000029"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000030"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000031"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000032"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000033"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000034"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000035"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000036"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000037"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000038"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000039"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000040"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000041"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000042"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000043"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000044"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000045"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000046"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000047"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000048"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000049"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000050"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000051"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000052"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000053"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000054"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000055"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000056"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000057"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000058"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000059"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000060"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000061"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000062"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000063"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000064"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000065"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000066"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_async()",
+    "historyId" : "ExamplesTests/XCTestTests/test_async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000067"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_asyncWithExpectation()",
+    "historyId" : "ExamplesTests/XCTestTests/test_asyncWithExpectation()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_asyncWithExpectation()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000068"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_attachmentInsideActivity()",
+    "historyId" : "ExamplesTests/XCTestTests/test_attachmentInsideActivity()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_attachmentInsideActivity()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000069"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_expectedFailure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 1298,
+    "uuid" : "00000000-0000-0000-0000-000000000070"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000071"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000072"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000073"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000074"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000075"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000076"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "ExamplesTests/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000077"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "ExamplesTests/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000078"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_performance()",
+    "historyId" : "ExamplesTests/XCTestTests/test_performance()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_performance()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 257,
+    "uuid" : "00000000-0000-0000-0000-000000000079"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_skip()",
+    "historyId" : "ExamplesTests/XCTestTests/test_skip()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_skip()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Skip message"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000080"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_success()",
+    "historyId" : "ExamplesTests/XCTestTests/test_success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000081"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000082"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000083"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000084"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000085"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withMultipleAttachments()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000086"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withPNGAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000087"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withWarning()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withWarning()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withWarning()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000088"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000089"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000090"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000091"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000092"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000093"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000094"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000095"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000096"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000097"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000098"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000099"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000100"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000101"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 15,
+    "status" : "passed",
+    "stop" : 26,
+    "uuid" : "00000000-0000-0000-0000-000000000102"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 27,
+    "status" : "passed",
+    "stop" : 40,
+    "uuid" : "00000000-0000-0000-0000-000000000103"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000104"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000105"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000106"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000107"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000108"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000109"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000110"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000111"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000112"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000113"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000114"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000115"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000116"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000117"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000118"
+  }
+]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-visionOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-visionOS_allure.txt
@@ -1,0 +1,2745 @@
+[
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000001"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "passed",
+    "stop" : 27,
+    "uuid" : "00000000-0000-0000-0000-000000000002"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 28,
+    "status" : "passed",
+    "stop" : 40,
+    "uuid" : "00000000-0000-0000-0000-000000000003"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000004"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000005"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000006"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000007"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000008"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000009"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000010"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000011"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000012"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 6872,
+    "uuid" : "00000000-0000-0000-0000-000000000013"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6873,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 14158,
+    "uuid" : "00000000-0000-0000-0000-000000000014"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14159,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 21772,
+    "uuid" : "00000000-0000-0000-0000-000000000015"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000016"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000017"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000018"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000019"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000020"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000021"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000022"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000023"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000024"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000025"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000026"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000027"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000028"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000029"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000030"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000031"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000032"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000033"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000034"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000035"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000036"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000037"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000038"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000039"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000040"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000041"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000042"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000043"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000044"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000045"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000046"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000047"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000048"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000049"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000050"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000051"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000052"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000053"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000054"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000055"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000056"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000057"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000058"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000059"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000060"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000061"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000062"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000063"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000064"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000065"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000066"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_async()",
+    "historyId" : "ExamplesTests/XCTestTests/test_async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000067"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_asyncWithExpectation()",
+    "historyId" : "ExamplesTests/XCTestTests/test_asyncWithExpectation()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_asyncWithExpectation()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000068"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_attachmentInsideActivity()",
+    "historyId" : "ExamplesTests/XCTestTests/test_attachmentInsideActivity()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_attachmentInsideActivity()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000069"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_expectedFailure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 252,
+    "uuid" : "00000000-0000-0000-0000-000000000070"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000071"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000072"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000073"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000074"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000075"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000076"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "ExamplesTests/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000077"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "ExamplesTests/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000078"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_performance()",
+    "historyId" : "ExamplesTests/XCTestTests/test_performance()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_performance()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 261,
+    "uuid" : "00000000-0000-0000-0000-000000000079"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_skip()",
+    "historyId" : "ExamplesTests/XCTestTests/test_skip()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_skip()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Skip message"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000080"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_success()",
+    "historyId" : "ExamplesTests/XCTestTests/test_success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000081"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000082"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000083"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000084"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000085"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withMultipleAttachments()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000086"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withPNGAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000087"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withWarning()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withWarning()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withWarning()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000088"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000089"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000090"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 15,
+    "status" : "passed",
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000091"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000092"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000093"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000094"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000095"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000096"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000097"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000098"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000099"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000100"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000101"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 20,
+    "status" : "passed",
+    "stop" : 33,
+    "uuid" : "00000000-0000-0000-0000-000000000102"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 34,
+    "status" : "passed",
+    "stop" : 47,
+    "uuid" : "00000000-0000-0000-0000-000000000103"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000104"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000105"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 15,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000106"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000107"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000108"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000109"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000110"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000111"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000112"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000113"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000114"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000115"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000116"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000117"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000118"
+  }
+]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-watchOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-watchOS_allure.txt
@@ -1,0 +1,2745 @@
+[
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000001"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 26,
+    "uuid" : "00000000-0000-0000-0000-000000000002"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "ExamplesTests/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 27,
+    "status" : "passed",
+    "stop" : 40,
+    "uuid" : "00000000-0000-0000-0000-000000000003"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000004"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000005"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "ExamplesTests/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000006"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000007"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000008"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000009"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000010"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000011"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000012"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1772,
+    "uuid" : "00000000-0000-0000-0000-000000000013"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1773,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 4043,
+    "uuid" : "00000000-0000-0000-0000-000000000014"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4044,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 6452,
+    "uuid" : "00000000-0000-0000-0000-000000000015"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000016"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000017"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "ExamplesTests/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000018"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000019"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000020"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000021"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000022"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000023"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "ExamplesTests/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000024"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000025"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000026"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "ExamplesTests/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000027"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000028"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000029"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "ExamplesTests/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: Caught error: .divisionByZero"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000030"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000031"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000032"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000033"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000034"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000035"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000036"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000037"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000038"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000039"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000040"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000041"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "ExamplesTests/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000042"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000043"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000044"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "ExamplesTests/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000045"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000046"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000047"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000048"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000049"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000050"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000051"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000052"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000053"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000054"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000055"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000056"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000057"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000058"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000059"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000060"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000061"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000062"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000063"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000064"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000065"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000066"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_async()",
+    "historyId" : "ExamplesTests/XCTestTests/test_async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000067"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_asyncWithExpectation()",
+    "historyId" : "ExamplesTests/XCTestTests/test_asyncWithExpectation()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_asyncWithExpectation()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000068"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_attachmentInsideActivity()",
+    "historyId" : "ExamplesTests/XCTestTests/test_attachmentInsideActivity()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_attachmentInsideActivity()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000069"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_expectedFailure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 687,
+    "uuid" : "00000000-0000-0000-0000-000000000070"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000071"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000072"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000073"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000074"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000075"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000076"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "ExamplesTests/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000077"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "ExamplesTests/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000078"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_performance()",
+    "historyId" : "ExamplesTests/XCTestTests/test_performance()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_performance()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 258,
+    "uuid" : "00000000-0000-0000-0000-000000000079"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_skip()",
+    "historyId" : "ExamplesTests/XCTestTests/test_skip()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_skip()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Skip message"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000080"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_success()",
+    "historyId" : "ExamplesTests/XCTestTests/test_success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000081"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000082"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000083"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "ExamplesTests/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000084"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000085"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withMultipleAttachments()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000086"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withPNGAttachment()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000087"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withWarning()",
+    "historyId" : "ExamplesTests/XCTestTests/test_withWarning()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "test_withWarning()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000088"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000089"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000090"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000091"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000092"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000093"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "ExamplesTests/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000094"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000095"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000096"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "ExamplesTests/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000097"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000098"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000099"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "ExamplesTests/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000100"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000101"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 26,
+    "uuid" : "00000000-0000-0000-0000-000000000102"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "ExamplesTests/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 27,
+    "status" : "passed",
+    "stop" : 40,
+    "uuid" : "00000000-0000-0000-0000-000000000103"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000104"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000105"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "ExamplesTests/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000106"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000107"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000108"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "ExamplesTests/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000109"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000110"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000111"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "ExamplesTests/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000112"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000113"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000114"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "ExamplesTests/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000115"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000116"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000117"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000118"
+  }
+]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.Xcworkspace-iOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.Xcworkspace-iOS_allure.txt
@@ -1,0 +1,2745 @@
+[
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000001"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 15,
+    "status" : "passed",
+    "stop" : 28,
+    "uuid" : "00000000-0000-0000-0000-000000000002"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 29,
+    "status" : "passed",
+    "stop" : 113,
+    "uuid" : "00000000-0000-0000-0000-000000000003"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000004"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000005"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000006"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000007"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000008"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 91,
+    "uuid" : "00000000-0000-0000-0000-000000000009"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000010"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000011"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 89,
+    "uuid" : "00000000-0000-0000-0000-000000000012"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000013"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000014"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 89,
+    "uuid" : "00000000-0000-0000-0000-000000000015"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000016"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000017"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 30,
+    "status" : "passed",
+    "stop" : 105,
+    "uuid" : "00000000-0000-0000-0000-000000000018"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000019"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000020"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 81,
+    "uuid" : "00000000-0000-0000-0000-000000000021"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 82,
+    "status" : "passed",
+    "stop" : 83,
+    "uuid" : "00000000-0000-0000-0000-000000000022"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 84,
+    "status" : "passed",
+    "stop" : 84,
+    "uuid" : "00000000-0000-0000-0000-000000000023"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 85,
+    "status" : "passed",
+    "stop" : 85,
+    "uuid" : "00000000-0000-0000-0000-000000000024"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000025"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000026"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "passed",
+    "stop" : 87,
+    "uuid" : "00000000-0000-0000-0000-000000000027"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000028"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
+    },
+    "stop" : 39,
+    "uuid" : "00000000-0000-0000-0000-000000000029"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 40,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
+    },
+    "stop" : 115,
+    "uuid" : "00000000-0000-0000-0000-000000000030"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000031"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000032"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 82,
+    "uuid" : "00000000-0000-0000-0000-000000000033"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000034"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000035"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "passed",
+    "stop" : 89,
+    "uuid" : "00000000-0000-0000-0000-000000000036"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000037"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000038"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 88,
+    "uuid" : "00000000-0000-0000-0000-000000000039"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000040"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000041"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 83,
+    "uuid" : "00000000-0000-0000-0000-000000000042"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000043"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 32,
+    "uuid" : "00000000-0000-0000-0000-000000000044"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 33,
+    "status" : "passed",
+    "stop" : 152,
+    "uuid" : "00000000-0000-0000-0000-000000000045"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000046"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 38,
+    "uuid" : "00000000-0000-0000-0000-000000000047"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 39,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 158,
+    "uuid" : "00000000-0000-0000-0000-000000000048"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000049"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 31,
+    "uuid" : "00000000-0000-0000-0000-000000000050"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 32,
+    "status" : "passed",
+    "stop" : 153,
+    "uuid" : "00000000-0000-0000-0000-000000000051"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000052"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000053"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 87,
+    "uuid" : "00000000-0000-0000-0000-000000000054"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000055"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000056"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 86,
+    "uuid" : "00000000-0000-0000-0000-000000000057"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000058"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000059"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000060"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000061"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000062"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000063"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000064"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000065"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000066"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_async()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000067"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_asyncWithExpectation()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_asyncWithExpectation()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_asyncWithExpectation()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000068"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_attachmentInsideActivity()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_attachmentInsideActivity()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_attachmentInsideActivity()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000069"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_expectedFailure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 287,
+    "uuid" : "00000000-0000-0000-0000-000000000070"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000071"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000072"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1791,
+    "uuid" : "00000000-0000-0000-0000-000000000073"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000074"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 27,
+    "uuid" : "00000000-0000-0000-0000-000000000075"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 28,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000076"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000077"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 18,
+    "status" : "passed",
+    "stop" : 18,
+    "uuid" : "00000000-0000-0000-0000-000000000078"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_performance()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_performance()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_performance()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 254,
+    "uuid" : "00000000-0000-0000-0000-000000000079"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_skip()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_skip()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_skip()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Skip message"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000080"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_success()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000081"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000082"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000083"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000084"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000085"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000086"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000087"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withWarning()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withWarning()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withWarning()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000088"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "XcodeprojExample.app/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000089"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "XcodeprojExample.app/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 30,
+    "uuid" : "00000000-0000-0000-0000-000000000090"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "XcodeprojExample.app/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 31,
+    "status" : "passed",
+    "stop" : 81,
+    "uuid" : "00000000-0000-0000-0000-000000000091"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "XcodeprojExample.app/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000092"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "XcodeprojExample.app/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 31,
+    "uuid" : "00000000-0000-0000-0000-000000000093"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "XcodeprojExample.app/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 32,
+    "status" : "passed",
+    "stop" : 81,
+    "uuid" : "00000000-0000-0000-0000-000000000094"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "XcodeprojExample.app/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000095"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "XcodeprojExample.app/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 31,
+    "uuid" : "00000000-0000-0000-0000-000000000096"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "XcodeprojExample.app/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 32,
+    "status" : "passed",
+    "stop" : 78,
+    "uuid" : "00000000-0000-0000-0000-000000000097"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000098"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 31,
+    "uuid" : "00000000-0000-0000-0000-000000000099"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 32,
+    "status" : "passed",
+    "stop" : 81,
+    "uuid" : "00000000-0000-0000-0000-000000000100"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "XcodeprojExample.app/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000101"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "XcodeprojExample.app/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "passed",
+    "stop" : 52,
+    "uuid" : "00000000-0000-0000-0000-000000000102"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "XcodeprojExample.app/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 53,
+    "status" : "passed",
+    "stop" : 174,
+    "uuid" : "00000000-0000-0000-0000-000000000103"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "XcodeprojExample.app/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000104"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "XcodeprojExample.app/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 38,
+    "uuid" : "00000000-0000-0000-0000-000000000105"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "XcodeprojExample.app/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 39,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 89,
+    "uuid" : "00000000-0000-0000-0000-000000000106"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "XcodeprojExample.app/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000107"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "XcodeprojExample.app/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 32,
+    "uuid" : "00000000-0000-0000-0000-000000000108"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "XcodeprojExample.app/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 33,
+    "status" : "passed",
+    "stop" : 83,
+    "uuid" : "00000000-0000-0000-0000-000000000109"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "XcodeprojExample.app/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000110"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "XcodeprojExample.app/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 31,
+    "uuid" : "00000000-0000-0000-0000-000000000111"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "XcodeprojExample.app/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 32,
+    "status" : "passed",
+    "stop" : 82,
+    "uuid" : "00000000-0000-0000-0000-000000000112"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "XcodeprojExample.app/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000113"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "XcodeprojExample.app/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 31,
+    "uuid" : "00000000-0000-0000-0000-000000000114"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "XcodeprojExample.app/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 32,
+    "status" : "passed",
+    "stop" : 78,
+    "uuid" : "00000000-0000-0000-0000-000000000115"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "XcodeprojExample.app/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000116"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "XcodeprojExample.app/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 31,
+    "uuid" : "00000000-0000-0000-0000-000000000117"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "XcodeprojExample.app/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 32,
+    "status" : "passed",
+    "stop" : 151,
+    "uuid" : "00000000-0000-0000-0000-000000000118"
+  }
+]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.Xcworkspace-macOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.Xcworkspace-macOS_allure.txt
@@ -1,0 +1,2745 @@
+[
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000001"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "passed",
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000002"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 30,
+    "status" : "passed",
+    "stop" : 43,
+    "uuid" : "00000000-0000-0000-0000-000000000003"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000004"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000005"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000006"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000007"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000008"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000009"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000010"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000011"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000012"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 36,
+    "uuid" : "00000000-0000-0000-0000-000000000013"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 37,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 70,
+    "uuid" : "00000000-0000-0000-0000-000000000014"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 71,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 101,
+    "uuid" : "00000000-0000-0000-0000-000000000015"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000016"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000017"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000018"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000019"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000020"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000021"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000022"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000023"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000024"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000025"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000026"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000027"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
+    },
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000028"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000029"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
+    },
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000030"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000031"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000032"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000033"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 9,
+    "uuid" : "00000000-0000-0000-0000-000000000034"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 10,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000035"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000036"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000037"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000038"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000039"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000040"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000041"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000042"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000043"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000044"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000045"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000046"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000047"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000048"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000049"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000050"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000051"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000052"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000053"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000054"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000055"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000056"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000057"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000058"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000059"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000060"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000061"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000062"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000063"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000064"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000065"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000066"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_async()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000067"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_asyncWithExpectation()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_asyncWithExpectation()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_asyncWithExpectation()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000068"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_attachmentInsideActivity()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_attachmentInsideActivity()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_attachmentInsideActivity()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000069"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_expectedFailure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 48,
+    "uuid" : "00000000-0000-0000-0000-000000000070"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000071"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000072"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000073"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000074"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000075"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000076"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000077"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000078"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_performance()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_performance()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_performance()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 257,
+    "uuid" : "00000000-0000-0000-0000-000000000079"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_skip()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_skip()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_skip()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Skip message"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000080"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_success()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000081"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000082"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000083"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000084"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000085"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000086"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000087"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withWarning()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withWarning()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withWarning()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000088"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "XcodeprojExample.app/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000089"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "XcodeprojExample.app/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000090"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "XcodeprojExample.app/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000091"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "XcodeprojExample.app/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000092"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "XcodeprojExample.app/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000093"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "XcodeprojExample.app/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000094"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "XcodeprojExample.app/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000095"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "XcodeprojExample.app/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000096"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "XcodeprojExample.app/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000097"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000098"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000099"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000100"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "XcodeprojExample.app/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000101"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "XcodeprojExample.app/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 17,
+    "status" : "passed",
+    "stop" : 30,
+    "uuid" : "00000000-0000-0000-0000-000000000102"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "XcodeprojExample.app/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 31,
+    "status" : "passed",
+    "stop" : 43,
+    "uuid" : "00000000-0000-0000-0000-000000000103"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "XcodeprojExample.app/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000104"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "XcodeprojExample.app/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000105"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "XcodeprojExample.app/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000106"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "XcodeprojExample.app/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000107"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "XcodeprojExample.app/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000108"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "XcodeprojExample.app/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000109"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "XcodeprojExample.app/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000110"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "XcodeprojExample.app/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 11,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000111"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "XcodeprojExample.app/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "passed",
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000112"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "XcodeprojExample.app/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000113"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "XcodeprojExample.app/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000114"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "XcodeprojExample.app/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000115"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "XcodeprojExample.app/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000116"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "XcodeprojExample.app/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 9,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000117"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "XcodeprojExample.app/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000118"
+  }
+]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.Xcworkspace-visionOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.Xcworkspace-visionOS_allure.txt
@@ -1,0 +1,2745 @@
+[
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 37,
+    "uuid" : "00000000-0000-0000-0000-000000000001"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 38,
+    "status" : "passed",
+    "stop" : 57,
+    "uuid" : "00000000-0000-0000-0000-000000000002"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/async()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 58,
+    "status" : "passed",
+    "stop" : 71,
+    "uuid" : "00000000-0000-0000-0000-000000000003"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000004"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000005"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/disabled()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/disabled()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "disabled()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Test skipped: Disabled reason"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000006"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000007"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 18,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 28,
+    "uuid" : "00000000-0000-0000-0000-000000000008"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/expectedFailure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 29,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 38,
+    "uuid" : "00000000-0000-0000-0000-000000000009"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000010"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 17,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 26,
+    "uuid" : "00000000-0000-0000-0000-000000000011"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failure()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 27,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000012"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000013"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 17,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 51,
+    "uuid" : "00000000-0000-0000-0000-000000000014"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 52,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 86,
+    "uuid" : "00000000-0000-0000-0000-000000000015"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000016"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 18,
+    "status" : "passed",
+    "stop" : 27,
+    "uuid" : "00000000-0000-0000-0000-000000000017"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flacky()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 28,
+    "status" : "passed",
+    "stop" : 30,
+    "uuid" : "00000000-0000-0000-0000-000000000018"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000019"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000020"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "false"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 12,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
+    },
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000021"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000022"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000023"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/flackyParameterized(value:)",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/flackyParameterized(value:)",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "flackyParameterized(value:)",
+    "parameters" : [
+      {
+        "name" : "arguments",
+        "value" : "true"
+      }
+    ],
+    "stage" : "finished",
+    "start" : 15,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000024"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000025"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 18,
+    "status" : "passed",
+    "stop" : 27,
+    "uuid" : "00000000-0000-0000-0000-000000000026"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/success()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 28,
+    "status" : "passed",
+    "stop" : 30,
+    "uuid" : "00000000-0000-0000-0000-000000000027"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
+    },
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000028"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 18,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
+    },
+    "stop" : 28,
+    "uuid" : "00000000-0000-0000-0000-000000000029"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/throwing()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 29,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
+    },
+    "stop" : 38,
+    "uuid" : "00000000-0000-0000-0000-000000000030"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000031"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 18,
+    "status" : "passed",
+    "stop" : 28,
+    "uuid" : "00000000-0000-0000-0000-000000000032"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 29,
+    "status" : "passed",
+    "stop" : 38,
+    "uuid" : "00000000-0000-0000-0000-000000000033"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000034"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "passed",
+    "stop" : 25,
+    "uuid" : "00000000-0000-0000-0000-000000000035"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 26,
+    "status" : "passed",
+    "stop" : 34,
+    "uuid" : "00000000-0000-0000-0000-000000000036"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000037"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 17,
+    "status" : "passed",
+    "stop" : 26,
+    "uuid" : "00000000-0000-0000-0000-000000000038"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 27,
+    "status" : "passed",
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000039"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 16,
+    "uuid" : "00000000-0000-0000-0000-000000000040"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 17,
+    "status" : "passed",
+    "stop" : 26,
+    "uuid" : "00000000-0000-0000-0000-000000000041"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "ExampleSUITests/withRawBinaryAttachment()",
+    "historyId" : "XcodeprojExample.app/ExampleSUITests/withRawBinaryAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "withRawBinaryAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 27,
+    "status" : "passed",
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000042"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000043"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 18,
+    "status" : "passed",
+    "stop" : 28,
+    "uuid" : "00000000-0000-0000-0000-000000000044"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/`outer with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/`outer with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`outer with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 29,
+    "status" : "passed",
+    "stop" : 31,
+    "uuid" : "00000000-0000-0000-0000-000000000045"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000046"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 24,
+    "uuid" : "00000000-0000-0000-0000-000000000047"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 25,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Outer suite failure: result was 200.0"
+    },
+    "stop" : 27,
+    "uuid" : "00000000-0000-0000-0000-000000000048"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000049"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "passed",
+    "stop" : 25,
+    "uuid" : "00000000-0000-0000-0000-000000000050"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 26,
+    "status" : "passed",
+    "stop" : 34,
+    "uuid" : "00000000-0000-0000-0000-000000000051"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000052"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000053"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Inner suite failure: result was 12.0"
+    },
+    "stop" : 24,
+    "uuid" : "00000000-0000-0000-0000-000000000054"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000055"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 13,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000056"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/innerSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/innerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "innerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "passed",
+    "stop" : 24,
+    "uuid" : "00000000-0000-0000-0000-000000000057"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000058"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000059"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Deeply nested failure: result was 0.0"
+    },
+    "stop" : 12,
+    "uuid" : "00000000-0000-0000-0000-000000000060"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000061"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000062"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000063"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000064"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000065"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "historyId" : "XcodeprojExample.app/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "deeplyNestedWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000066"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_async()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_async()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_async()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000067"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_asyncWithExpectation()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_asyncWithExpectation()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_asyncWithExpectation()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 11,
+    "uuid" : "00000000-0000-0000-0000-000000000068"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_attachmentInsideActivity()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_attachmentInsideActivity()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_attachmentInsideActivity()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000069"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_expectedFailure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_expectedFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_expectedFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "statusDetails" : {
+      "message" : "Failure is expected"
+    },
+    "stop" : 457,
+    "uuid" : "00000000-0000-0000-0000-000000000070"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000071"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000072"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failure()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1598,
+    "uuid" : "00000000-0000-0000-0000-000000000073"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000074"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 2,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 32,
+    "uuid" : "00000000-0000-0000-0000-000000000075"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_failureWithAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_failureWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_failureWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 33,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 34,
+    "uuid" : "00000000-0000-0000-0000-000000000076"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Flacky failure message: result was 2.0"
+    },
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000077"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_flacky()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_flacky()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_flacky()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 30,
+    "status" : "passed",
+    "stop" : 31,
+    "uuid" : "00000000-0000-0000-0000-000000000078"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_performance()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_performance()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_performance()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 254,
+    "uuid" : "00000000-0000-0000-0000-000000000079"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_skip()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_skip()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_skip()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "skipped",
+    "statusDetails" : {
+      "message" : "Skip message"
+    },
+    "stop" : 10,
+    "uuid" : "00000000-0000-0000-0000-000000000080"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_success()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_success()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_success()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000081"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000082"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000083"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_throwing()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_throwing()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_throwing()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
+    },
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000084"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000085"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withMultipleAttachments()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withMultipleAttachments()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withMultipleAttachments()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000086"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withPNGAttachment()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withPNGAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withPNGAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000087"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "XCTestTests/test_withWarning()",
+    "historyId" : "XcodeprojExample.app/XCTestTests/test_withWarning()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "test_withWarning()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 0,
+    "uuid" : "00000000-0000-0000-0000-000000000088"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "XcodeprojExample.app/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 2,
+    "uuid" : "00000000-0000-0000-0000-000000000089"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "XcodeprojExample.app/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 3,
+    "status" : "passed",
+    "stop" : 13,
+    "uuid" : "00000000-0000-0000-0000-000000000090"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "XcodeprojExample.app/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 14,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000091"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "XcodeprojExample.app/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000092"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "XcodeprojExample.app/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 20,
+    "status" : "passed",
+    "stop" : 30,
+    "uuid" : "00000000-0000-0000-0000-000000000093"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`array[0] is nil?`()",
+    "historyId" : "XcodeprojExample.app/`array[0] is nil?`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`array[0] is nil?`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 31,
+    "status" : "passed",
+    "stop" : 33,
+    "uuid" : "00000000-0000-0000-0000-000000000094"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "XcodeprojExample.app/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 4,
+    "uuid" : "00000000-0000-0000-0000-000000000095"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "XcodeprojExample.app/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 5,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000096"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`divide(10, 2) / returns 5`()",
+    "historyId" : "XcodeprojExample.app/`divide(10, 2) / returns 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`divide(10, 2) / returns 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "passed",
+    "stop" : 18,
+    "uuid" : "00000000-0000-0000-0000-000000000097"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 15,
+    "uuid" : "00000000-0000-0000-0000-000000000098"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 16,
+    "status" : "passed",
+    "stop" : 26,
+    "uuid" : "00000000-0000-0000-0000-000000000099"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`root level with spaces in name`()",
+    "historyId" : "XcodeprojExample.app/`root level with spaces in name`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`root level with spaces in name`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 27,
+    "status" : "passed",
+    "stop" : 29,
+    "uuid" : "00000000-0000-0000-0000-000000000100"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "XcodeprojExample.app/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 39,
+    "uuid" : "00000000-0000-0000-0000-000000000101"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "XcodeprojExample.app/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 40,
+    "status" : "passed",
+    "stop" : 60,
+    "uuid" : "00000000-0000-0000-0000-000000000102"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelAsync()",
+    "historyId" : "XcodeprojExample.app/rootLevelAsync()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelAsync()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 61,
+    "status" : "passed",
+    "stop" : 113,
+    "uuid" : "00000000-0000-0000-0000-000000000103"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "XcodeprojExample.app/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 19,
+    "uuid" : "00000000-0000-0000-0000-000000000104"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "XcodeprojExample.app/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 20,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 30,
+    "uuid" : "00000000-0000-0000-0000-000000000105"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelFailure()",
+    "historyId" : "XcodeprojExample.app/rootLevelFailure()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelFailure()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 31,
+    "status" : "failed",
+    "statusDetails" : {
+      "message" : "Expected 5.0 but got 6.0"
+    },
+    "stop" : 40,
+    "uuid" : "00000000-0000-0000-0000-000000000106"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "XcodeprojExample.app/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000107"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "XcodeprojExample.app/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 18,
+    "status" : "passed",
+    "stop" : 28,
+    "uuid" : "00000000-0000-0000-0000-000000000108"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelSuccess()",
+    "historyId" : "XcodeprojExample.app/rootLevelSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 29,
+    "status" : "passed",
+    "stop" : 30,
+    "uuid" : "00000000-0000-0000-0000-000000000109"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "XcodeprojExample.app/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 18,
+    "uuid" : "00000000-0000-0000-0000-000000000110"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "XcodeprojExample.app/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 19,
+    "status" : "passed",
+    "stop" : 21,
+    "uuid" : "00000000-0000-0000-0000-000000000111"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "rootLevelWithAttachment()",
+    "historyId" : "XcodeprojExample.app/rootLevelWithAttachment()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "rootLevelWithAttachment()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 22,
+    "status" : "passed",
+    "stop" : 24,
+    "uuid" : "00000000-0000-0000-0000-000000000112"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "XcodeprojExample.app/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000113"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "XcodeprojExample.app/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 14,
+    "uuid" : "00000000-0000-0000-0000-000000000114"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`success 🎯`()",
+    "historyId" : "XcodeprojExample.app/`success 🎯`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`success 🎯`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 15,
+    "status" : "passed",
+    "stop" : 17,
+    "uuid" : "00000000-0000-0000-0000-000000000115"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "XcodeprojExample.app/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 0,
+    "status" : "passed",
+    "stop" : 3,
+    "uuid" : "00000000-0000-0000-0000-000000000116"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "XcodeprojExample.app/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 4,
+    "status" : "passed",
+    "stop" : 6,
+    "uuid" : "00000000-0000-0000-0000-000000000117"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "XcodeprojExample.app/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "XcodeprojExample.app"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 7,
+    "status" : "passed",
+    "stop" : 8,
+    "uuid" : "00000000-0000-0000-0000-000000000118"
+  }
+]


### PR DESCRIPTION
## Summary

Adds `--format allure` to `peekie tests`: writes an allure-results directory ready for `allurectl upload` (Allure TestOps) or `allure generate` (Allure Report).

The niche is currently served by exporters built on the legacy per-test `xcresulttool get object` API — one process per test execution. On a real-world 327 MB bundle with 9390 tests (14015 executions including retries) that takes ~15 minutes; this formatter reuses the already-parsed `Report` from the bulk API and converts the same bundle in **~4 seconds**.

Output was validated for field-level parity against the legacy exporter on that bundle: multisets of `fullName`/`status`/`suite`/`name` match on all 14015 records, so switching preserves test history and success-rate statistics in Allure TestOps.

## Key Changes

- `AllureFormatter` in PeekieSDK: `results(report:startedAt:makeUUID:)` (pure, deterministic) and `write(report:to:)` (files + attachments). Identity follows eroshenkoam/xcresults conventions: `fullName` = canonical xcresult test identifier, `historyId` = `<target>/<fullName>`, one result per execution (repetition/device/arguments), `suite`/`runDestination` labels, arguments surfaced as Allure parameters.
- Executions of one test are chained on the timeline (`start`/`stop`), so consumers resolving retries by the latest `stop` pick the final attempt — matching the ordering real per-attempt timestamps produce.
- `peekie tests <xcresult> --format allure --output-dir <dir>`; attachments are auto-exported to a temporary directory when `--attachments export` isn't set.
- `RepeatableTest.nodeIdentifier`: test-case nodes now surface the canonical identifier. For parameterized tests it is the function signature (`getValue(input:expected:)`), which no display-name heuristic can reconstruct — a display-name fallback exists for reports built without it. The field is omitted from Mirror-based dumps, keeping existing `Report` snapshots byte-for-byte stable (same approach as `Test.attachments`).

## Additional Changes

- README: `allure` format documented in the `peekie tests` section.
- Snapshot + unit tests: `AllureFormatterSnapshotTests` (all resource bundles, deterministic UUIDs), identifier derivation edge cases (parameterized signatures, nested suites, `/` inside backticked display names), `write` smoke test with attachments.