### PR TITLE
Map XCTest activities to Allure steps via --steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,13 @@ peekie tests Tests.xcresult --format sonar --tests-path Tests > sonar-tests.xml
 
 # Allure 2 results directory, ready for `allurectl upload` / `allure generate`
 peekie tests Tests.xcresult --format allure --output-dir allure-results
+
+# Same, with XCTest activities mapped to Allure steps and metadata labels
+# (allure.id / allure.label.* / allure.name / allure.description) — for UI tests
+peekie tests UITests.xcresult --format allure --output-dir allure-results --steps
 ```
 
-**Options:** `--include` (comma-separated statuses), `--include-device-details`, `--tests-path` (required with `--format sonar`), `--output-dir` (required with `--format allure`), `--attachments skip|export` + `--attachments-to <dir>` (embeds attachment metadata into each test in the JSON output; required together when exporting).
+**Options:** `--include` (comma-separated statuses), `--include-device-details`, `--tests-path` (required with `--format sonar`), `--output-dir` (required with `--format allure`), `--steps` (with `--format allure`: activities → steps and labels; one extra `xcresulttool` call per test), `--attachments skip|export` + `--attachments-to <dir>` (embeds attachment metadata into each test in the JSON output; required together when exporting).
 
 ### `peekie warnings`
 

--- a/Sources/Peekie/Tests.swift
+++ b/Sources/Peekie/Tests.swift
@@ -49,6 +49,14 @@ public struct Tests: AsyncParsableCommand {
     )
     public var outputDir: String?
 
+    @Flag(
+        help: """
+        With --format allure: map XCTest activities to Allure steps and metadata labels \
+        (one extra xcresulttool call per test — recommended for UI test bundles).
+        """
+    )
+    public var steps = false
+
     @Option(help: "Attachments handling: skip (default) or export.")
     public var attachments = AttachmentsMode.skip
 
@@ -117,7 +125,7 @@ public struct Tests: AsyncParsableCommand {
                 throw ValidationError("--output-dir is required when --format allure")
             }
 
-            try exportAllure(report: report, outputDir: outputDir)
+            try await exportAllure(report: report, outputDir: outputDir)
         }
     }
 
@@ -148,12 +156,21 @@ public struct Tests: AsyncParsableCommand {
         }
     }
 
-    private func exportAllure(report: Report, outputDir: String) throws {
+    private func exportAllure(report: Report, outputDir: String) async throws {
         let formatter = PeekieSDK.AllureFormatter()
-        let summary = try formatter.write(
-            report: report,
-            to: URL(fileURLWithPath: outputDir)
-        )
+        let summary: PeekieSDK.AllureFormatter.WriteSummary =
+            if steps {
+                try await formatter.write(
+                    report: report,
+                    to: URL(fileURLWithPath: outputDir),
+                    stepsFrom: URL(fileURLWithPath: xcresultPath)
+                )
+            } else {
+                try formatter.write(
+                    report: report,
+                    to: URL(fileURLWithPath: outputDir)
+                )
+            }
         let counts = summary.resultCountsByStatus
             .sorted { $0.key < $1.key }
             .map { "\($0.key): \($0.value)" }

--- a/Sources/PeekieSDK/Formatters/AllureFormatter+Steps.swift
+++ b/Sources/PeekieSDK/Formatters/AllureFormatter+Steps.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+// MARK: - Steps Support
+
+extension AllureFormatter {
+    /// Allure metadata extracted from specially-titled activities, the
+    /// convention established by eroshenkoam/xcresults:
+    /// `allure.id:`, `allure.name:`, `allure.description:`,
+    /// `allure.label.<name>:<value>`.
+    struct ActivityMetadata {
+        // MARK: Internal
+
+        var labels = [AllureTestResult.Label]()
+        var nameOverride: String?
+        var description: String?
+
+        /// Consumes the title when it is a metadata activity.
+        mutating func consume(title: String) -> Bool {
+            if let value = value(of: "allure.id:", in: title) {
+                labels.append(.init(name: "AS_ID", value: value))
+                return true
+            }
+            if let value = value(of: "allure.name:", in: title) {
+                nameOverride = value
+                return true
+            }
+            if let value = value(of: "allure.description:", in: title) {
+                description = value
+                return true
+            }
+            if title.hasPrefix("allure.label.") {
+                let payload = title.dropFirst("allure.label.".count)
+                guard let colon = payload.firstIndex(of: ":") else {
+                    return true
+                }
+
+                labels.append(.init(
+                    name: String(payload[..<colon]),
+                    value: String(payload[payload.index(after: colon)...])
+                        .trimmingCharacters(in: .whitespaces)
+                ))
+                return true
+            }
+            return false
+        }
+
+        // MARK: Private
+
+        private func value(of prefix: String, in title: String) -> String? {
+            guard title.hasPrefix(prefix) else {
+                return nil
+            }
+
+            return String(title.dropFirst(prefix.count)).trimmingCharacters(in: .whitespaces)
+        }
+    }
+
+    /// Maps one execution's activity tree to Allure steps, collecting metadata
+    /// labels, result-level attachments and consuming exported attachment files
+    /// referenced by activities.
+    struct StepsBuilder {
+        // MARK: Lifecycle
+
+        init(
+            testAttachments: [Report.Module.Suite.RepeatableTest.Test.Attachment],
+            makeUUID: @escaping () -> UUID
+        ) {
+            self.makeUUID = makeUUID
+            attachmentsByUUIDPrefix = .init(
+                testAttachments.map { attachment in
+                    ((attachment.exportedFileName as NSString).deletingPathExtension, attachment)
+                }
+            ) { first, _ in first }
+        }
+
+        // MARK: Internal
+
+        var metadata = ActivityMetadata()
+        var resultAttachments = [AllureTestResult.Attachment]()
+
+        /// Attachments not referenced from any activity — they stay on the
+        /// result itself so nothing exported is lost.
+        var unclaimedAttachments: [AllureTestResult.Attachment] {
+            attachmentsByUUIDPrefix.values.map { makeAllureAttachment(from: $0) }
+        }
+
+        /// Builds steps from activities. Metadata activities are consumed into
+        /// `metadata` at any depth; the synthetic "Start Test at …" activity is
+        /// not a step, but its attachments (e.g. screen recordings) surface on
+        /// the result.
+        mutating func makeSteps(
+            _ activities: [TestActivitiesDTO.Activity],
+            runStopMs: Int
+        )
+            -> [AllureTestResult.Step]
+        {
+            var steps = [AllureTestResult.Step]()
+
+            for (index, activity) in activities.enumerated() {
+                if metadata.consume(title: activity.title) {
+                    continue
+                }
+
+                let attachments = claimAttachments(of: activity)
+
+                if activity.title.hasPrefix("Start Test at") {
+                    resultAttachments.append(contentsOf: attachments)
+                    continue
+                }
+
+                let startMs = activity.startTime.map { Int(($0 * 1000).rounded()) } ?? runStopMs
+                let nextStartMs = activities.dropFirst(index + 1)
+                    .compactMap(\.startTime)
+                    .first
+                    .map { Int(($0 * 1000).rounded()) }
+                let stopMs = min(max(nextStartMs ?? runStopMs, startMs), runStopMs)
+
+                let childSteps = makeSteps(
+                    activity.childActivities ?? [],
+                    runStopMs: stopMs
+                )
+
+                steps.append(
+                    AllureTestResult.Step(
+                        name: activity.title,
+                        status: activity.isAssociatedWithFailure ? "failed" : "passed",
+                        stage: "finished",
+                        start: startMs,
+                        stop: stopMs,
+                        steps: childSteps,
+                        attachments: attachments
+                    )
+                )
+            }
+
+            return steps
+        }
+
+        // MARK: Private
+
+        private var attachmentsByUUIDPrefix: [
+            String: Report.Module.Suite.RepeatableTest.Test.Attachment
+        ]
+
+        private let makeUUID: () -> UUID
+
+        private mutating func claimAttachments(
+            of activity: TestActivitiesDTO.Activity
+        )
+            -> [AllureTestResult.Attachment]
+        {
+            (activity.attachments ?? []).compactMap { reference in
+                guard let uuid = reference.uuid,
+                      let attachment = attachmentsByUUIDPrefix.removeValue(forKey: uuid)
+                else {
+                    return nil
+                }
+
+                return makeAllureAttachment(from: attachment, nameOverride: reference.name)
+            }
+        }
+
+        private func makeAllureAttachment(
+            from attachment: Report.Module.Suite.RepeatableTest.Test.Attachment,
+            nameOverride: String? = nil
+        )
+            -> AllureTestResult.Attachment
+        {
+            let fileExtension = (attachment.exportedFileName as NSString).pathExtension
+            let suffix = fileExtension.isEmpty ? "" : ".\(fileExtension)"
+            return AllureTestResult.Attachment(
+                name: nameOverride ?? attachment.name,
+                source: "\(makeUUID().uuidString.lowercased())-attachment\(suffix)",
+                type: attachment.contentType,
+                originalPath: attachment.path
+            )
+        }
+    }
+
+    /// Loads activity trees for every test of the report that carries a
+    /// canonical identifier. Tests whose activities cannot be read still get
+    /// plain results — steps are an enrichment, not a requirement.
+    func loadActivities(
+        report: Report,
+        xcresultPath: URL
+    ) async
+        -> [String: TestActivitiesDTO]
+    {
+        var identifiers = [String]()
+        for module in report.modules {
+            let suites = report.suites(in: module).flatMap { Self.flatten($0) }
+            for suite in suites {
+                identifiers.append(contentsOf: suite.repeatableTests.compactMap(\.nodeIdentifier))
+            }
+            identifiers.append(
+                contentsOf: report.rootLevelTests(in: module).compactMap(\.nodeIdentifier)
+            )
+        }
+
+        var result = [String: TestActivitiesDTO]()
+        for identifier in identifiers {
+            guard let dto = try? await TestActivitiesDTO.load(
+                xcresultPath: xcresultPath,
+                testIdentifier: identifier
+            ) else {
+                continue
+            }
+
+            result[identifier] = dto
+        }
+        return result
+    }
+}

--- a/Sources/PeekieSDK/Formatters/AllureFormatter.swift
+++ b/Sources/PeekieSDK/Formatters/AllureFormatter.swift
@@ -1,94 +1,5 @@
 import Foundation
 
-// MARK: - AllureTestResult
-
-/// A single Allure 2 test result, one `<uuid>-result.json` file worth of data.
-///
-/// Field set follows the [Allure 2 result
-/// schema](https://allurereport.org/docs/how-it-works-test-result-file/)
-/// as produced by the de-facto standard xcresult exporter
-/// [eroshenkoam/xcresults](https://github.com/eroshenkoam/xcresults), so migrating
-/// to Peekie preserves test identity in Allure TestOps:
-/// - `fullName` is the legacy xcresult test identifier, e.g. ``Suite/`display name`()``;
-/// - `historyId` is `<target>/<fullName>`;
-/// - a result is emitted per execution (repetition × device × arguments), and executions
-///   of one test are chained on the timeline so retry resolution picks the final attempt.
-public struct AllureTestResult: Encodable {
-    // MARK: Public
-
-    public struct Label: Encodable {
-        public let name: String
-        public let value: String
-    }
-
-    public struct Parameter: Encodable {
-        public let name: String
-        public let value: String
-    }
-
-    public struct StatusDetails: Encodable {
-        public let message: String
-    }
-
-    public struct Attachment: Encodable {
-        // MARK: Public
-
-        /// Human-readable attachment name as set in test code.
-        public let name: String
-
-        /// File name inside the allure-results directory (`<uuid>-attachment.<ext>`).
-        public let source: String
-
-        /// MIME type when known.
-        public let type: String?
-
-        // MARK: Internal
-
-        enum CodingKeys: String, CodingKey {
-            case name
-            case source
-            case type
-        }
-
-        /// Where the exported file currently lives on disk; used by
-        /// ``AllureFormatter/write(report:to:startedAt:makeUUID:)`` to copy the
-        /// file next to the result JSONs. Not part of the Allure schema.
-        let originalPath: URL
-    }
-
-    public let uuid: String
-    public let historyID: String
-    public let fullName: String
-    public let name: String
-    public let status: String
-    public let stage: String
-    public let start: Int
-    public let stop: Int
-    public let labels: [Label]
-    public let parameters: [Parameter]
-    public let statusDetails: StatusDetails?
-    public let attachments: [Attachment]
-
-    // MARK: Internal
-
-    /// The Allure 2 schema spells the key `historyId`; the property follows
-    /// Swift acronym casing, so the mapping is explicit.
-    enum CodingKeys: String, CodingKey {
-        case uuid
-        case historyID = "historyId"
-        case fullName
-        case name
-        case status
-        case stage
-        case start
-        case stop
-        case labels
-        case parameters
-        case statusDetails
-        case attachments
-    }
-}
-
 // MARK: - AllureFormatter
 
 /// Formatter that emits test results in Allure 2 format.
@@ -99,7 +10,11 @@ public struct AllureTestResult: Encodable {
 ///
 /// Unlike exporters built on the legacy `xcresulttool get object` API (one process
 /// per test — minutes on large bundles), this formatter reuses the already-parsed
-/// ``Report``, so the only cost on top of `Report(xcresultPath:)` is writing files.
+/// ``Report``. The `stepsFrom` variants additionally read per-test activity trees
+/// (`xcresulttool get test-results activities`) and map them to Allure steps,
+/// labels (`allure.label.<name>:<value>`, `allure.id:<value>`), name and
+/// description overrides — one cheap call per test, worthwhile for UI test
+/// bundles where the step log is the report's main content.
 public final class AllureFormatter {
     // MARK: Lifecycle
 
@@ -108,7 +23,7 @@ public final class AllureFormatter {
 
     // MARK: Public
 
-    /// Totals of a completed ``write(report:to:startedAt:makeUUID:)`` call.
+    /// Totals of a completed `write` call.
     public struct WriteSummary {
         /// Number of result files written, keyed by Allure status.
         public let resultCountsByStatus: [String: Int]
@@ -123,10 +38,10 @@ public final class AllureFormatter {
     /// Builds Allure results from a report. Pure transform: deterministic given
     /// `startedAt` and `makeUUID`.
     ///
-    /// Executions of one test are chained back-to-back starting at `startedAt`
-    /// so that consumers resolving retries by the latest `stop` (Allure TestOps,
-    /// Allure Report) pick the final attempt — the same order real per-attempt
-    /// timestamps would produce.
+    /// Without activity data there are no per-attempt timestamps, so executions
+    /// of one test are chained back-to-back starting at `startedAt` — consumers
+    /// resolving retries by the latest `stop` (Allure TestOps, Allure Report)
+    /// then pick the final attempt, the same order real timestamps would produce.
     ///
     /// - Parameters:
     ///   - report: Parsed report; build it with `attachments: .extractTo(_)` if
@@ -136,43 +51,36 @@ public final class AllureFormatter {
     public func results(
         report: Report,
         startedAt: Date,
-        makeUUID: () -> UUID = UUID.init
+        makeUUID: @escaping () -> UUID = UUID.init
     )
         -> [AllureTestResult]
     {
-        var results = [AllureTestResult]()
-        let baseStartMs = Int((startedAt.timeIntervalSince1970 * 1000).rounded())
+        makeResults(
+            report: report,
+            startedAt: startedAt,
+            activitiesByIdentifier: [:],
+            makeUUID: makeUUID
+        )
+    }
 
-        for module in report.modules.sorted(by: { $0.name < $1.name }) {
-            let suites = report.suites(in: module).flatMap { Self.flatten($0) }
-            for suite in suites.sorted(by: { $0.fullPath < $1.fullPath }) {
-                let prefix = Self.suiteIdentifierPrefix(from: suite.nodeIdentifierURL)
-                for repeatableTest in suite.repeatableTests.sorted(by: { $0.name < $1.name }) {
-                    append(
-                        repeatableTest,
-                        module: module,
-                        suitePrefix: prefix,
-                        baseStartMs: baseStartMs,
-                        makeUUID: makeUUID,
-                        into: &results
-                    )
-                }
-            }
-
-            let rootLevelTests = report.rootLevelTests(in: module)
-            for repeatableTest in rootLevelTests.sorted(by: { $0.name < $1.name }) {
-                append(
-                    repeatableTest,
-                    module: module,
-                    suitePrefix: nil,
-                    baseStartMs: baseStartMs,
-                    makeUUID: makeUUID,
-                    into: &results
-                )
-            }
-        }
-
-        return results
+    /// Builds Allure results with steps: reads the activity tree of every test
+    /// from the bundle and maps it to Allure steps and metadata labels. Attempt
+    /// timestamps come from the activities, so retries carry real times.
+    public func results(
+        report: Report,
+        startedAt: Date,
+        stepsFrom xcresultPath: URL,
+        makeUUID: @escaping () -> UUID = UUID.init
+    ) async
+        -> [AllureTestResult]
+    {
+        let activities = await loadActivities(report: report, xcresultPath: xcresultPath)
+        return makeResults(
+            report: report,
+            startedAt: startedAt,
+            activitiesByIdentifier: activities,
+            makeUUID: makeUUID
+        )
     }
 
     /// Writes Allure results and their attachment files into `outputDirectory`,
@@ -182,44 +90,35 @@ public final class AllureFormatter {
         report: Report,
         to outputDirectory: URL,
         startedAt: Date = Date(),
-        makeUUID: () -> UUID = UUID.init
+        makeUUID: @escaping () -> UUID = UUID.init
     ) throws
         -> WriteSummary
     {
-        let fileManager = FileManager.default
-        try fileManager.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        try write(
+            items: results(report: report, startedAt: startedAt, makeUUID: makeUUID),
+            to: outputDirectory
+        )
+    }
 
-        let items = results(report: report, startedAt: startedAt, makeUUID: makeUUID)
-
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-
-        var countsByStatus = [String: Int]()
-        var attachmentsTotal = 0
-
-        for item in items {
-            countsByStatus[item.status, default: 0] += 1
-
-            for attachment in item.attachments {
-                let destination = outputDirectory.appendingPathComponent(attachment.source)
-                do {
-                    try fileManager.copyItem(at: attachment.originalPath, to: destination)
-                    attachmentsTotal += 1
-                } catch {
-                    // A missing attachment file should not sink the whole export:
-                    // results are the valuable part, attachments are extras.
-                    continue
-                }
-            }
-
-            let fileURL = outputDirectory.appendingPathComponent("\(item.uuid)-result.json")
-            try encoder.encode(item).write(to: fileURL)
-        }
-
-        return WriteSummary(
-            resultCountsByStatus: countsByStatus,
-            resultsTotal: items.count,
-            attachmentsTotal: attachmentsTotal
+    /// Writes Allure results with steps — see ``results(report:startedAt:stepsFrom:makeUUID:)``.
+    @discardableResult
+    public func write(
+        report: Report,
+        to outputDirectory: URL,
+        stepsFrom xcresultPath: URL,
+        startedAt: Date = Date(),
+        makeUUID: @escaping () -> UUID = UUID.init
+    ) async throws
+        -> WriteSummary
+    {
+        try await write(
+            items: results(
+                report: report,
+                startedAt: startedAt,
+                stepsFrom: xcresultPath,
+                makeUUID: makeUUID
+            ),
+            to: outputDirectory
         )
     }
 
@@ -289,11 +188,11 @@ public final class AllureFormatter {
             .joined(separator: "/")
     }
 
-    // MARK: Private
-
-    private static func flatten(_ suite: Report.Module.Suite) -> [Report.Module.Suite] {
+    static func flatten(_ suite: Report.Module.Suite) -> [Report.Module.Suite] {
         [suite] + suite.nestedSuites.flatMap { flatten($0) }
     }
+
+    // MARK: Private
 
     private static func isPlainFunctionName(_ name: String) -> Bool {
         guard name.hasSuffix("()") else {
@@ -322,68 +221,177 @@ public final class AllureFormatter {
         }
     }
 
-    private func append(
+    private func write(items: [AllureTestResult], to outputDirectory: URL) throws -> WriteSummary {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
+        var countsByStatus = [String: Int]()
+        var attachmentsTotal = 0
+
+        for item in items {
+            countsByStatus[item.status, default: 0] += 1
+
+            for attachment in item.allAttachments {
+                let destination = outputDirectory.appendingPathComponent(attachment.source)
+                do {
+                    try fileManager.copyItem(at: attachment.originalPath, to: destination)
+                    attachmentsTotal += 1
+                } catch {
+                    // A missing attachment file should not sink the whole export:
+                    // results are the valuable part, attachments are extras.
+                    continue
+                }
+            }
+
+            let fileURL = outputDirectory.appendingPathComponent("\(item.uuid)-result.json")
+            try encoder.encode(item).write(to: fileURL)
+        }
+
+        return WriteSummary(
+            resultCountsByStatus: countsByStatus,
+            resultsTotal: items.count,
+            attachmentsTotal: attachmentsTotal
+        )
+    }
+
+    private func makeResults(
+        report: Report,
+        startedAt: Date,
+        activitiesByIdentifier: [String: TestActivitiesDTO],
+        makeUUID: @escaping () -> UUID
+    )
+        -> [AllureTestResult]
+    {
+        var results = [AllureTestResult]()
+        let baseStartMs = Int((startedAt.timeIntervalSince1970 * 1000).rounded())
+
+        for module in report.modules.sorted(by: { $0.name < $1.name }) {
+            let suites = report.suites(in: module).flatMap { Self.flatten($0) }
+            for suite in suites.sorted(by: { $0.fullPath < $1.fullPath }) {
+                let prefix = Self.suiteIdentifierPrefix(from: suite.nodeIdentifierURL)
+                for repeatableTest in suite.repeatableTests.sorted(by: { $0.name < $1.name }) {
+                    append(
+                        repeatableTest,
+                        context: EmitContext(
+                            module: module,
+                            suitePrefix: prefix,
+                            activities: repeatableTest.nodeIdentifier
+                                .flatMap { activitiesByIdentifier[$0] },
+                            baseStartMs: baseStartMs,
+                            makeUUID: makeUUID
+                        ),
+                        into: &results
+                    )
+                }
+            }
+
+            let rootLevelTests = report.rootLevelTests(in: module)
+            for repeatableTest in rootLevelTests.sorted(by: { $0.name < $1.name }) {
+                append(
+                    repeatableTest,
+                    context: EmitContext(
+                        module: module,
+                        suitePrefix: nil,
+                        activities: repeatableTest.nodeIdentifier
+                            .flatMap { activitiesByIdentifier[$0] },
+                        baseStartMs: baseStartMs,
+                        makeUUID: makeUUID
+                    ),
+                    into: &results
+                )
+            }
+        }
+
+        return results
+    }
+}
+
+// MARK: - Emitting
+
+private extension AllureFormatter {
+    /// Everything one test needs to be emitted: its target, suite identifier
+    /// prefix, optional activity trees and the timeline origin.
+    struct EmitContext {
+        let module: Report.Module
+        let suitePrefix: String?
+        let activities: TestActivitiesDTO?
+        let baseStartMs: Int
+        let makeUUID: () -> UUID
+    }
+
+    func append(
         _ repeatableTest: Report.Module.Suite.RepeatableTest,
-        module: Report.Module,
-        suitePrefix: String?,
-        baseStartMs: Int,
-        makeUUID: () -> UUID,
+        context: EmitContext,
         into results: inout [AllureTestResult]
     ) {
+        let module = context.module
+        let activities = context.activities
+        let makeUUID = context.makeUUID
+
         let fullName: String
         if let identifier = repeatableTest.nodeIdentifier {
             fullName = identifier
         } else {
             let testName = Self.legacyTestName(repeatableTest.name)
-            fullName = suitePrefix.map { "\($0)/\(testName)" } ?? testName
+            fullName = context.suitePrefix.map { "\($0)/\(testName)" } ?? testName
         }
-        let name = Self.testName(fromIdentifier: fullName)
+        let defaultName = Self.testName(fromIdentifier: fullName)
         let historyID = "\(module.name)/\(fullName)"
 
-        // Executions run back-to-back on the timeline; see `results(report:...)`.
-        var cursor = baseStartMs
-        for test in repeatableTest.tests {
+        // Without real timestamps the executions run back-to-back on the
+        // timeline; see `results(report:startedAt:makeUUID:)`.
+        var chainCursorMs = context.baseStartMs
+        for (index, test) in repeatableTest.tests.enumerated() {
             let durationMs = Int(test.duration.converted(to: .milliseconds).value.rounded())
-            let start = cursor
+            let runActivities = activities?.testRuns[safe: index]?.activities ?? []
+
+            let realStartMs = runActivities.first?.startTime.map { Int(($0 * 1000).rounded()) }
+            let start = realStartMs ?? chainCursorMs
             let stop = start + durationMs
-            cursor = stop + 1
+            chainCursorMs = stop + 1
+
+            var builder = StepsBuilder(testAttachments: test.attachments, makeUUID: makeUUID)
+            let steps = builder.makeSteps(runActivities, runStopMs: stop)
 
             var labels = [AllureTestResult.Label(name: "suite", value: module.name)]
             if let device = test.path.first(where: { $0.type == .device }) {
                 labels.append(.init(name: "runDestination", value: device.name))
             }
+            labels.append(contentsOf: builder.metadata.labels)
 
             let parameters = test.path
                 .filter { $0.type == .arguments }
                 .map { AllureTestResult.Parameter(name: "arguments", value: $0.name) }
-
-            let attachments = test.attachments.map { attachment in
-                let fileExtension = (attachment.exportedFileName as NSString).pathExtension
-                let suffix = fileExtension.isEmpty ? "" : ".\(fileExtension)"
-                return AllureTestResult.Attachment(
-                    name: attachment.name,
-                    source: "\(makeUUID().uuidString.lowercased())-attachment\(suffix)",
-                    type: attachment.contentType,
-                    originalPath: attachment.path
-                )
-            }
 
             results.append(
                 AllureTestResult(
                     uuid: makeUUID().uuidString.lowercased(),
                     historyID: historyID,
                     fullName: fullName,
-                    name: name,
+                    name: builder.metadata.nameOverride ?? defaultName,
                     status: Self.allureStatus(test.status),
                     stage: "finished",
                     start: start,
                     stop: stop,
+                    description: builder.metadata.description,
                     labels: labels,
                     parameters: parameters,
                     statusDetails: test.message.map { .init(message: $0) },
-                    attachments: attachments
+                    steps: steps,
+                    attachments: builder.resultAttachments + builder.unclaimedAttachments
                 )
             )
         }
+    }
+}
+
+// MARK: - Collection Helpers
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }

--- a/Sources/PeekieSDK/Formatters/AllureTestResult.swift
+++ b/Sources/PeekieSDK/Formatters/AllureTestResult.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+// MARK: - AllureTestResult
+
+/// A single Allure 2 test result, one `<uuid>-result.json` file worth of data.
+///
+/// Field set follows the [Allure 2 result
+/// schema](https://allurereport.org/docs/how-it-works-test-result-file/)
+/// as produced by the de-facto standard xcresult exporter
+/// [eroshenkoam/xcresults](https://github.com/eroshenkoam/xcresults), so migrating
+/// to Peekie preserves test identity in Allure TestOps:
+/// - `fullName` is the legacy xcresult test identifier, e.g. ``Suite/`display name`()``;
+/// - `historyId` is `<target>/<fullName>`;
+/// - a result is emitted per execution (repetition × device × arguments), and executions
+///   of one test are ordered on the timeline so retry resolution picks the final attempt.
+public struct AllureTestResult: Encodable {
+    // MARK: Public
+
+    public struct Label: Encodable {
+        public let name: String
+        public let value: String
+    }
+
+    public struct Parameter: Encodable {
+        public let name: String
+        public let value: String
+    }
+
+    public struct StatusDetails: Encodable {
+        public let message: String
+    }
+
+    public struct Attachment: Encodable {
+        // MARK: Public
+
+        /// Human-readable attachment name as set in test code.
+        public let name: String
+
+        /// File name inside the allure-results directory (`<uuid>-attachment.<ext>`).
+        public let source: String
+
+        /// MIME type when known.
+        public let type: String?
+
+        // MARK: Internal
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case source
+            case type
+        }
+
+        /// Where the exported file currently lives on disk; used by
+        /// ``AllureFormatter/write(report:to:startedAt:makeUUID:)`` to copy the
+        /// file next to the result JSONs. Not part of the Allure schema.
+        let originalPath: URL
+    }
+
+    /// A test step mapped from an XCTest activity.
+    public struct Step: Encodable {
+        public let name: String
+        public let status: String
+        public let stage: String
+        public let start: Int
+        public let stop: Int
+        public let steps: [Self]
+        public let attachments: [Attachment]
+    }
+
+    public let uuid: String
+    public let historyID: String
+    public let fullName: String
+    public let name: String
+    public let status: String
+    public let stage: String
+    public let start: Int
+    public let stop: Int
+    public let description: String?
+    public let labels: [Label]
+    public let parameters: [Parameter]
+    public let statusDetails: StatusDetails?
+    public let steps: [Step]
+    public var attachments: [Attachment]
+
+    // MARK: Internal
+
+    /// The Allure 2 schema spells the key `historyId`; the property follows
+    /// Swift acronym casing, so the mapping is explicit.
+    enum CodingKeys: String, CodingKey {
+        case uuid
+        case historyID = "historyId"
+        case fullName
+        case name
+        case status
+        case stage
+        case start
+        case stop
+        case description
+        case labels
+        case parameters
+        case statusDetails
+        case steps
+        case attachments
+    }
+
+    /// All attachments of the result, including the ones nested in steps.
+    /// ``AllureFormatter/write(report:to:startedAt:makeUUID:)`` copies files
+    /// from here so nothing referenced stays behind.
+    var allAttachments: [Attachment] {
+        func collect(_ steps: [Step]) -> [Attachment] {
+            steps.flatMap { $0.attachments + collect($0.steps) }
+        }
+        return attachments + collect(steps)
+    }
+}

--- a/Sources/PeekieSDK/Models/DTO/TestActivitiesDTO.swift
+++ b/Sources/PeekieSDK/Models/DTO/TestActivitiesDTO.swift
@@ -55,7 +55,6 @@ struct TestActivitiesDTO: Decodable {
         let uuid: String?
     }
 
-    let testIdentifier: String
     let testRuns: [TestRun]
 }
 

--- a/Sources/PeekieSDK/Models/DTO/TestActivitiesDTO.swift
+++ b/Sources/PeekieSDK/Models/DTO/TestActivitiesDTO.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Logging
+
+// MARK: - TestActivitiesDTO
+
+/// Per-test activity tree from `xcrun xcresulttool get test-results activities`.
+///
+/// Activities are the XCTest/XCUITest step log: `XCTContext.runActivity` titles,
+/// attachment markers, and Allure-style metadata activities
+/// (`allure.label.<name>:<value>`, `allure.id:<value>`). One `TestRun` per
+/// execution of the test, in the same order as `Repetition` nodes of the
+/// test-results tree.
+struct TestActivitiesDTO: Decodable {
+    struct TestRun: Decodable {
+        let activities: [Activity]?
+    }
+
+    struct Activity: Decodable {
+        // MARK: Lifecycle
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            title = try container.decode(String.self, forKey: .title)
+            startTime = try container.decodeIfPresent(Double.self, forKey: .startTime)
+            isAssociatedWithFailure = try container
+                .decodeIfPresent(Bool.self, forKey: .isAssociatedWithFailure) ?? false
+            childActivities = try container
+                .decodeIfPresent([Self].self, forKey: .childActivities)
+            attachments = try container
+                .decodeIfPresent([ActivityAttachment].self, forKey: .attachments)
+        }
+
+        // MARK: Internal
+
+        enum CodingKeys: String, CodingKey {
+            case title
+            case startTime
+            case isAssociatedWithFailure
+            case childActivities
+            case attachments
+        }
+
+        let title: String
+        let startTime: Double?
+        let isAssociatedWithFailure: Bool
+        let childActivities: [Self]?
+        let attachments: [ActivityAttachment]?
+    }
+
+    /// Attachment reference inside an activity. `uuid` is the prefix of the
+    /// `exportedFileName` that `xcresulttool export attachments` writes, which
+    /// makes an exact join with the attachment manifest possible.
+    struct ActivityAttachment: Decodable {
+        let name: String?
+        let uuid: String?
+    }
+
+    let testIdentifier: String
+    let testRuns: [TestRun]
+}
+
+extension TestActivitiesDTO {
+    private static let logger = Logger(label: "com.peekie.dto")
+
+    /// Runs `xcrun xcresulttool get test-results activities --test-id <id>` and
+    /// decodes the output. One invocation per test — cheap (tens of milliseconds),
+    /// but callers iterating thousands of tests should expect the total to add up.
+    static func load(xcresultPath: URL, testIdentifier: String) async throws -> Self {
+        let data = try await Shell.execute(
+            "xcrun",
+            arguments: [
+                "xcresulttool", "get", "test-results", "activities",
+                "--test-id", testIdentifier,
+                "--path", xcresultPath.path,
+                "--compact",
+            ]
+        )
+
+        logger.debug(
+            "Parsing TestActivitiesDTO",
+            metadata: ["testIdentifier": "\(testIdentifier)"]
+        )
+
+        return try JSONDecoder().decode(Self.self, from: data)
+    }
+}

--- a/Tests/PeekieTests/AllureFormatterSnapshotTests.swift
+++ b/Tests/PeekieTests/AllureFormatterSnapshotTests.swift
@@ -38,6 +38,33 @@ struct AllureFormatterSnapshotTests {
     }
 
     @Test(arguments: Constants.testsReportFileNames)
+    func results_withSteps(_ fileName: String) async throws {
+        let originalPath = try Constants.url(for: fileName)
+        let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
+        defer {
+            try? FileManager.default.removeItem(at: reportPath)
+        }
+        let report = try await Report(xcresultPath: reportPath)
+
+        let results = await formatter.results(
+            report: report,
+            startedAt: Date(timeIntervalSince1970: 0),
+            stepsFrom: reportPath,
+            makeUUID: Self.makeSequentialUUID()
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let json = try String(decoding: encoder.encode(results), as: UTF8.self)
+
+        assertSnapshot(
+            of: json,
+            as: .lines,
+            named: "\(snapshotName(from: fileName))_allure_steps"
+        )
+    }
+
+    @Test(arguments: Constants.testsReportFileNames)
     func write_producesResultFilesAndAttachments(_ fileName: String) async throws {
         let originalPath = try Constants.url(for: fileName)
         let reportPath = try Constants.copyXcresultToTemporaryDirectory(originalPath)
@@ -182,5 +209,51 @@ struct AllureFormatterIdentifierTests {
                 from: "test://com.apple.xcode/Module/ModuleTests"
             ) == nil
         )
+    }
+}
+
+// MARK: - AllureActivityMetadataTests
+
+struct AllureActivityMetadataTests {
+    @Test
+    func allureIDBecomesASIDLabel() {
+        var metadata = AllureFormatter.ActivityMetadata()
+        let consumed = metadata.consume(title: "allure.id:862916")
+        #expect(consumed)
+        #expect(metadata.labels.map(\.name) == ["AS_ID"])
+        #expect(metadata.labels.map(\.value) == ["862916"])
+    }
+
+    @Test
+    func allureLabelBecomesNamedLabel() {
+        var metadata = AllureFormatter.ActivityMetadata()
+        let consumed = metadata.consume(title: "allure.label.ALLURE_ID:862916")
+        #expect(consumed)
+        #expect(metadata.labels.map(\.name) == ["ALLURE_ID"])
+        #expect(metadata.labels.map(\.value) == ["862916"])
+    }
+
+    @Test
+    func allureNameOverridesResultName() {
+        var metadata = AllureFormatter.ActivityMetadata()
+        let consumed = metadata.consume(title: "allure.name:Readable test name")
+        #expect(consumed)
+        #expect(metadata.nameOverride == "Readable test name")
+    }
+
+    @Test
+    func allureDescriptionIsCaptured() {
+        var metadata = AllureFormatter.ActivityMetadata()
+        let consumed = metadata.consume(title: "allure.description:What the test verifies")
+        #expect(consumed)
+        #expect(metadata.description == "What the test verifies")
+    }
+
+    @Test
+    func regularStepTitleIsNotConsumed() {
+        var metadata = AllureFormatter.ActivityMetadata()
+        let consumed = metadata.consume(title: "Step: Открыть корзину")
+        #expect(consumed == false)
+        #expect(metadata.labels.isEmpty)
     }
 }

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-iOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-iOS_allure.txt
@@ -18,6 +18,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 16,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
@@ -40,6 +43,9 @@
     "stage" : "finished",
     "start" : 17,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 29,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
@@ -62,6 +68,9 @@
     "stage" : "finished",
     "start" : 30,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 42,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
@@ -87,6 +96,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000004"
   },
@@ -112,6 +124,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000005"
   },
@@ -137,6 +152,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000006"
   },
@@ -162,6 +180,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
@@ -187,6 +208,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
@@ -212,6 +236,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
@@ -237,6 +264,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
@@ -262,6 +292,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
@@ -287,6 +320,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
@@ -312,6 +348,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 13591,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
@@ -337,6 +376,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 27925,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
@@ -362,6 +404,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 42362,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
@@ -387,6 +432,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
@@ -409,6 +457,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
@@ -431,6 +482,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
@@ -459,6 +513,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
@@ -487,6 +544,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
@@ -515,6 +575,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
@@ -540,6 +603,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
@@ -565,6 +631,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
@@ -590,6 +659,9 @@
     "stage" : "finished",
     "start" : 7,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
@@ -612,6 +684,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
@@ -634,6 +709,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
@@ -656,6 +734,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
@@ -681,6 +762,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
@@ -706,6 +790,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
@@ -731,6 +818,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
@@ -753,6 +843,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
@@ -775,6 +868,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
@@ -797,6 +893,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
@@ -819,6 +918,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
@@ -841,6 +943,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
@@ -863,6 +968,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
@@ -885,6 +993,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
@@ -907,6 +1018,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
@@ -929,6 +1043,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
@@ -951,6 +1068,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
@@ -973,6 +1093,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
@@ -995,6 +1118,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
@@ -1017,6 +1143,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
@@ -1039,6 +1168,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
@@ -1061,6 +1193,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
@@ -1086,6 +1221,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
@@ -1111,6 +1249,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
@@ -1136,6 +1277,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
@@ -1158,6 +1302,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000049"
   },
@@ -1180,6 +1327,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000050"
   },
@@ -1202,6 +1352,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
@@ -1227,6 +1380,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
@@ -1252,6 +1408,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
@@ -1277,6 +1436,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
@@ -1299,6 +1461,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
@@ -1321,6 +1486,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
@@ -1343,6 +1511,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
@@ -1368,6 +1539,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
@@ -1393,6 +1567,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
@@ -1418,6 +1595,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
@@ -1440,6 +1620,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000061"
   },
@@ -1462,6 +1645,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000062"
   },
@@ -1484,6 +1670,9 @@
     "stage" : "finished",
     "start" : 3,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
@@ -1506,6 +1695,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
@@ -1528,6 +1720,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
@@ -1550,6 +1745,9 @@
     "stage" : "finished",
     "start" : 3,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
@@ -1572,6 +1770,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
@@ -1594,6 +1795,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 60,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
@@ -1616,6 +1820,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
@@ -1641,6 +1848,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 612,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
@@ -1666,6 +1876,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
@@ -1691,6 +1904,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
@@ -1716,6 +1932,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
@@ -1741,6 +1960,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
@@ -1766,6 +1988,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
@@ -1791,6 +2016,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 22,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
@@ -1816,6 +2044,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
@@ -1838,6 +2069,9 @@
     "stage" : "finished",
     "start" : 7,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
@@ -1860,6 +2094,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 258,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
@@ -1885,6 +2122,9 @@
     "statusDetails" : {
       "message" : "Skip message"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
@@ -1907,6 +2147,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000081"
   },
@@ -1932,6 +2175,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
@@ -1957,6 +2203,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
@@ -1982,6 +2231,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
@@ -2004,6 +2256,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
@@ -2026,6 +2281,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
@@ -2048,6 +2306,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
@@ -2070,6 +2331,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000088"
   },
@@ -2092,6 +2356,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000089"
   },
@@ -2114,6 +2381,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000090"
   },
@@ -2136,6 +2406,9 @@
     "stage" : "finished",
     "start" : 13,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
@@ -2158,6 +2431,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
@@ -2180,6 +2456,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
@@ -2202,6 +2481,9 @@
     "stage" : "finished",
     "start" : 13,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
@@ -2224,6 +2506,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
@@ -2246,6 +2531,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
@@ -2268,6 +2556,9 @@
     "stage" : "finished",
     "start" : 13,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
@@ -2290,6 +2581,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
@@ -2312,6 +2606,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
@@ -2334,6 +2631,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
@@ -2356,6 +2656,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 17,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
@@ -2378,6 +2681,9 @@
     "stage" : "finished",
     "start" : 18,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
@@ -2400,6 +2706,9 @@
     "stage" : "finished",
     "start" : 32,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 44,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
@@ -2425,6 +2734,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
@@ -2450,6 +2762,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
@@ -2475,6 +2790,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
@@ -2497,6 +2815,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
@@ -2519,6 +2840,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
@@ -2541,6 +2865,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
@@ -2563,6 +2890,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
@@ -2585,6 +2915,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
@@ -2607,6 +2940,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
@@ -2629,6 +2965,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
@@ -2651,6 +2990,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
@@ -2673,6 +3015,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
@@ -2695,6 +3040,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000116"
   },
@@ -2717,6 +3065,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
@@ -2739,6 +3090,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-macOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-macOS_allure.txt
@@ -18,6 +18,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
@@ -40,6 +43,9 @@
     "stage" : "finished",
     "start" : 20,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 49,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
@@ -62,6 +68,9 @@
     "stage" : "finished",
     "start" : 50,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 80,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
@@ -87,6 +96,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000004"
   },
@@ -112,6 +124,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000005"
   },
@@ -137,6 +152,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000006"
   },
@@ -162,6 +180,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
@@ -187,6 +208,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 35,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
@@ -212,6 +236,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 63,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
@@ -237,6 +264,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
@@ -262,6 +292,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 23,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
@@ -287,6 +320,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 51,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
@@ -312,6 +348,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
@@ -337,6 +376,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 25,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
@@ -362,6 +404,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 53,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
@@ -387,6 +432,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
@@ -409,6 +457,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 23,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
@@ -431,6 +482,9 @@
     "stage" : "finished",
     "start" : 24,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 51,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
@@ -459,6 +513,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
@@ -487,6 +544,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
@@ -515,6 +575,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
@@ -540,6 +603,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 16,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
@@ -565,6 +631,9 @@
     "stage" : "finished",
     "start" : 17,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 17,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
@@ -590,6 +659,9 @@
     "stage" : "finished",
     "start" : 18,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 18,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
@@ -612,6 +684,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
@@ -634,6 +709,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 22,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
@@ -656,6 +734,9 @@
     "stage" : "finished",
     "start" : 23,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 50,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
@@ -681,6 +762,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
@@ -706,6 +790,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 23,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
@@ -731,6 +818,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 51,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
@@ -753,6 +843,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
@@ -775,6 +868,9 @@
     "stage" : "finished",
     "start" : 20,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 35,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
@@ -797,6 +893,9 @@
     "stage" : "finished",
     "start" : 36,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 63,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
@@ -819,6 +918,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
@@ -841,6 +943,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 23,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
@@ -863,6 +968,9 @@
     "stage" : "finished",
     "start" : 24,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 51,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
@@ -885,6 +993,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
@@ -907,6 +1018,9 @@
     "stage" : "finished",
     "start" : 20,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 35,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
@@ -929,6 +1043,9 @@
     "stage" : "finished",
     "start" : 36,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 62,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
@@ -951,6 +1068,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
@@ -973,6 +1093,9 @@
     "stage" : "finished",
     "start" : 20,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 35,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
@@ -995,6 +1118,9 @@
     "stage" : "finished",
     "start" : 36,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 63,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
@@ -1017,6 +1143,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
@@ -1039,6 +1168,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 21,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
@@ -1061,6 +1193,9 @@
     "stage" : "finished",
     "start" : 22,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 48,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
@@ -1086,6 +1221,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
@@ -1111,6 +1249,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
@@ -1136,6 +1277,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 33,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
@@ -1158,6 +1302,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000049"
   },
@@ -1180,6 +1327,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 24,
     "uuid" : "00000000-0000-0000-0000-000000000050"
   },
@@ -1202,6 +1352,9 @@
     "stage" : "finished",
     "start" : 25,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 35,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
@@ -1227,6 +1380,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
@@ -1252,6 +1408,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 35,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
@@ -1277,6 +1436,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 45,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
@@ -1299,6 +1461,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
@@ -1321,6 +1486,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
@@ -1343,6 +1511,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
@@ -1368,6 +1539,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
@@ -1393,6 +1567,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 27,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
@@ -1418,6 +1595,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 29,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
@@ -1440,6 +1620,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000061"
   },
@@ -1462,6 +1645,9 @@
     "stage" : "finished",
     "start" : 13,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 27,
     "uuid" : "00000000-0000-0000-0000-000000000062"
   },
@@ -1484,6 +1670,9 @@
     "stage" : "finished",
     "start" : 28,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 29,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
@@ -1506,6 +1695,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
@@ -1528,6 +1720,9 @@
     "stage" : "finished",
     "start" : 13,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 27,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
@@ -1550,6 +1745,9 @@
     "stage" : "finished",
     "start" : 28,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 29,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
@@ -1572,6 +1770,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
@@ -1594,6 +1795,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
@@ -1616,6 +1820,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
@@ -1641,6 +1848,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 343,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
@@ -1666,6 +1876,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
@@ -1691,6 +1904,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
@@ -1716,6 +1932,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
@@ -1741,6 +1960,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
@@ -1766,6 +1988,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
@@ -1791,6 +2016,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
@@ -1816,6 +2044,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
@@ -1838,6 +2069,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
@@ -1860,6 +2094,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 261,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
@@ -1885,6 +2122,9 @@
     "statusDetails" : {
       "message" : "Skip message"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
@@ -1907,6 +2147,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000081"
   },
@@ -1932,6 +2175,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
@@ -1957,6 +2203,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
@@ -1982,6 +2231,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
@@ -2004,6 +2256,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
@@ -2026,6 +2281,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
@@ -2048,6 +2306,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
@@ -2070,6 +2331,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000088"
   },
@@ -2092,6 +2356,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000089"
   },
@@ -2114,6 +2381,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 21,
     "uuid" : "00000000-0000-0000-0000-000000000090"
   },
@@ -2136,6 +2406,9 @@
     "stage" : "finished",
     "start" : 22,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
@@ -2158,6 +2431,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
@@ -2180,6 +2456,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 20,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
@@ -2202,6 +2481,9 @@
     "stage" : "finished",
     "start" : 21,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 38,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
@@ -2224,6 +2506,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
@@ -2246,6 +2531,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 20,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
@@ -2268,6 +2556,9 @@
     "stage" : "finished",
     "start" : 21,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 38,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
@@ -2290,6 +2581,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
@@ -2312,6 +2606,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 21,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
@@ -2334,6 +2631,9 @@
     "stage" : "finished",
     "start" : 22,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 49,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
@@ -2356,6 +2656,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 24,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
@@ -2378,6 +2681,9 @@
     "stage" : "finished",
     "start" : 25,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
@@ -2400,6 +2706,9 @@
     "stage" : "finished",
     "start" : 41,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 68,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
@@ -2425,6 +2734,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
@@ -2450,6 +2762,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 27,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
@@ -2475,6 +2790,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 46,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
@@ -2497,6 +2815,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
@@ -2519,6 +2840,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 21,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
@@ -2541,6 +2865,9 @@
     "stage" : "finished",
     "start" : 22,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
@@ -2563,6 +2890,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
@@ -2585,6 +2915,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 21,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
@@ -2607,6 +2940,9 @@
     "stage" : "finished",
     "start" : 22,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
@@ -2629,6 +2965,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
@@ -2651,6 +2990,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 20,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
@@ -2673,6 +3015,9 @@
     "stage" : "finished",
     "start" : 21,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 39,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
@@ -2695,6 +3040,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000116"
   },
@@ -2717,6 +3065,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 26,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
@@ -2739,6 +3090,9 @@
     "stage" : "finished",
     "start" : 27,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 45,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-visionOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-visionOS_allure.txt
@@ -18,6 +18,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
@@ -40,6 +43,9 @@
     "stage" : "finished",
     "start" : 14,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 27,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
@@ -62,6 +68,9 @@
     "stage" : "finished",
     "start" : 28,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
@@ -87,6 +96,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000004"
   },
@@ -112,6 +124,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000005"
   },
@@ -137,6 +152,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000006"
   },
@@ -162,6 +180,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
@@ -187,6 +208,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
@@ -212,6 +236,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
@@ -237,6 +264,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
@@ -262,6 +292,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
@@ -287,6 +320,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
@@ -312,6 +348,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6872,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
@@ -337,6 +376,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 14158,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
@@ -362,6 +404,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 21772,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
@@ -387,6 +432,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
@@ -409,6 +457,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
@@ -431,6 +482,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
@@ -459,6 +513,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
@@ -487,6 +544,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
@@ -515,6 +575,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
@@ -540,6 +603,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
@@ -565,6 +631,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
@@ -590,6 +659,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
@@ -612,6 +684,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
@@ -634,6 +709,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
@@ -656,6 +734,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
@@ -681,6 +762,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
@@ -706,6 +790,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
@@ -731,6 +818,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
@@ -753,6 +843,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
@@ -775,6 +868,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
@@ -797,6 +893,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
@@ -819,6 +918,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
@@ -841,6 +943,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
@@ -863,6 +968,9 @@
     "stage" : "finished",
     "start" : 13,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
@@ -885,6 +993,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
@@ -907,6 +1018,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
@@ -929,6 +1043,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
@@ -951,6 +1068,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
@@ -973,6 +1093,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
@@ -995,6 +1118,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
@@ -1017,6 +1143,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
@@ -1039,6 +1168,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
@@ -1061,6 +1193,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
@@ -1086,6 +1221,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
@@ -1111,6 +1249,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
@@ -1136,6 +1277,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
@@ -1158,6 +1302,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000049"
   },
@@ -1180,6 +1327,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000050"
   },
@@ -1202,6 +1352,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
@@ -1227,6 +1380,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
@@ -1252,6 +1408,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
@@ -1277,6 +1436,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
@@ -1299,6 +1461,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
@@ -1321,6 +1486,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
@@ -1343,6 +1511,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
@@ -1368,6 +1539,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
@@ -1393,6 +1567,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
@@ -1418,6 +1595,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
@@ -1440,6 +1620,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000061"
   },
@@ -1462,6 +1645,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000062"
   },
@@ -1484,6 +1670,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
@@ -1506,6 +1695,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
@@ -1528,6 +1720,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
@@ -1550,6 +1745,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
@@ -1572,6 +1770,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
@@ -1594,6 +1795,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
@@ -1616,6 +1820,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
@@ -1641,6 +1848,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 252,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
@@ -1666,6 +1876,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
@@ -1691,6 +1904,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
@@ -1716,6 +1932,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
@@ -1741,6 +1960,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
@@ -1766,6 +1988,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
@@ -1791,6 +2016,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
@@ -1816,6 +2044,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
@@ -1838,6 +2069,9 @@
     "stage" : "finished",
     "start" : 3,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
@@ -1860,6 +2094,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 261,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
@@ -1885,6 +2122,9 @@
     "statusDetails" : {
       "message" : "Skip message"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
@@ -1907,6 +2147,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000081"
   },
@@ -1932,6 +2175,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
@@ -1957,6 +2203,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
@@ -1982,6 +2231,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
@@ -2004,6 +2256,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
@@ -2026,6 +2281,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
@@ -2048,6 +2306,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
@@ -2070,6 +2331,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000088"
   },
@@ -2092,6 +2356,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000089"
   },
@@ -2114,6 +2381,9 @@
     "stage" : "finished",
     "start" : 13,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000090"
   },
@@ -2136,6 +2406,9 @@
     "stage" : "finished",
     "start" : 15,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 16,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
@@ -2158,6 +2431,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
@@ -2180,6 +2456,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
@@ -2202,6 +2481,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
@@ -2224,6 +2506,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
@@ -2246,6 +2531,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
@@ -2268,6 +2556,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
@@ -2290,6 +2581,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
@@ -2312,6 +2606,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
@@ -2334,6 +2631,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
@@ -2356,6 +2656,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
@@ -2378,6 +2681,9 @@
     "stage" : "finished",
     "start" : 20,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 33,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
@@ -2400,6 +2706,9 @@
     "stage" : "finished",
     "start" : 34,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 47,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
@@ -2425,6 +2734,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
@@ -2450,6 +2762,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
@@ -2475,6 +2790,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 16,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
@@ -2497,6 +2815,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
@@ -2519,6 +2840,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
@@ -2541,6 +2865,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
@@ -2563,6 +2890,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
@@ -2585,6 +2915,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
@@ -2607,6 +2940,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
@@ -2629,6 +2965,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
@@ -2651,6 +2990,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
@@ -2673,6 +3015,9 @@
     "stage" : "finished",
     "start" : 14,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
@@ -2695,6 +3040,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000116"
   },
@@ -2717,6 +3065,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
@@ -2739,6 +3090,9 @@
     "stage" : "finished",
     "start" : 14,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-watchOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.SPM-watchOS_allure.txt
@@ -18,6 +18,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
@@ -40,6 +43,9 @@
     "stage" : "finished",
     "start" : 13,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 26,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
@@ -62,6 +68,9 @@
     "stage" : "finished",
     "start" : 27,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
@@ -87,6 +96,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000004"
   },
@@ -112,6 +124,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000005"
   },
@@ -137,6 +152,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000006"
   },
@@ -162,6 +180,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
@@ -187,6 +208,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
@@ -212,6 +236,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
@@ -237,6 +264,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
@@ -262,6 +292,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
@@ -287,6 +320,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
@@ -312,6 +348,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1772,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
@@ -337,6 +376,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4043,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
@@ -362,6 +404,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6452,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
@@ -387,6 +432,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
@@ -409,6 +457,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
@@ -431,6 +482,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
@@ -459,6 +513,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
@@ -487,6 +544,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
@@ -515,6 +575,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
@@ -540,6 +603,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
@@ -565,6 +631,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
@@ -590,6 +659,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
@@ -612,6 +684,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
@@ -634,6 +709,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
@@ -656,6 +734,9 @@
     "stage" : "finished",
     "start" : 7,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
@@ -681,6 +762,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
@@ -706,6 +790,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
@@ -731,6 +818,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
@@ -753,6 +843,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
@@ -775,6 +868,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
@@ -797,6 +893,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
@@ -819,6 +918,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
@@ -841,6 +943,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
@@ -863,6 +968,9 @@
     "stage" : "finished",
     "start" : 7,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
@@ -885,6 +993,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
@@ -907,6 +1018,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
@@ -929,6 +1043,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
@@ -951,6 +1068,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
@@ -973,6 +1093,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
@@ -995,6 +1118,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
@@ -1017,6 +1143,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
@@ -1039,6 +1168,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
@@ -1061,6 +1193,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
@@ -1086,6 +1221,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
@@ -1111,6 +1249,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
@@ -1136,6 +1277,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
@@ -1158,6 +1302,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000049"
   },
@@ -1180,6 +1327,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000050"
   },
@@ -1202,6 +1352,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
@@ -1227,6 +1380,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
@@ -1252,6 +1408,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
@@ -1277,6 +1436,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
@@ -1299,6 +1461,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
@@ -1321,6 +1486,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
@@ -1343,6 +1511,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
@@ -1368,6 +1539,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
@@ -1393,6 +1567,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
@@ -1418,6 +1595,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
@@ -1440,6 +1620,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000061"
   },
@@ -1462,6 +1645,9 @@
     "stage" : "finished",
     "start" : 1,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000062"
   },
@@ -1484,6 +1670,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
@@ -1506,6 +1695,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
@@ -1528,6 +1720,9 @@
     "stage" : "finished",
     "start" : 1,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
@@ -1550,6 +1745,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
@@ -1572,6 +1770,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
@@ -1594,6 +1795,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
@@ -1616,6 +1820,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
@@ -1641,6 +1848,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 687,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
@@ -1666,6 +1876,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
@@ -1691,6 +1904,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
@@ -1716,6 +1932,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
@@ -1741,6 +1960,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
@@ -1766,6 +1988,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
@@ -1791,6 +2016,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
@@ -1816,6 +2044,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
@@ -1838,6 +2069,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
@@ -1860,6 +2094,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 258,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
@@ -1885,6 +2122,9 @@
     "statusDetails" : {
       "message" : "Skip message"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
@@ -1907,6 +2147,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000081"
   },
@@ -1932,6 +2175,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
@@ -1957,6 +2203,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
@@ -1982,6 +2231,9 @@
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
@@ -2004,6 +2256,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
@@ -2026,6 +2281,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
@@ -2048,6 +2306,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
@@ -2070,6 +2331,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000088"
   },
@@ -2092,6 +2356,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000089"
   },
@@ -2114,6 +2381,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000090"
   },
@@ -2136,6 +2406,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
@@ -2158,6 +2431,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
@@ -2180,6 +2456,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
@@ -2202,6 +2481,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
@@ -2224,6 +2506,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
@@ -2246,6 +2531,9 @@
     "stage" : "finished",
     "start" : 7,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
@@ -2268,6 +2556,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
@@ -2290,6 +2581,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
@@ -2312,6 +2606,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
@@ -2334,6 +2631,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
@@ -2356,6 +2656,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
@@ -2378,6 +2681,9 @@
     "stage" : "finished",
     "start" : 13,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 26,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
@@ -2400,6 +2706,9 @@
     "stage" : "finished",
     "start" : 27,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
@@ -2425,6 +2734,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
@@ -2450,6 +2762,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
@@ -2475,6 +2790,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
@@ -2497,6 +2815,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
@@ -2519,6 +2840,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
@@ -2541,6 +2865,9 @@
     "stage" : "finished",
     "start" : 7,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
@@ -2563,6 +2890,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
@@ -2585,6 +2915,9 @@
     "stage" : "finished",
     "start" : 7,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
@@ -2607,6 +2940,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
@@ -2629,6 +2965,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
@@ -2651,6 +2990,9 @@
     "stage" : "finished",
     "start" : 3,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
@@ -2673,6 +3015,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
@@ -2695,6 +3040,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000116"
   },
@@ -2717,6 +3065,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
@@ -2739,6 +3090,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.Xcworkspace-iOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.Xcworkspace-iOS_allure.txt
@@ -18,6 +18,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
@@ -40,6 +43,9 @@
     "stage" : "finished",
     "start" : 15,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 28,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
@@ -62,6 +68,9 @@
     "stage" : "finished",
     "start" : 29,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 113,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
@@ -87,6 +96,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000004"
   },
@@ -112,6 +124,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000005"
   },
@@ -137,6 +152,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000006"
   },
@@ -162,6 +180,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
@@ -187,6 +208,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
@@ -212,6 +236,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 91,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
@@ -237,6 +264,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
@@ -262,6 +292,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
@@ -287,6 +320,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 89,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
@@ -312,6 +348,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
@@ -337,6 +376,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
@@ -362,6 +404,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 89,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
@@ -387,6 +432,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
@@ -409,6 +457,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 29,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
@@ -431,6 +482,9 @@
     "stage" : "finished",
     "start" : 30,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 105,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
@@ -459,6 +513,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
@@ -487,6 +544,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
@@ -515,6 +575,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 81,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
@@ -540,6 +603,9 @@
     "stage" : "finished",
     "start" : 82,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 83,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
@@ -565,6 +631,9 @@
     "stage" : "finished",
     "start" : 84,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 84,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
@@ -590,6 +659,9 @@
     "stage" : "finished",
     "start" : 85,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 85,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
@@ -612,6 +684,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
@@ -634,6 +709,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
@@ -656,6 +734,9 @@
     "stage" : "finished",
     "start" : 14,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 87,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
@@ -681,6 +762,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
@@ -706,6 +790,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 39,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
@@ -731,6 +818,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 115,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
@@ -753,6 +843,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
@@ -775,6 +868,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
@@ -797,6 +893,9 @@
     "stage" : "finished",
     "start" : 7,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 82,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
@@ -819,6 +918,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
@@ -841,6 +943,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
@@ -863,6 +968,9 @@
     "stage" : "finished",
     "start" : 14,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 89,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
@@ -885,6 +993,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
@@ -907,6 +1018,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
@@ -929,6 +1043,9 @@
     "stage" : "finished",
     "start" : 13,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 88,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
@@ -951,6 +1068,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
@@ -973,6 +1093,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
@@ -995,6 +1118,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 83,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
@@ -1017,6 +1143,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
@@ -1039,6 +1168,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 32,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
@@ -1061,6 +1193,9 @@
     "stage" : "finished",
     "start" : 33,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 152,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
@@ -1086,6 +1221,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
@@ -1111,6 +1249,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 38,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
@@ -1136,6 +1277,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 158,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
@@ -1158,6 +1302,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000049"
   },
@@ -1180,6 +1327,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000050"
   },
@@ -1202,6 +1352,9 @@
     "stage" : "finished",
     "start" : 32,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 153,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
@@ -1227,6 +1380,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
@@ -1252,6 +1408,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
@@ -1277,6 +1436,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 87,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
@@ -1299,6 +1461,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
@@ -1321,6 +1486,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
@@ -1343,6 +1511,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 86,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
@@ -1368,6 +1539,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
@@ -1393,6 +1567,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
@@ -1418,6 +1595,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
@@ -1440,6 +1620,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000061"
   },
@@ -1462,6 +1645,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000062"
   },
@@ -1484,6 +1670,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
@@ -1506,6 +1695,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
@@ -1528,6 +1720,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
@@ -1550,6 +1745,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
@@ -1572,6 +1770,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
@@ -1594,6 +1795,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
@@ -1616,6 +1820,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
@@ -1641,6 +1848,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 287,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
@@ -1666,6 +1876,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
@@ -1691,6 +1904,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
@@ -1716,6 +1932,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1791,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
@@ -1741,6 +1960,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
@@ -1766,6 +1988,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 27,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
@@ -1791,6 +2016,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 29,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
@@ -1816,6 +2044,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 17,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
@@ -1838,6 +2069,9 @@
     "stage" : "finished",
     "start" : 18,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 18,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
@@ -1860,6 +2094,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 254,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
@@ -1885,6 +2122,9 @@
     "statusDetails" : {
       "message" : "Skip message"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
@@ -1907,6 +2147,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000081"
   },
@@ -1932,6 +2175,9 @@
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
@@ -1957,6 +2203,9 @@
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
@@ -1982,6 +2231,9 @@
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
@@ -2004,6 +2256,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
@@ -2026,6 +2281,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
@@ -2048,6 +2306,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
@@ -2070,6 +2331,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000088"
   },
@@ -2092,6 +2356,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000089"
   },
@@ -2114,6 +2381,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 30,
     "uuid" : "00000000-0000-0000-0000-000000000090"
   },
@@ -2136,6 +2406,9 @@
     "stage" : "finished",
     "start" : 31,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 81,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
@@ -2158,6 +2431,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
@@ -2180,6 +2456,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
@@ -2202,6 +2481,9 @@
     "stage" : "finished",
     "start" : 32,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 81,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
@@ -2224,6 +2506,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
@@ -2246,6 +2531,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
@@ -2268,6 +2556,9 @@
     "stage" : "finished",
     "start" : 32,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 78,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
@@ -2290,6 +2581,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
@@ -2312,6 +2606,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
@@ -2334,6 +2631,9 @@
     "stage" : "finished",
     "start" : 32,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 81,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
@@ -2356,6 +2656,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
@@ -2378,6 +2681,9 @@
     "stage" : "finished",
     "start" : 16,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 52,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
@@ -2400,6 +2706,9 @@
     "stage" : "finished",
     "start" : 53,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 174,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
@@ -2425,6 +2734,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
@@ -2450,6 +2762,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 38,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
@@ -2475,6 +2790,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 89,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
@@ -2497,6 +2815,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
@@ -2519,6 +2840,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 32,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
@@ -2541,6 +2865,9 @@
     "stage" : "finished",
     "start" : 33,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 83,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
@@ -2563,6 +2890,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
@@ -2585,6 +2915,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
@@ -2607,6 +2940,9 @@
     "stage" : "finished",
     "start" : 32,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 82,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
@@ -2629,6 +2965,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
@@ -2651,6 +2990,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
@@ -2673,6 +3015,9 @@
     "stage" : "finished",
     "start" : 32,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 78,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
@@ -2695,6 +3040,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000116"
   },
@@ -2717,6 +3065,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
@@ -2739,6 +3090,9 @@
     "stage" : "finished",
     "start" : 32,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 151,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.Xcworkspace-macOS_allure.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_allBundles-_.Xcworkspace-macOS_allure.txt
@@ -18,6 +18,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
@@ -40,6 +43,9 @@
     "stage" : "finished",
     "start" : 16,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 29,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
@@ -62,6 +68,9 @@
     "stage" : "finished",
     "start" : 30,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 43,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
@@ -87,6 +96,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000004"
   },
@@ -112,6 +124,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000005"
   },
@@ -137,6 +152,9 @@
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000006"
   },
@@ -162,6 +180,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
@@ -187,6 +208,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
@@ -212,6 +236,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
@@ -237,6 +264,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
@@ -262,6 +292,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
@@ -287,6 +320,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
@@ -312,6 +348,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 36,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
@@ -337,6 +376,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 70,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
@@ -362,6 +404,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 101,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
@@ -387,6 +432,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
@@ -409,6 +457,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
@@ -431,6 +482,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
@@ -459,6 +513,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
@@ -487,6 +544,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
@@ -515,6 +575,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
@@ -540,6 +603,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
@@ -565,6 +631,9 @@
     "stage" : "finished",
     "start" : 7,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
@@ -590,6 +659,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
@@ -612,6 +684,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
@@ -634,6 +709,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
@@ -656,6 +734,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
@@ -681,6 +762,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
@@ -706,6 +790,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
@@ -731,6 +818,9 @@
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
@@ -753,6 +843,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
@@ -775,6 +868,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
@@ -797,6 +893,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
@@ -819,6 +918,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
@@ -841,6 +943,9 @@
     "stage" : "finished",
     "start" : 10,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
@@ -863,6 +968,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
@@ -885,6 +993,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
@@ -907,6 +1018,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
@@ -929,6 +1043,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
@@ -951,6 +1068,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
@@ -973,6 +1093,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
@@ -995,6 +1118,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
@@ -1017,6 +1143,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
@@ -1039,6 +1168,9 @@
     "stage" : "finished",
     "start" : 8,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
@@ -1061,6 +1193,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
@@ -1086,6 +1221,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
@@ -1111,6 +1249,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
@@ -1136,6 +1277,9 @@
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
@@ -1158,6 +1302,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000049"
   },
@@ -1180,6 +1327,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000050"
   },
@@ -1202,6 +1352,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
@@ -1227,6 +1380,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
@@ -1252,6 +1408,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
@@ -1277,6 +1436,9 @@
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
@@ -1299,6 +1461,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
@@ -1321,6 +1486,9 @@
     "stage" : "finished",
     "start" : 3,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
@@ -1343,6 +1511,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
@@ -1368,6 +1539,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
@@ -1393,6 +1567,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
@@ -1418,6 +1595,9 @@
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
@@ -1440,6 +1620,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000061"
   },
@@ -1462,6 +1645,9 @@
     "stage" : "finished",
     "start" : 3,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000062"
   },
@@ -1484,6 +1670,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
@@ -1506,6 +1695,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
@@ -1528,6 +1720,9 @@
     "stage" : "finished",
     "start" : 4,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
@@ -1550,6 +1745,9 @@
     "stage" : "finished",
     "start" : 5,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
@@ -1572,6 +1770,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
@@ -1594,6 +1795,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
@@ -1616,6 +1820,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
@@ -1641,6 +1848,9 @@
     "statusDetails" : {
       "message" : "Failure is expected"
     },
+    "steps" : [
+
+    ],
     "stop" : 48,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
@@ -1666,6 +1876,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
@@ -1691,6 +1904,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
@@ -1716,6 +1932,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
@@ -1741,6 +1960,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
@@ -1766,6 +1988,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
@@ -1791,6 +2016,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
@@ -1816,6 +2044,9 @@
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
@@ -1838,6 +2069,9 @@
     "stage" : "finished",
     "start" : 2,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
@@ -1860,6 +2094,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 257,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
@@ -1885,6 +2122,9 @@
     "statusDetails" : {
       "message" : "Skip message"
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
@@ -1907,6 +2147,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000081"
   },
@@ -1932,6 +2175,9 @@
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
@@ -1957,6 +2203,9 @@
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
@@ -1982,6 +2231,9 @@
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
@@ -2004,6 +2256,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
@@ -2026,6 +2281,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
@@ -2048,6 +2306,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
@@ -2070,6 +2331,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000088"
   },
@@ -2092,6 +2356,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000089"
   },
@@ -2114,6 +2381,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000090"
   },
@@ -2136,6 +2406,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
@@ -2158,6 +2431,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
@@ -2180,6 +2456,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
@@ -2202,6 +2481,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
@@ -2224,6 +2506,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
@@ -2246,6 +2531,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
@@ -2268,6 +2556,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
@@ -2290,6 +2581,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
@@ -2312,6 +2606,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
@@ -2334,6 +2631,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
@@ -2356,6 +2656,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 16,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
@@ -2378,6 +2681,9 @@
     "stage" : "finished",
     "start" : 17,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 30,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
@@ -2400,6 +2706,9 @@
     "stage" : "finished",
     "start" : 31,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 43,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
@@ -2425,6 +2734,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
@@ -2450,6 +2762,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
@@ -2475,6 +2790,9 @@
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
@@ -2497,6 +2815,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
@@ -2519,6 +2840,9 @@
     "stage" : "finished",
     "start" : 6,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
@@ -2541,6 +2865,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
@@ -2563,6 +2890,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
@@ -2585,6 +2915,9 @@
     "stage" : "finished",
     "start" : 11,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
@@ -2607,6 +2940,9 @@
     "stage" : "finished",
     "start" : 14,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 16,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
@@ -2629,6 +2965,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
@@ -2651,6 +2990,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
@@ -2673,6 +3015,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
@@ -2695,6 +3040,9 @@
     "stage" : "finished",
     "start" : 0,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000116"
   },
@@ -2717,6 +3065,9 @@
     "stage" : "finished",
     "start" : 9,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
@@ -2739,6 +3090,9 @@
     "stage" : "finished",
     "start" : 12,
     "status" : "passed",
+    "steps" : [
+
+    ],
     "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.SPM-iOS_allure_steps.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.SPM-iOS_allure_steps.txt
@@ -21,7 +21,7 @@
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 16,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
   {
@@ -41,12 +41,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 14,
+    "start" : 17,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 25,
+    "stop" : 29,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
   {
@@ -66,12 +66,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 26,
+    "start" : 30,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 38,
+    "stop" : 42,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
   {
@@ -175,15 +175,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907715382,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907715382,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907715391,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715391
+          }
+        ],
+        "stop" : 1780907715391
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907715391,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
   {
@@ -203,15 +227,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907715805,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907715805,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907715806,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715806
+          }
+        ],
+        "stop" : 1780907715806
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907715806,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
   {
@@ -231,15 +279,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907715911,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907715911,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907715912,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715912
+          }
+        ],
+        "stop" : 1780907715912
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907715912,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
   {
@@ -259,15 +331,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907715064,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907715064,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907715072,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715072
+          }
+        ],
+        "stop" : 1780907715072
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907715072,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
   {
@@ -287,15 +383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907715703,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907715703,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907715704,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715704
+          }
+        ],
+        "stop" : 1780907715704
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907715704,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
   {
@@ -315,15 +435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907715881,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907715881,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907715882,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715882
+          }
+        ],
+        "stop" : 1780907715882
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907715882,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
   {
@@ -343,15 +487,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701443,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907701443,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907701443,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715034
+          }
+        ],
+        "stop" : 1780907715034
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907715034,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907715034,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715034
+          }
+        ],
+        "stop" : 1780907715034
+      }
     ],
-    "stop" : 374,
+    "stop" : 1780907715034,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
   {
@@ -371,15 +564,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 375,
+    "start" : 1780907701461,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907701461,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907701461,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715794
+          }
+        ],
+        "stop" : 1780907715794
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907715794,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907715794,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715794
+          }
+        ],
+        "stop" : 1780907715794
+      }
     ],
-    "stop" : 823,
+    "stop" : 1780907715794,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
   {
@@ -399,15 +641,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 824,
+    "start" : 1780907701474,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907701474,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907701474,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715910
+          }
+        ],
+        "stop" : 1780907715910
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907715910,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907715910,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715910
+          }
+        ],
+        "stop" : 1780907715910
+      }
     ],
-    "stop" : 1312,
+    "stop" : 1780907715910,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
   {
@@ -427,15 +718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907715137,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907715137,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flacky()",
+            "stage" : "finished",
+            "start" : 1780907715146,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715146
+          }
+        ],
+        "stop" : 1780907715146
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907715146,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
   {
@@ -455,12 +770,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907715147,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 1780907715148,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
   {
@@ -480,12 +795,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907715149,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 1780907715150,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
   {
@@ -508,15 +823,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907715414,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907715414,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907715415,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715415
+          }
+        ],
+        "stop" : 1780907715415
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907715415,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
   {
@@ -539,7 +878,7 @@
       }
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907715416,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
@@ -547,7 +886,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 1780907715416,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
   {
@@ -570,7 +909,7 @@
       }
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907715417,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
@@ -578,7 +917,7 @@
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 1780907715417,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
   {
@@ -601,12 +940,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907715806,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907715806,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907715807,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715807
+          }
+        ],
+        "stop" : 1780907715807
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907715807,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
   {
@@ -629,12 +992,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907715808,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 1780907715808,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
   {
@@ -657,12 +1020,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 8,
+    "start" : 1780907715917,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907715917,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907715917,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715917
+          }
+        ],
+        "stop" : 1780907715917
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907715917,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
   {
@@ -687,7 +1074,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
   {
@@ -707,12 +1094,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
   {
@@ -732,12 +1119,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
   {
@@ -757,15 +1144,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907715437,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907715437,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907715448,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715448
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907715448,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715448
+          }
+        ],
+        "stop" : 1780907715448
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907715448,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
   {
@@ -785,15 +1209,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907715704,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907715704,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907715705,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715705
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907715705,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715705
+          }
+        ],
+        "stop" : 1780907715705
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907715705,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
   {
@@ -813,15 +1274,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907715915,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907715915,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907715916,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715916
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907715916,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715916
+          }
+        ],
+        "stop" : 1780907715916
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907715916,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
   {
@@ -841,12 +1339,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701448,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907701448,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907701448,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701456
+          }
+        ],
+        "stop" : 1780907701456
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907701456,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
   {
@@ -866,12 +1388,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907701461,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907701461,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907701461,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701462
+          }
+        ],
+        "stop" : 1780907701462
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907701462,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
   {
@@ -891,12 +1437,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907701474,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907701474,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907701474,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701475
+          }
+        ],
+        "stop" : 1780907701475
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907701475,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
   {
@@ -916,12 +1486,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701443,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907701443,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907701443,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701443
+          }
+        ],
+        "stop" : 1780907701443
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907701443,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907701443,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701443
+          }
+        ],
+        "stop" : 1780907701443
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907701443,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907701443,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701451
+          }
+        ],
+        "stop" : 1780907701451
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907701451,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
   {
@@ -941,12 +1585,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907701461,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907701461,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907701461,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701461
+          }
+        ],
+        "stop" : 1780907701461
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907701461,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907701461,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701461
+          }
+        ],
+        "stop" : 1780907701461
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907701461,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907701461,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701462
+          }
+        ],
+        "stop" : 1780907701462
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907701462,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
   {
@@ -966,12 +1684,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907701474,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907701474,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907701474,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701474
+          }
+        ],
+        "stop" : 1780907701474
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907701474,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907701474,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701474
+          }
+        ],
+        "stop" : 1780907701474
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907701474,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907701474,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701475
+          }
+        ],
+        "stop" : 1780907701475
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907701475,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
   {
@@ -991,12 +1783,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701443,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907701443,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907701443,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701451
+          }
+        ],
+        "stop" : 1780907701451
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907701451,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
   {
@@ -1016,12 +1832,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907701461,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907701461,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907701461,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701462
+          }
+        ],
+        "stop" : 1780907701462
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907701462,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
   {
@@ -1041,12 +1881,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907701474,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907701474,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907701474,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701475
+          }
+        ],
+        "stop" : 1780907701475
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907701475,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
   {
@@ -1066,12 +1930,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701448,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907701448,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907701448,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701453
+          }
+        ],
+        "stop" : 1780907701453
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907701453,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
   {
@@ -1091,12 +1979,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907701461,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907701461,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907701461,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701462
+          }
+        ],
+        "stop" : 1780907701462
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907701462,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
   {
@@ -1116,12 +2028,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907701474,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907701474,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907701474,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701475
+          }
+        ],
+        "stop" : 1780907701475
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907701475,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
   {
@@ -1146,7 +2082,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
   {
@@ -1166,12 +2102,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
   {
@@ -1191,12 +2127,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
   {
@@ -1216,15 +2152,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907715127,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907715127,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907715135,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715135
+          }
+        ],
+        "stop" : 1780907715135
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907715135,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
   {
@@ -1244,15 +2204,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907715702,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907715702,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907715703,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715703
+          }
+        ],
+        "stop" : 1780907715703
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907715703,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
   {
@@ -1272,15 +2256,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907715892,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907715892,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907715893,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715893
+          }
+        ],
+        "stop" : 1780907715893
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907715893,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
   {
@@ -1305,7 +2313,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000049"
   },
   {
@@ -1325,12 +2333,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000050"
   },
   {
@@ -1350,12 +2358,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
   {
@@ -1375,15 +2383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907715178,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907715178,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907715183,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715183
+          }
+        ],
+        "stop" : 1780907715183
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907715183,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
   {
@@ -1403,15 +2435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907715808,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907715808,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907715809,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715809
+          }
+        ],
+        "stop" : 1780907715809
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907715809,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
   {
@@ -1431,15 +2487,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907715896,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907715896,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907715897,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715897
+          }
+        ],
+        "stop" : 1780907715897
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907715897,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
   {
@@ -1464,7 +2544,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
   {
@@ -1484,12 +2564,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 2,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
   {
@@ -1509,7 +2589,7 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 4,
     "status" : "passed",
     "steps" : [
 
@@ -1534,15 +2614,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907715152,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907715152,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907715153,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715153
+          }
+        ],
+        "stop" : 1780907715153
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907715153,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
   {
@@ -1562,15 +2666,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907715809,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907715809,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907715809,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715809
+          }
+        ],
+        "stop" : 1780907715809
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907715809,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
   {
@@ -1590,15 +2718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907715917,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907715917,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907715917,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715917
+          }
+        ],
+        "stop" : 1780907715917
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907715917,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
   {
@@ -1648,7 +2800,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000062"
   },
   {
@@ -1668,12 +2820,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 3,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
   {
@@ -1693,12 +2845,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701449,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907701449,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907701449,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701450
+          }
+        ],
+        "stop" : 1780907701450
+      }
     ],
-    "stop" : 0,
+    "stop" : 1780907701450,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
   {
@@ -1718,12 +2894,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 1,
+    "start" : 1780907701462,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907701462,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907701462,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701462
+          }
+        ],
+        "stop" : 1780907701462
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907701462,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
   {
@@ -1743,12 +2943,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907701475,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907701475,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907701475,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701476
+          }
+        ],
+        "stop" : 1780907701476
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907701476,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
   {
@@ -1773,7 +2997,7 @@
     "steps" : [
 
     ],
-    "stop" : 16,
+    "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
   {
@@ -1798,7 +3022,7 @@
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 60,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
   {
@@ -1818,12 +3042,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907700485,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Compute and record",
+        "stage" : "finished",
+        "start" : 1780907700485,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Activity attachment",
+            "stage" : "finished",
+            "start" : 1780907700487,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907700504
+          }
+        ],
+        "stop" : 1780907700504
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907700504,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
   {
@@ -1843,15 +3091,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907700492,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Failure is expected",
+        "stage" : "finished",
+        "start" : 1780907700492,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907701104,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701104
+          }
+        ],
+        "stop" : 1780907701104
+      }
     ],
-    "stop" : 1298,
+    "stop" : 1780907701104,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
   {
@@ -1871,15 +3143,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701104,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907701104,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907701106,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701106
+          }
+        ],
+        "stop" : 1780907701106
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907701106,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
   {
@@ -1899,15 +3195,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907701105,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907701105,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907701106,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701106
+          }
+        ],
+        "stop" : 1780907701106
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907701106,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
   {
@@ -1927,15 +3247,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907701107,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907701107,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907701114,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701114
+          }
+        ],
+        "stop" : 1780907701114
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907701114,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
   {
@@ -1955,15 +3299,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701114,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907701114,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907701114,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701114
+          }
+        ],
+        "stop" : 1780907701114
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907701114,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907701122,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701122
+          }
+        ],
+        "stop" : 1780907701122
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907701122,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
   {
@@ -1983,15 +3376,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907701123,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907701123,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907701123,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701123
+          }
+        ],
+        "stop" : 1780907701123
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907701123,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907701125,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701125
+          }
+        ],
+        "stop" : 1780907701125
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907701125,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
   {
@@ -2011,15 +3453,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907701126,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907701126,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907701126,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701126
+          }
+        ],
+        "stop" : 1780907701126
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907701126,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907701136,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701136
+          }
+        ],
+        "stop" : 1780907701136
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907701136,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
   {
@@ -2039,15 +3530,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701137,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907701137,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_flacky()",
+            "stage" : "finished",
+            "start" : 1780907701143,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701143
+          }
+        ],
+        "stop" : 1780907701143
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907701143,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
   {
@@ -2067,12 +3582,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907701144,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 1780907701148,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
   {
@@ -2097,7 +3612,7 @@
     "steps" : [
 
     ],
-    "stop" : 257,
+    "stop" : 258,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
   {
@@ -2125,7 +3640,7 @@
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
   {
@@ -2170,15 +3685,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701415,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907701415,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907701418,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701418
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907701418,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701418
+          }
+        ],
+        "stop" : 1780907701418
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907701418,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
   {
@@ -2198,15 +3750,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907701416,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907701416,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907701417,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701417
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907701417,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701417
+          }
+        ],
+        "stop" : 1780907701417
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907701417,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
   {
@@ -2226,15 +3815,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907701417,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907701417,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907701418,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701418
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907701418,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701418
+          }
+        ],
+        "stop" : 1780907701418
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907701418,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
   {
@@ -2254,12 +3880,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701418,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Calculation Result'",
+        "stage" : "finished",
+        "start" : 1780907701418,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result",
+            "stage" : "finished",
+            "start" : 1780907701418,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701419
+          }
+        ],
+        "stop" : 1780907701419
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907701419,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
   {
@@ -2279,12 +3929,61 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701420,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Sum result'",
+        "stage" : "finished",
+        "start" : 1780907701420,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result",
+            "stage" : "finished",
+            "start" : 1780907701420,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701420
+          }
+        ],
+        "stop" : 1780907701420
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment named 'Product result'",
+        "stage" : "finished",
+        "start" : 1780907701420,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result",
+            "stage" : "finished",
+            "start" : 1780907701420,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701421
+          }
+        ],
+        "stop" : 1780907701421
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907701421,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
   {
@@ -2304,12 +4003,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701421,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Pixel.png'",
+        "stage" : "finished",
+        "start" : 1780907701421,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907701421,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701422
+          }
+        ],
+        "stop" : 1780907701422
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907701422,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
   {
@@ -2334,7 +4057,7 @@
     "steps" : [
 
     ],
-    "stop" : 0,
+    "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000088"
   },
   {
@@ -2359,7 +4082,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000089"
   },
   {
@@ -2379,12 +4102,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 10,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000090"
   },
   {
@@ -2404,12 +4127,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 13,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
   {
@@ -2434,7 +4157,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
   {
@@ -2454,12 +4177,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
   {
@@ -2479,12 +4202,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 13,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
   {
@@ -2509,7 +4232,7 @@
     "steps" : [
 
     ],
-    "stop" : 0,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
   {
@@ -2529,12 +4252,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 1,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
   {
@@ -2554,12 +4277,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 13,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
   {
@@ -2584,7 +4307,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
   {
@@ -2604,12 +4327,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
   {
@@ -2629,12 +4352,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
   {
@@ -2659,7 +4382,7 @@
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 17,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
   {
@@ -2679,12 +4402,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 15,
+    "start" : 18,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 26,
+    "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
   {
@@ -2704,12 +4427,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 32,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 40,
+    "stop" : 44,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
   {
@@ -2729,15 +4452,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907715052,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907715052,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907715061,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715061
+          }
+        ],
+        "stop" : 1780907715061
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907715061,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
   {
@@ -2757,15 +4504,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907715627,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907715627,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907715629,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715629
+          }
+        ],
+        "stop" : 1780907715629
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907715629,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
   {
@@ -2785,15 +4556,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907715988,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907715988,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907715988,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907715988
+          }
+        ],
+        "stop" : 1780907715988
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907715988,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
   {
@@ -2818,7 +4613,7 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
   {
@@ -2838,12 +4633,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 10,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
   {
@@ -2863,12 +4658,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 12,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
   {
@@ -2888,12 +4683,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907701440,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907701440,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907701440,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701449
+          }
+        ],
+        "stop" : 1780907701449
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907701449,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
   {
@@ -2913,12 +4732,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907701460,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907701460,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907701460,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701461
+          }
+        ],
+        "stop" : 1780907701461
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907701461,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
   {
@@ -2938,12 +4781,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 7,
+    "start" : 1780907701474,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907701474,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907701474,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907701475
+          }
+        ],
+        "stop" : 1780907701475
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907701475,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
   {
@@ -2968,7 +4835,7 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
   {
@@ -2988,12 +4855,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
   {
@@ -3013,12 +4880,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
   {
@@ -3043,7 +4910,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000116"
   },
   {
@@ -3063,12 +4930,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 10,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
   {
@@ -3088,12 +4955,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 12,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }
 ]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.SPM-macOS_allure_steps.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.SPM-macOS_allure_steps.txt
@@ -21,7 +21,7 @@
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
   {
@@ -41,12 +41,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 14,
+    "start" : 20,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 25,
+    "stop" : 49,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
   {
@@ -66,12 +66,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 26,
+    "start" : 50,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 38,
+    "stop" : 80,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
   {
@@ -175,15 +175,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684657,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907684657,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907684676,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684676
+          }
+        ],
+        "stop" : 1780907684676
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907684676,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
   {
@@ -203,15 +227,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907684683,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907684683,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907684698,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684698
+          }
+        ],
+        "stop" : 1780907684698
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907684698,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
   {
@@ -231,15 +279,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907684716,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907684716,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907684743,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684743
+          }
+        ],
+        "stop" : 1780907684743
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907684743,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
   {
@@ -259,15 +331,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684651,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684651,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907684658,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684658
+          }
+        ],
+        "stop" : 1780907684658
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907684658,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
   {
@@ -287,15 +383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907684682,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684682,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907684697,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684697
+          }
+        ],
+        "stop" : 1780907684697
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907684697,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
   {
@@ -315,15 +435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907684715,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684715,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907684742,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684742
+          }
+        ],
+        "stop" : 1780907684742
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907684742,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
   {
@@ -343,15 +487,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684646,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907684646,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907684646,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684655
+          }
+        ],
+        "stop" : 1780907684655
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684655,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907684655,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684655
+          }
+        ],
+        "stop" : 1780907684655
+      }
     ],
-    "stop" : 374,
+    "stop" : 1780907684655,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
   {
@@ -371,15 +564,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 375,
+    "start" : 1780907684679,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907684679,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907684679,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684680
+          }
+        ],
+        "stop" : 1780907684680
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684680,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907684694,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684694
+          }
+        ],
+        "stop" : 1780907684694
+      }
     ],
-    "stop" : 823,
+    "stop" : 1780907684694,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
   {
@@ -399,15 +641,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 824,
+    "start" : 1780907684713,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907684713,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907684713,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684717
+          }
+        ],
+        "stop" : 1780907684717
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684717,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907684740,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684740
+          }
+        ],
+        "stop" : 1780907684740
+      }
     ],
-    "stop" : 1312,
+    "stop" : 1780907684740,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
   {
@@ -427,15 +718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684653,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907684653,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flacky()",
+            "stage" : "finished",
+            "start" : 1780907684660,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684660
+          }
+        ],
+        "stop" : 1780907684660
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907684660,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
   {
@@ -455,12 +770,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907684661,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 1780907684676,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
   {
@@ -480,12 +795,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907684677,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 1780907684704,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
   {
@@ -516,7 +831,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
   {
@@ -539,15 +854,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907684657,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907684657,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907684657,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684657
+          }
+        ],
+        "stop" : 1780907684657
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907684657,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
   {
@@ -570,7 +909,7 @@
       }
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907684658,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
@@ -578,7 +917,7 @@
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 1780907684658,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
   {
@@ -601,12 +940,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907684682,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907684682,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907684688,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684688
+          }
+        ],
+        "stop" : 1780907684688
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907684688,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
   {
@@ -629,12 +992,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907684689,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 1780907684689,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
   {
@@ -657,12 +1020,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 8,
+    "start" : 1780907684715,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907684715,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907684715,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684715
+          }
+        ],
+        "stop" : 1780907684715
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907684715,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
   {
@@ -687,7 +1074,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
   {
@@ -707,12 +1094,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 22,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
   {
@@ -732,12 +1119,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 23,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 50,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
   {
@@ -757,15 +1144,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684654,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907684654,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907684661,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684661
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907684661,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684661
+          }
+        ],
+        "stop" : 1780907684661
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907684661,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
   {
@@ -785,15 +1209,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907684683,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907684683,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907684698,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684698
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907684698,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684698
+          }
+        ],
+        "stop" : 1780907684698
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907684698,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
   {
@@ -813,15 +1274,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907684714,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907684714,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907684741,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684741
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907684741,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684741
+          }
+        ],
+        "stop" : 1780907684741
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907684741,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
   {
@@ -841,12 +1339,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684652,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907684652,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907684652,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684671
+          }
+        ],
+        "stop" : 1780907684671
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907684671,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
   {
@@ -866,12 +1388,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907684679,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907684679,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907684679,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684694
+          }
+        ],
+        "stop" : 1780907684694
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907684694,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
   {
@@ -891,12 +1437,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907684712,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907684712,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907684712,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684739
+          }
+        ],
+        "stop" : 1780907684739
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907684739,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
   {
@@ -916,12 +1486,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684646,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907684646,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907684646,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684652
+          }
+        ],
+        "stop" : 1780907684652
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907684652,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907684652,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684652
+          }
+        ],
+        "stop" : 1780907684652
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907684652,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907684652,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684653
+          }
+        ],
+        "stop" : 1780907684653
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907684653,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
   {
@@ -941,12 +1585,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907684679,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907684679,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907684679,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684679
+          }
+        ],
+        "stop" : 1780907684679
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907684679,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907684679,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684680
+          }
+        ],
+        "stop" : 1780907684680
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907684680,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907684680,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684694
+          }
+        ],
+        "stop" : 1780907684694
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907684694,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
   {
@@ -966,12 +1684,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907684713,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907684713,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907684713,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684713
+          }
+        ],
+        "stop" : 1780907684713
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907684713,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907684713,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684713
+          }
+        ],
+        "stop" : 1780907684713
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907684713,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907684713,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684740
+          }
+        ],
+        "stop" : 1780907684740
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907684740,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
   {
@@ -991,12 +1783,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684652,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907684652,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907684652,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684671
+          }
+        ],
+        "stop" : 1780907684671
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907684671,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
   {
@@ -1016,12 +1832,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907684679,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907684679,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907684679,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684694
+          }
+        ],
+        "stop" : 1780907684694
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907684694,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
   {
@@ -1041,12 +1881,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907684712,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907684712,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907684712,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684738
+          }
+        ],
+        "stop" : 1780907684738
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907684738,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
   {
@@ -1066,12 +1930,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684652,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907684652,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907684652,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684671
+          }
+        ],
+        "stop" : 1780907684671
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907684671,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
   {
@@ -1091,12 +1979,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907684679,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907684679,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907684679,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684694
+          }
+        ],
+        "stop" : 1780907684694
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907684694,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
   {
@@ -1116,12 +2028,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907684713,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907684713,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907684713,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684740
+          }
+        ],
+        "stop" : 1780907684740
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907684740,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
   {
@@ -1146,7 +2082,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
   {
@@ -1166,12 +2102,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 21,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
   {
@@ -1191,12 +2127,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 22,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 48,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
   {
@@ -1216,15 +2152,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684649,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907684649,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907684654,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684654
+          }
+        ],
+        "stop" : 1780907684654
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907684654,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
   {
@@ -1244,15 +2204,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907684684,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907684684,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907684685,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684685
+          }
+        ],
+        "stop" : 1780907684685
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907684685,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
   {
@@ -1272,15 +2256,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907684717,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907684717,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907684742,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684742
+          }
+        ],
+        "stop" : 1780907684742
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907684742,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
   {
@@ -1305,7 +2313,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000049"
   },
   {
@@ -1325,12 +2333,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 12,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 24,
     "uuid" : "00000000-0000-0000-0000-000000000050"
   },
   {
@@ -1350,12 +2358,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 25,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 35,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
   {
@@ -1375,15 +2383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684655,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907684655,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907684674,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684674
+          }
+        ],
+        "stop" : 1780907684674
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907684674,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
   {
@@ -1403,15 +2435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907684685,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907684685,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907684700,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684700
+          }
+        ],
+        "stop" : 1780907684700
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907684700,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
   {
@@ -1431,15 +2487,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907684722,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907684722,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907684731,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684731
+          }
+        ],
+        "stop" : 1780907684731
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907684731,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
   {
@@ -1464,7 +2544,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
   {
@@ -1484,12 +2564,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
   {
@@ -1509,12 +2589,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 10,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
   {
@@ -1534,15 +2614,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684664,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907684664,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907684676,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684676
+          }
+        ],
+        "stop" : 1780907684676
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907684676,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
   {
@@ -1562,15 +2666,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907684694,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907684694,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907684708,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684708
+          }
+        ],
+        "stop" : 1780907684708
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907684708,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
   {
@@ -1590,15 +2718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907684723,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907684723,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907684724,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684724
+          }
+        ],
+        "stop" : 1780907684724
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907684724,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
   {
@@ -1623,7 +2775,7 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000061"
   },
   {
@@ -1643,12 +2795,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 13,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 27,
     "uuid" : "00000000-0000-0000-0000-000000000062"
   },
   {
@@ -1668,12 +2820,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 28,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 29,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
   {
@@ -1693,12 +2845,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684653,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907684653,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907684653,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684665
+          }
+        ],
+        "stop" : 1780907684665
+      }
     ],
-    "stop" : 0,
+    "stop" : 1780907684665,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
   {
@@ -1718,12 +2894,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 1,
+    "start" : 1780907684680,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907684680,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907684680,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684694
+          }
+        ],
+        "stop" : 1780907684694
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907684694,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
   {
@@ -1743,12 +2943,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907684722,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907684722,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907684722,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684723
+          }
+        ],
+        "stop" : 1780907684723
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907684723,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
   {
@@ -1773,7 +2997,7 @@
     "steps" : [
 
     ],
-    "stop" : 16,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
   {
@@ -1798,7 +3022,7 @@
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
   {
@@ -1818,12 +3042,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684008,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Compute and record",
+        "stage" : "finished",
+        "start" : 1780907684008,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Activity attachment",
+            "stage" : "finished",
+            "start" : 1780907684008,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684009
+          }
+        ],
+        "stop" : 1780907684009
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907684009,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
   {
@@ -1843,15 +3091,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684010,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Failure is expected",
+        "stage" : "finished",
+        "start" : 1780907684010,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907684353,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684353
+          }
+        ],
+        "stop" : 1780907684353
+      }
     ],
-    "stop" : 1298,
+    "stop" : 1780907684353,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
   {
@@ -1871,15 +3143,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684353,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684353,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907684354,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684354
+          }
+        ],
+        "stop" : 1780907684354
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907684354,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
   {
@@ -1899,15 +3195,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907684354,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684354,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907684355,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684355
+          }
+        ],
+        "stop" : 1780907684355
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907684355,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
   {
@@ -1927,15 +3247,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907684355,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684355,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907684356,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684356
+          }
+        ],
+        "stop" : 1780907684356
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907684356,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
   {
@@ -1955,15 +3299,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684356,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907684356,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907684356,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684356
+          }
+        ],
+        "stop" : 1780907684356
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684356,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907684357,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684357
+          }
+        ],
+        "stop" : 1780907684357
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907684357,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
   {
@@ -1983,15 +3376,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907684357,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907684357,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907684357,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684357
+          }
+        ],
+        "stop" : 1780907684357
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684357,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907684358,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684358
+          }
+        ],
+        "stop" : 1780907684358
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907684358,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
   {
@@ -2011,15 +3453,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907684358,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907684358,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907684358,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684359
+          }
+        ],
+        "stop" : 1780907684359
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684359,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907684359,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684359
+          }
+        ],
+        "stop" : 1780907684359
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907684359,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
   {
@@ -2039,15 +3530,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684360,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907684360,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_flacky()",
+            "stage" : "finished",
+            "start" : 1780907684361,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684361
+          }
+        ],
+        "stop" : 1780907684361
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907684361,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
   {
@@ -2067,12 +3582,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907684362,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 1780907684362,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
   {
@@ -2097,7 +3612,7 @@
     "steps" : [
 
     ],
-    "stop" : 257,
+    "stop" : 261,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
   {
@@ -2125,7 +3640,7 @@
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
   {
@@ -2150,7 +3665,7 @@
     "steps" : [
 
     ],
-    "stop" : 0,
+    "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000081"
   },
   {
@@ -2170,15 +3685,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684627,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907684627,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907684629,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684629
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907684629,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684629
+          }
+        ],
+        "stop" : 1780907684629
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907684629,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
   {
@@ -2198,15 +3750,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907684629,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907684629,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907684631,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684631
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907684631,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684631
+          }
+        ],
+        "stop" : 1780907684631
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907684631,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
   {
@@ -2226,15 +3815,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907684631,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907684631,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907684632,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684632
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907684632,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684632
+          }
+        ],
+        "stop" : 1780907684632
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907684632,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
   {
@@ -2254,12 +3880,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684633,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Calculation Result'",
+        "stage" : "finished",
+        "start" : 1780907684633,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result",
+            "stage" : "finished",
+            "start" : 1780907684633,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684634
+          }
+        ],
+        "stop" : 1780907684634
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907684634,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
   {
@@ -2279,12 +3929,61 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684634,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Sum result'",
+        "stage" : "finished",
+        "start" : 1780907684634,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result",
+            "stage" : "finished",
+            "start" : 1780907684634,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684634
+          }
+        ],
+        "stop" : 1780907684634
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment named 'Product result'",
+        "stage" : "finished",
+        "start" : 1780907684634,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result",
+            "stage" : "finished",
+            "start" : 1780907684634,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684635
+          }
+        ],
+        "stop" : 1780907684635
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907684635,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
   {
@@ -2304,12 +4003,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684635,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Pixel.png'",
+        "stage" : "finished",
+        "start" : 1780907684635,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907684635,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684636
+          }
+        ],
+        "stop" : 1780907684636
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907684636,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
   {
@@ -2334,7 +4057,7 @@
     "steps" : [
 
     ],
-    "stop" : 0,
+    "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000088"
   },
   {
@@ -2359,33 +4082,8 @@
     "steps" : [
 
     ],
-    "stop" : 3,
-    "uuid" : "00000000-0000-0000-0000-000000000089"
-  },
-  {
-    "attachments" : [
-
-    ],
-    "fullName" : "`2 + 3 = 5`()",
-    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
-    "labels" : [
-      {
-        "name" : "suite",
-        "value" : "ExamplesTests"
-      }
-    ],
-    "name" : "`2 + 3 = 5`()",
-    "parameters" : [
-
-    ],
-    "stage" : "finished",
-    "start" : 4,
-    "status" : "passed",
-    "steps" : [
-
-    ],
     "stop" : 5,
-    "uuid" : "00000000-0000-0000-0000-000000000090"
+    "uuid" : "00000000-0000-0000-0000-000000000089"
   },
   {
     "attachments" : [
@@ -2409,7 +4107,32 @@
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 21,
+    "uuid" : "00000000-0000-0000-0000-000000000090"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`2 + 3 = 5`()",
+    "historyId" : "ExamplesTests/`2 + 3 = 5`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`2 + 3 = 5`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 22,
+    "status" : "passed",
+    "steps" : [
+
+    ],
+    "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
   {
@@ -2434,7 +4157,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
   {
@@ -2454,12 +4177,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 20,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
   {
@@ -2479,12 +4202,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 21,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 38,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
   {
@@ -2509,7 +4232,7 @@
     "steps" : [
 
     ],
-    "stop" : 0,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
   {
@@ -2529,12 +4252,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 1,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 20,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
   {
@@ -2554,12 +4277,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 21,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 38,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
   {
@@ -2584,7 +4307,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
   {
@@ -2604,12 +4327,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 21,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
   {
@@ -2629,12 +4352,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 22,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 49,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
   {
@@ -2659,7 +4382,7 @@
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 24,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
   {
@@ -2679,12 +4402,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 15,
+    "start" : 25,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 26,
+    "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
   {
@@ -2704,12 +4427,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 41,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 40,
+    "stop" : 68,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
   {
@@ -2729,15 +4452,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684649,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684649,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907684660,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684660
+          }
+        ],
+        "stop" : 1780907684660
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907684660,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
   {
@@ -2757,15 +4504,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907684668,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684668,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907684683,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684683
+          }
+        ],
+        "stop" : 1780907684683
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907684683,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
   {
@@ -2785,15 +4556,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907684714,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907684714,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907684732,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684732
+          }
+        ],
+        "stop" : 1780907684732
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907684732,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
   {
@@ -2818,7 +4613,7 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
   {
@@ -2838,12 +4633,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 21,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
   {
@@ -2863,12 +4658,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 22,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
   {
@@ -2888,12 +4683,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907684641,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907684641,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907684641,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684646
+          }
+        ],
+        "stop" : 1780907684646
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907684646,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
   {
@@ -2913,12 +4732,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907684679,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907684679,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907684679,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684694
+          }
+        ],
+        "stop" : 1780907684694
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907684694,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
   {
@@ -2938,12 +4781,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 7,
+    "start" : 1780907684695,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907684695,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907684695,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907684713
+          }
+        ],
+        "stop" : 1780907684713
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907684713,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
   {
@@ -2968,7 +4835,7 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
   {
@@ -2988,12 +4855,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 20,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
   {
@@ -3013,12 +4880,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 21,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 39,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
   {
@@ -3043,7 +4910,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000116"
   },
   {
@@ -3063,12 +4930,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 12,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 26,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
   {
@@ -3088,12 +4955,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 27,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 45,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }
 ]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.SPM-tvOS_allure_steps.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.SPM-tvOS_allure_steps.txt
@@ -175,15 +175,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737445,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907737445,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907737447,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737447
+          }
+        ],
+        "stop" : 1780907737447
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907737447,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
   {
@@ -203,15 +227,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907737508,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907737508,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907737509,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737509
+          }
+        ],
+        "stop" : 1780907737509
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907737509,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
   {
@@ -231,15 +279,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907737545,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907737545,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907737546,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737546
+          }
+        ],
+        "stop" : 1780907737546
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907737546,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
   {
@@ -259,15 +331,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737418,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907737418,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907737420,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737420
+          }
+        ],
+        "stop" : 1780907737420
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907737420,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
   {
@@ -287,15 +383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907737489,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907737489,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907737490,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737490
+          }
+        ],
+        "stop" : 1780907737490
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907737490,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
   {
@@ -315,15 +435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907737563,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907737563,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907737564,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737564
+          }
+        ],
+        "stop" : 1780907737564
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907737564,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
   {
@@ -343,15 +487,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737040,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907737040,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907737040,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737414
+          }
+        ],
+        "stop" : 1780907737414
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907737414,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907737414,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737414
+          }
+        ],
+        "stop" : 1780907737414
+      }
     ],
-    "stop" : 374,
+    "stop" : 1780907737414,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
   {
@@ -371,15 +564,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 375,
+    "start" : 1780907737053,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907737053,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907737053,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737501
+          }
+        ],
+        "stop" : 1780907737501
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907737501,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907737501,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737501
+          }
+        ],
+        "stop" : 1780907737501
+      }
     ],
-    "stop" : 823,
+    "stop" : 1780907737501,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
   {
@@ -399,15 +641,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 824,
+    "start" : 1780907737065,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907737065,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907737065,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737553
+          }
+        ],
+        "stop" : 1780907737553
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907737553,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907737553,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737553
+          }
+        ],
+        "stop" : 1780907737553
+      }
     ],
-    "stop" : 1312,
+    "stop" : 1780907737553,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
   {
@@ -427,15 +718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737446,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907737446,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flacky()",
+            "stage" : "finished",
+            "start" : 1780907737448,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737448
+          }
+        ],
+        "stop" : 1780907737448
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907737448,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
   {
@@ -455,12 +770,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907737449,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 1780907737450,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
   {
@@ -480,12 +795,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907737451,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 1780907737452,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
   {
@@ -539,15 +854,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907737474,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907737474,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907737474,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737474
+          }
+        ],
+        "stop" : 1780907737474
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907737474,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
   {
@@ -570,15 +909,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907737504,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907737504,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907737504,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737504
+          }
+        ],
+        "stop" : 1780907737504
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907737504,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
   {
@@ -601,12 +964,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907737505,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 1780907737505,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
   {
@@ -629,12 +992,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907737506,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 1780907737507,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
   {
@@ -657,12 +1020,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 8,
+    "start" : 1780907737562,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907737562,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907737562,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737562
+          }
+        ],
+        "stop" : 1780907737562
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907737562,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
   {
@@ -757,15 +1144,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737472,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907737472,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907737475,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737475
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907737475,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737475
+          }
+        ],
+        "stop" : 1780907737475
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907737475,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
   {
@@ -785,15 +1209,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907737498,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907737498,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907737499,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737499
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907737499,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737499
+          }
+        ],
+        "stop" : 1780907737499
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907737499,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
   {
@@ -813,15 +1274,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907737551,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907737551,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907737552,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737552
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907737552,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737552
+          }
+        ],
+        "stop" : 1780907737552
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907737552,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
   {
@@ -841,12 +1339,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737040,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907737040,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907737040,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737042
+          }
+        ],
+        "stop" : 1780907737042
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907737042,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
   {
@@ -866,12 +1388,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907737054,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907737054,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907737054,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737055
+          }
+        ],
+        "stop" : 1780907737055
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907737055,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
   {
@@ -891,12 +1437,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907737066,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907737066,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907737066,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737067
+          }
+        ],
+        "stop" : 1780907737067
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907737067,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
   {
@@ -916,12 +1486,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737040,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907737040,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907737040,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737040
+          }
+        ],
+        "stop" : 1780907737040
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907737040,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907737040,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737041
+          }
+        ],
+        "stop" : 1780907737041
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907737041,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907737041,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737043
+          }
+        ],
+        "stop" : 1780907737043
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907737043,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
   {
@@ -941,12 +1585,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907737054,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907737054,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907737054,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737054
+          }
+        ],
+        "stop" : 1780907737054
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907737054,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907737054,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737054
+          }
+        ],
+        "stop" : 1780907737054
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907737054,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907737054,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737055
+          }
+        ],
+        "stop" : 1780907737055
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907737055,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
   {
@@ -966,12 +1684,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907737065,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907737065,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907737065,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737065
+          }
+        ],
+        "stop" : 1780907737065
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907737065,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907737065,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737065
+          }
+        ],
+        "stop" : 1780907737065
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907737065,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907737065,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737066
+          }
+        ],
+        "stop" : 1780907737066
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907737066,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
   {
@@ -991,12 +1783,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737041,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907737041,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907737041,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737044
+          }
+        ],
+        "stop" : 1780907737044
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907737044,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
   {
@@ -1016,12 +1832,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907737053,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907737053,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907737053,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737054
+          }
+        ],
+        "stop" : 1780907737054
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907737054,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
   {
@@ -1041,12 +1881,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907737066,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907737066,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907737066,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737067
+          }
+        ],
+        "stop" : 1780907737067
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907737067,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
   {
@@ -1066,12 +1930,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737041,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907737041,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907737041,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737043
+          }
+        ],
+        "stop" : 1780907737043
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907737043,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
   {
@@ -1091,12 +1979,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907737053,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907737053,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907737053,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737054
+          }
+        ],
+        "stop" : 1780907737054
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907737054,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
   {
@@ -1116,12 +2028,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907737065,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907737065,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907737065,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737066
+          }
+        ],
+        "stop" : 1780907737066
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907737066,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
   {
@@ -1216,15 +2152,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737462,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907737462,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907737465,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737465
+          }
+        ],
+        "stop" : 1780907737465
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907737465,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
   {
@@ -1244,15 +2204,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907737502,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907737502,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907737503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737503
+          }
+        ],
+        "stop" : 1780907737503
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907737503,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
   {
@@ -1272,15 +2256,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907737565,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907737565,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907737566,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737566
+          }
+        ],
+        "stop" : 1780907737566
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907737566,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
   {
@@ -1375,15 +2383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737461,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907737461,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907737463,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737463
+          }
+        ],
+        "stop" : 1780907737463
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907737463,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
   {
@@ -1403,15 +2435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907737511,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907737511,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907737512,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737512
+          }
+        ],
+        "stop" : 1780907737512
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907737512,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
   {
@@ -1431,15 +2487,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907737571,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907737571,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907737571,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737571
+          }
+        ],
+        "stop" : 1780907737571
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907737571,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
   {
@@ -1534,15 +2614,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737463,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907737463,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907737464,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737464
+          }
+        ],
+        "stop" : 1780907737464
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907737464,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
   {
@@ -1562,15 +2666,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907737531,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907737531,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907737532,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737532
+          }
+        ],
+        "stop" : 1780907737532
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907737532,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
   {
@@ -1590,15 +2718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907737576,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907737576,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907737576,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737576
+          }
+        ],
+        "stop" : 1780907737576
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907737576,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
   {
@@ -1693,12 +2845,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737042,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907737042,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907737042,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737042
+          }
+        ],
+        "stop" : 1780907737042
+      }
     ],
-    "stop" : 0,
+    "stop" : 1780907737042,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
   {
@@ -1718,12 +2894,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 1,
+    "start" : 1780907737054,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907737054,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907737054,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737055
+          }
+        ],
+        "stop" : 1780907737055
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907737055,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
   {
@@ -1743,12 +2943,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907737066,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907737066,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907737066,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737066
+          }
+        ],
+        "stop" : 1780907737066
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907737066,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
   {
@@ -1818,12 +3042,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907735436,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Compute and record",
+        "stage" : "finished",
+        "start" : 1780907735436,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Activity attachment",
+            "stage" : "finished",
+            "start" : 1780907735436,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907735438
+          }
+        ],
+        "stop" : 1780907735438
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907735438,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
   {
@@ -1843,15 +3091,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907735438,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Failure is expected",
+        "stage" : "finished",
+        "start" : 1780907735438,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907736736,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736736
+          }
+        ],
+        "stop" : 1780907736736
+      }
     ],
-    "stop" : 1298,
+    "stop" : 1780907736736,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
   {
@@ -1871,15 +3143,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907736736,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907736736,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907736738,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736738
+          }
+        ],
+        "stop" : 1780907736738
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907736738,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
   {
@@ -1899,15 +3195,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907736738,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907736738,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907736739,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736739
+          }
+        ],
+        "stop" : 1780907736739
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907736739,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
   {
@@ -1927,15 +3247,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907736739,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907736739,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907736740,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736740
+          }
+        ],
+        "stop" : 1780907736740
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907736740,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
   {
@@ -1955,15 +3299,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907736740,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907736740,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907736740,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736740
+          }
+        ],
+        "stop" : 1780907736740
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907736740,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907736741,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736741
+          }
+        ],
+        "stop" : 1780907736741
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907736741,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
   {
@@ -1983,15 +3376,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907736741,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907736741,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907736741,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736741
+          }
+        ],
+        "stop" : 1780907736741
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907736741,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907736754,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736754
+          }
+        ],
+        "stop" : 1780907736754
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907736754,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
   {
@@ -2011,15 +3453,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907736755,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907736755,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907736755,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736755
+          }
+        ],
+        "stop" : 1780907736755
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907736755,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907736756,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736756
+          }
+        ],
+        "stop" : 1780907736756
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907736756,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
   {
@@ -2039,15 +3530,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907736756,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907736756,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_flacky()",
+            "stage" : "finished",
+            "start" : 1780907736757,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907736757
+          }
+        ],
+        "stop" : 1780907736757
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907736757,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
   {
@@ -2067,12 +3582,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907736758,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 1780907736758,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
   {
@@ -2170,15 +3685,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737021,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907737021,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907737024,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737024
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907737024,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737024
+          }
+        ],
+        "stop" : 1780907737024
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907737024,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
   {
@@ -2198,15 +3750,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907737022,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907737022,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907737023,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737023
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907737023,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737023
+          }
+        ],
+        "stop" : 1780907737023
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907737023,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
   {
@@ -2226,15 +3815,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907737024,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907737024,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907737025,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737025
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907737025,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737025
+          }
+        ],
+        "stop" : 1780907737025
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907737025,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
   {
@@ -2254,12 +3880,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737025,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Calculation Result'",
+        "stage" : "finished",
+        "start" : 1780907737025,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result",
+            "stage" : "finished",
+            "start" : 1780907737025,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737026
+          }
+        ],
+        "stop" : 1780907737026
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907737026,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
   {
@@ -2279,12 +3929,61 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737026,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Sum result'",
+        "stage" : "finished",
+        "start" : 1780907737026,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result",
+            "stage" : "finished",
+            "start" : 1780907737026,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737026
+          }
+        ],
+        "stop" : 1780907737026
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment named 'Product result'",
+        "stage" : "finished",
+        "start" : 1780907737026,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result",
+            "stage" : "finished",
+            "start" : 1780907737026,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737027
+          }
+        ],
+        "stop" : 1780907737027
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907737027,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
   {
@@ -2304,12 +4003,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737027,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Pixel.png'",
+        "stage" : "finished",
+        "start" : 1780907737027,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907737027,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737028
+          }
+        ],
+        "stop" : 1780907737028
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907737028,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
   {
@@ -2729,15 +4452,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737413,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907737413,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907737416,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737416
+          }
+        ],
+        "stop" : 1780907737416
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907737416,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
   {
@@ -2757,15 +4504,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907737492,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907737492,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907737493,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737493
+          }
+        ],
+        "stop" : 1780907737493
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907737493,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
   {
@@ -2785,15 +4556,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907737540,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907737540,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907737541,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737541
+          }
+        ],
+        "stop" : 1780907737541
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907737541,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
   {
@@ -2888,12 +4683,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907737040,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907737040,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907737040,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737043
+          }
+        ],
+        "stop" : 1780907737043
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907737043,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
   {
@@ -2913,12 +4732,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907737053,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907737053,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907737053,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737055
+          }
+        ],
+        "stop" : 1780907737055
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907737055,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
   {
@@ -2938,12 +4781,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 7,
+    "start" : 1780907737065,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907737065,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907737065,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907737066
+          }
+        ],
+        "stop" : 1780907737066
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907737066,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
   {

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.SPM-visionOS_allure_steps.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.SPM-visionOS_allure_steps.txt
@@ -46,7 +46,7 @@
     "steps" : [
 
     ],
-    "stop" : 25,
+    "stop" : 27,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
   {
@@ -66,12 +66,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 26,
+    "start" : 28,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 38,
+    "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
   {
@@ -175,15 +175,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907785624,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907785624,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907785634,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785634
+          }
+        ],
+        "stop" : 1780907785634
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907785634,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
   {
@@ -203,15 +227,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907785814,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907785814,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907785815,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785815
+          }
+        ],
+        "stop" : 1780907785815
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907785815,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
   {
@@ -231,15 +279,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907786168,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907786168,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907786169,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786169
+          }
+        ],
+        "stop" : 1780907786169
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907786169,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
   {
@@ -259,15 +331,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907785336,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907785336,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907785341,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785341
+          }
+        ],
+        "stop" : 1780907785341
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907785341,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
   {
@@ -287,15 +383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907785786,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907785786,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907785787,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785787
+          }
+        ],
+        "stop" : 1780907785787
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907785787,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
   {
@@ -315,15 +435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907786128,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907786128,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907786129,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786129
+          }
+        ],
+        "stop" : 1780907786129
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907786129,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
   {
@@ -343,15 +487,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778492,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907778492,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907778492,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785364
+          }
+        ],
+        "stop" : 1780907785364
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907785364,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907785364,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785364
+          }
+        ],
+        "stop" : 1780907785364
+      }
     ],
-    "stop" : 374,
+    "stop" : 1780907785364,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
   {
@@ -371,15 +564,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 375,
+    "start" : 1780907778503,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907778503,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907778503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785788
+          }
+        ],
+        "stop" : 1780907785788
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907785788,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907785788,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785788
+          }
+        ],
+        "stop" : 1780907785788
+      }
     ],
-    "stop" : 823,
+    "stop" : 1780907785788,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
   {
@@ -399,15 +641,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 824,
+    "start" : 1780907778516,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907778516,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907778516,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786129
+          }
+        ],
+        "stop" : 1780907786129
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907786129,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907786129,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786129
+          }
+        ],
+        "stop" : 1780907786129
+      }
     ],
-    "stop" : 1312,
+    "stop" : 1780907786129,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
   {
@@ -427,15 +718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907785391,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907785391,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flacky()",
+            "stage" : "finished",
+            "start" : 1780907785399,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785399
+          }
+        ],
+        "stop" : 1780907785399
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907785399,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
   {
@@ -455,12 +770,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907785400,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 1780907785401,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
   {
@@ -480,12 +795,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907785402,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 1780907785403,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
   {
@@ -508,15 +823,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907785408,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907785408,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907785410,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785410
+          }
+        ],
+        "stop" : 1780907785410
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907785410,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
   {
@@ -539,7 +878,7 @@
       }
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907785411,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
@@ -547,7 +886,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 1780907785411,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
   {
@@ -570,15 +909,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907785793,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907785793,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907785793,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785793
+          }
+        ],
+        "stop" : 1780907785793
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907785793,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
   {
@@ -601,12 +964,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907785794,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 1780907785796,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
   {
@@ -629,12 +992,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907785797,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 1780907785797,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
   {
@@ -657,12 +1020,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 8,
+    "start" : 1780907786127,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907786127,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907786127,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786127
+          }
+        ],
+        "stop" : 1780907786127
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907786127,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
   {
@@ -687,7 +1074,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
   {
@@ -707,12 +1094,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
   {
@@ -732,12 +1119,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 10,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
   {
@@ -757,15 +1144,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907785334,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907785334,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907785339,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785339
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907785339,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785339
+          }
+        ],
+        "stop" : 1780907785339
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907785339,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
   {
@@ -785,15 +1209,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907785778,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907785778,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907785779,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785779
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907785779,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785779
+          }
+        ],
+        "stop" : 1780907785779
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907785779,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
   {
@@ -813,15 +1274,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907786132,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907786132,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907786133,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786133
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907786133,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786133
+          }
+        ],
+        "stop" : 1780907786133
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907786133,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
   {
@@ -841,12 +1339,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778490,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907778490,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907778490,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778495
+          }
+        ],
+        "stop" : 1780907778495
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907778495,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
   {
@@ -866,12 +1388,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907778503,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907778503,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907778503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778504
+          }
+        ],
+        "stop" : 1780907778504
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907778504,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
   {
@@ -891,12 +1437,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907778516,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907778516,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907778516,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778517
+          }
+        ],
+        "stop" : 1780907778517
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907778517,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
   {
@@ -916,12 +1486,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778493,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907778493,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907778493,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778493
+          }
+        ],
+        "stop" : 1780907778493
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907778493,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907778493,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778493
+          }
+        ],
+        "stop" : 1780907778493
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907778493,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907778493,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778503
+          }
+        ],
+        "stop" : 1780907778503
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907778503,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
   {
@@ -941,12 +1585,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907778503,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907778503,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907778503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778503
+          }
+        ],
+        "stop" : 1780907778503
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907778503,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907778503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778503
+          }
+        ],
+        "stop" : 1780907778503
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907778503,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907778503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778504
+          }
+        ],
+        "stop" : 1780907778504
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907778504,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
   {
@@ -966,12 +1684,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907778516,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907778516,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907778516,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778516
+          }
+        ],
+        "stop" : 1780907778516
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907778516,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907778516,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778516
+          }
+        ],
+        "stop" : 1780907778516
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907778516,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907778516,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778517
+          }
+        ],
+        "stop" : 1780907778517
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907778517,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
   {
@@ -991,12 +1783,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778490,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907778490,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907778490,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778497
+          }
+        ],
+        "stop" : 1780907778497
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907778497,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
   {
@@ -1016,12 +1832,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907778503,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907778503,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907778503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778505
+          }
+        ],
+        "stop" : 1780907778505
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907778505,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
   {
@@ -1041,12 +1881,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907778516,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907778516,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907778516,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778517
+          }
+        ],
+        "stop" : 1780907778517
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907778517,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
   {
@@ -1066,12 +1930,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778490,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907778490,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907778490,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778495
+          }
+        ],
+        "stop" : 1780907778495
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907778495,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
   {
@@ -1091,12 +1979,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907778503,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907778503,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907778503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778504
+          }
+        ],
+        "stop" : 1780907778504
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907778504,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
   {
@@ -1116,12 +2028,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907778516,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907778516,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907778516,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778517
+          }
+        ],
+        "stop" : 1780907778517
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907778517,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
   {
@@ -1146,7 +2082,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
   {
@@ -1166,12 +2102,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
   {
@@ -1191,12 +2127,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
   {
@@ -1216,15 +2152,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907785391,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907785391,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907785396,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785396
+          }
+        ],
+        "stop" : 1780907785396
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907785396,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
   {
@@ -1244,15 +2204,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907785791,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907785791,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907785792,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785792
+          }
+        ],
+        "stop" : 1780907785792
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907785792,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
   {
@@ -1272,15 +2256,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907786141,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907786141,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907786142,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786142
+          }
+        ],
+        "stop" : 1780907786142
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907786142,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
   {
@@ -1305,33 +2313,8 @@
     "steps" : [
 
     ],
-    "stop" : 2,
-    "uuid" : "00000000-0000-0000-0000-000000000049"
-  },
-  {
-    "attachments" : [
-
-    ],
-    "fullName" : "OuterSuite/outerSuccess()",
-    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
-    "labels" : [
-      {
-        "name" : "suite",
-        "value" : "ExamplesTests"
-      }
-    ],
-    "name" : "outerSuccess()",
-    "parameters" : [
-
-    ],
-    "stage" : "finished",
-    "start" : 3,
-    "status" : "passed",
-    "steps" : [
-
-    ],
     "stop" : 5,
-    "uuid" : "00000000-0000-0000-0000-000000000050"
+    "uuid" : "00000000-0000-0000-0000-000000000049"
   },
   {
     "attachments" : [
@@ -1356,6 +2339,31 @@
 
     ],
     "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000050"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "steps" : [
+
+    ],
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
   {
@@ -1375,15 +2383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907785605,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907785605,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907785608,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785608
+          }
+        ],
+        "stop" : 1780907785608
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907785608,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
   {
@@ -1403,15 +2435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907785855,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907785855,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907785856,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785856
+          }
+        ],
+        "stop" : 1780907785856
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907785856,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
   {
@@ -1431,15 +2487,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907786141,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907786141,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907786141,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786141
+          }
+        ],
+        "stop" : 1780907786141
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907786141,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
   {
@@ -1464,7 +2544,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
   {
@@ -1484,12 +2564,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 4,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
   {
@@ -1509,12 +2589,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
   {
@@ -1534,15 +2614,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907785614,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907785614,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907785615,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785615
+          }
+        ],
+        "stop" : 1780907785615
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907785615,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
   {
@@ -1562,15 +2666,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907785853,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907785853,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907785854,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785854
+          }
+        ],
+        "stop" : 1780907785854
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907785854,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
   {
@@ -1590,15 +2718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907786169,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907786169,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907786169,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786169
+          }
+        ],
+        "stop" : 1780907786169
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907786169,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
   {
@@ -1693,12 +2845,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778495,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907778495,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907778495,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778496
+          }
+        ],
+        "stop" : 1780907778496
+      }
     ],
-    "stop" : 0,
+    "stop" : 1780907778496,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
   {
@@ -1718,12 +2894,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 1,
+    "start" : 1780907778504,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907778504,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907778504,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778505
+          }
+        ],
+        "stop" : 1780907778505
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907778505,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
   {
@@ -1743,12 +2943,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907778517,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907778517,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907778517,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778517
+          }
+        ],
+        "stop" : 1780907778517
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907778517,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
   {
@@ -1773,7 +2997,7 @@
     "steps" : [
 
     ],
-    "stop" : 16,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
   {
@@ -1798,7 +3022,7 @@
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
   {
@@ -1818,12 +3042,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907777900,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Compute and record",
+        "stage" : "finished",
+        "start" : 1780907777900,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Activity attachment",
+            "stage" : "finished",
+            "start" : 1780907777900,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907777903
+          }
+        ],
+        "stop" : 1780907777903
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907777903,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
   {
@@ -1843,15 +3091,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907777906,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Failure is expected",
+        "stage" : "finished",
+        "start" : 1780907777906,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907778158,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778158
+          }
+        ],
+        "stop" : 1780907778158
+      }
     ],
-    "stop" : 1298,
+    "stop" : 1780907778158,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
   {
@@ -1871,15 +3143,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778157,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907778157,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907778159,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778159
+          }
+        ],
+        "stop" : 1780907778159
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907778159,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
   {
@@ -1899,15 +3195,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907778158,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907778158,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907778159,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778159
+          }
+        ],
+        "stop" : 1780907778159
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907778159,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
   {
@@ -1927,15 +3247,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907778159,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907778159,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907778160,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778160
+          }
+        ],
+        "stop" : 1780907778160
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907778160,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
   {
@@ -1955,15 +3299,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778161,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907778161,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907778161,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778161
+          }
+        ],
+        "stop" : 1780907778161
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907778161,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907778163,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778163
+          }
+        ],
+        "stop" : 1780907778163
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907778163,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
   {
@@ -1983,15 +3376,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907778163,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907778163,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907778163,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778163
+          }
+        ],
+        "stop" : 1780907778163
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907778163,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907778165,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778165
+          }
+        ],
+        "stop" : 1780907778165
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907778165,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
   {
@@ -2011,15 +3453,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907778165,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907778165,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907778165,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778165
+          }
+        ],
+        "stop" : 1780907778165
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907778165,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907778167,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778167
+          }
+        ],
+        "stop" : 1780907778167
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907778167,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
   {
@@ -2039,15 +3530,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778167,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907778167,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_flacky()",
+            "stage" : "finished",
+            "start" : 1780907778169,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778169
+          }
+        ],
+        "stop" : 1780907778169
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907778169,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
   {
@@ -2067,12 +3582,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907778170,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 1780907778171,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
   {
@@ -2097,7 +3612,7 @@
     "steps" : [
 
     ],
-    "stop" : 257,
+    "stop" : 261,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
   {
@@ -2125,7 +3640,7 @@
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
   {
@@ -2170,15 +3685,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778440,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907778440,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907778444,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778444
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907778444,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778444
+          }
+        ],
+        "stop" : 1780907778444
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907778444,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
   {
@@ -2198,15 +3750,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907778443,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907778443,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907778445,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778445
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907778445,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778445
+          }
+        ],
+        "stop" : 1780907778445
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907778445,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
   {
@@ -2226,15 +3815,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907778445,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907778445,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907778446,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778446
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907778446,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778446
+          }
+        ],
+        "stop" : 1780907778446
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907778446,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
   {
@@ -2254,12 +3880,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778447,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Calculation Result'",
+        "stage" : "finished",
+        "start" : 1780907778447,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result",
+            "stage" : "finished",
+            "start" : 1780907778447,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778448
+          }
+        ],
+        "stop" : 1780907778448
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907778448,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
   {
@@ -2279,12 +3929,61 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778448,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Sum result'",
+        "stage" : "finished",
+        "start" : 1780907778448,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result",
+            "stage" : "finished",
+            "start" : 1780907778448,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778448
+          }
+        ],
+        "stop" : 1780907778448
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment named 'Product result'",
+        "stage" : "finished",
+        "start" : 1780907778448,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result",
+            "stage" : "finished",
+            "start" : 1780907778448,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778449
+          }
+        ],
+        "stop" : 1780907778449
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907778449,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
   {
@@ -2304,12 +4003,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778449,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Pixel.png'",
+        "stage" : "finished",
+        "start" : 1780907778449,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907778449,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778452
+          }
+        ],
+        "stop" : 1780907778452
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907778452,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
   {
@@ -2359,7 +4082,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000089"
   },
   {
@@ -2379,12 +4102,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 13,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000090"
   },
   {
@@ -2404,12 +4127,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 15,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 16,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
   {
@@ -2434,7 +4157,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
   {
@@ -2454,12 +4177,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
   {
@@ -2479,12 +4202,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 10,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
   {
@@ -2509,7 +4232,7 @@
     "steps" : [
 
     ],
-    "stop" : 0,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
   {
@@ -2529,12 +4252,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 1,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
   {
@@ -2554,12 +4277,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 10,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
   {
@@ -2584,7 +4307,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
   {
@@ -2604,12 +4327,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
   {
@@ -2629,12 +4352,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
   {
@@ -2659,7 +4382,7 @@
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 19,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
   {
@@ -2679,12 +4402,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 15,
+    "start" : 20,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 26,
+    "stop" : 33,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
   {
@@ -2704,12 +4427,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 34,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 40,
+    "stop" : 47,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
   {
@@ -2729,15 +4452,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907785127,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907785127,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907785138,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785138
+          }
+        ],
+        "stop" : 1780907785138
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907785138,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
   {
@@ -2757,15 +4504,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907785775,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907785775,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907785777,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907785777
+          }
+        ],
+        "stop" : 1780907785777
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907785777,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
   {
@@ -2785,15 +4556,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907786072,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907786072,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907786073,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907786073
+          }
+        ],
+        "stop" : 1780907786073
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907786073,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
   {
@@ -2818,7 +4613,7 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
   {
@@ -2838,12 +4633,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
   {
@@ -2863,12 +4658,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
   {
@@ -2888,12 +4683,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907778486,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907778486,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907778486,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778494
+          }
+        ],
+        "stop" : 1780907778494
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907778494,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
   {
@@ -2913,12 +4732,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907778502,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907778502,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907778502,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778503
+          }
+        ],
+        "stop" : 1780907778503
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907778503,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
   {
@@ -2938,12 +4781,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 7,
+    "start" : 1780907778516,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907778516,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907778516,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907778517
+          }
+        ],
+        "stop" : 1780907778517
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907778517,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
   {
@@ -2968,7 +4835,7 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
   {
@@ -2988,12 +4855,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 12,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
   {
@@ -3013,12 +4880,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 14,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
   {
@@ -3043,7 +4910,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000116"
   },
   {
@@ -3063,12 +4930,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 12,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
   {
@@ -3088,12 +4955,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 14,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }
 ]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.SPM-watchOS_allure_steps.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.SPM-watchOS_allure_steps.txt
@@ -21,7 +21,7 @@
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
   {
@@ -41,12 +41,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 14,
+    "start" : 13,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 25,
+    "stop" : 26,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
   {
@@ -66,12 +66,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 26,
+    "start" : 27,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 38,
+    "stop" : 40,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
   {
@@ -175,15 +175,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907756846,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907756846,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907756851,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756851
+          }
+        ],
+        "stop" : 1780907756851
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907756851,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
   {
@@ -203,15 +227,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907757068,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907757068,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907757069,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757069
+          }
+        ],
+        "stop" : 1780907757069
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907757069,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
   {
@@ -231,15 +279,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907757231,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907757231,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907757232,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757232
+          }
+        ],
+        "stop" : 1780907757232
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907757232,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
   {
@@ -259,15 +331,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907756873,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907756873,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907756876,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756876
+          }
+        ],
+        "stop" : 1780907756876
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907756876,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
   {
@@ -287,15 +383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907757037,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907757037,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907757038,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757038
+          }
+        ],
+        "stop" : 1780907757038
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907757038,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
   {
@@ -315,15 +435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907757295,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907757295,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907757296,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757296
+          }
+        ],
+        "stop" : 1780907757296
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907757296,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
   {
@@ -343,15 +487,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754801,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907754801,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907754801,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756573
+          }
+        ],
+        "stop" : 1780907756573
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907756573,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907756573,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756573
+          }
+        ],
+        "stop" : 1780907756573
+      }
     ],
-    "stop" : 374,
+    "stop" : 1780907756573,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
   {
@@ -371,15 +564,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 375,
+    "start" : 1780907754813,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907754813,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907754813,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757083
+          }
+        ],
+        "stop" : 1780907757083
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907757083,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907757083,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757083
+          }
+        ],
+        "stop" : 1780907757083
+      }
     ],
-    "stop" : 823,
+    "stop" : 1780907757083,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
   {
@@ -399,15 +641,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 824,
+    "start" : 1780907754826,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907754826,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907754826,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757234
+          }
+        ],
+        "stop" : 1780907757234
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907757234,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907757234,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757234
+          }
+        ],
+        "stop" : 1780907757234
+      }
     ],
-    "stop" : 1312,
+    "stop" : 1780907757234,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
   {
@@ -427,15 +718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907756582,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907756582,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flacky()",
+            "stage" : "finished",
+            "start" : 1780907756587,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756587
+          }
+        ],
+        "stop" : 1780907756587
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907756587,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
   {
@@ -455,12 +770,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907756588,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 1780907756589,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
   {
@@ -480,12 +795,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907756590,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 1780907756591,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
   {
@@ -508,15 +823,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907756692,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907756692,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907756695,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756695
+          }
+        ],
+        "stop" : 1780907756695
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907756695,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
   {
@@ -539,7 +878,7 @@
       }
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907756696,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
@@ -547,7 +886,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 1780907756696,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
   {
@@ -570,15 +909,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907757075,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907757075,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907757075,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757075
+          }
+        ],
+        "stop" : 1780907757075
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907757075,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
   {
@@ -601,12 +964,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907757076,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 1780907757077,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
   {
@@ -629,12 +992,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907757302,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907757302,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907757302,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757302
+          }
+        ],
+        "stop" : 1780907757302
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907757302,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
   {
@@ -657,12 +1044,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 8,
+    "start" : 1780907757303,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 8,
+    "stop" : 1780907757303,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
   {
@@ -687,7 +1074,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
   {
@@ -707,12 +1094,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 5,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
   {
@@ -732,12 +1119,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 7,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 7,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
   {
@@ -757,15 +1144,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907756877,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907756877,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907756883,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756883
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907756883,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756883
+          }
+        ],
+        "stop" : 1780907756883
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907756883,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
   {
@@ -785,15 +1209,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907757079,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907757079,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907757080,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757080
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907757080,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757080
+          }
+        ],
+        "stop" : 1780907757080
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907757080,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
   {
@@ -813,15 +1274,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907757255,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907757255,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907757256,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757256
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907757256,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757256
+          }
+        ],
+        "stop" : 1780907757256
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907757256,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
   {
@@ -841,12 +1339,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754800,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907754800,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907754800,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754805
+          }
+        ],
+        "stop" : 1780907754805
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907754805,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
   {
@@ -866,12 +1388,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907754813,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907754813,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907754813,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754814
+          }
+        ],
+        "stop" : 1780907754814
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907754814,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
   {
@@ -891,12 +1437,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907754826,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907754826,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907754826,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754827
+          }
+        ],
+        "stop" : 1780907754827
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907754827,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
   {
@@ -916,12 +1486,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754801,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907754801,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907754801,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754803
+          }
+        ],
+        "stop" : 1780907754803
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907754803,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907754803,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754803
+          }
+        ],
+        "stop" : 1780907754803
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907754803,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907754803,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754805
+          }
+        ],
+        "stop" : 1780907754805
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907754805,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
   {
@@ -941,12 +1585,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907754813,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907754813,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907754813,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754813
+          }
+        ],
+        "stop" : 1780907754813
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907754813,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907754813,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754813
+          }
+        ],
+        "stop" : 1780907754813
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907754813,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907754813,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754814
+          }
+        ],
+        "stop" : 1780907754814
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907754814,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
   {
@@ -966,12 +1684,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907754826,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907754826,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907754826,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754826
+          }
+        ],
+        "stop" : 1780907754826
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907754826,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907754826,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754826
+          }
+        ],
+        "stop" : 1780907754826
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907754826,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907754826,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754827
+          }
+        ],
+        "stop" : 1780907754827
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907754827,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
   {
@@ -991,12 +1783,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754803,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907754803,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907754803,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754806
+          }
+        ],
+        "stop" : 1780907754806
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907754806,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
   {
@@ -1016,12 +1832,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907754813,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907754813,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907754813,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754814
+          }
+        ],
+        "stop" : 1780907754814
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907754814,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
   {
@@ -1041,12 +1881,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907754826,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907754826,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907754826,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754827
+          }
+        ],
+        "stop" : 1780907754827
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907754827,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
   {
@@ -1066,12 +1930,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754800,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907754800,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907754800,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754805
+          }
+        ],
+        "stop" : 1780907754805
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907754805,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
   {
@@ -1091,12 +1979,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907754813,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907754813,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907754813,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754814
+          }
+        ],
+        "stop" : 1780907754814
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907754814,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
   {
@@ -1116,12 +2028,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907754826,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907754826,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907754826,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754827
+          }
+        ],
+        "stop" : 1780907754827
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907754827,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
   {
@@ -1146,7 +2082,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
   {
@@ -1166,12 +2102,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
   {
@@ -1191,12 +2127,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
   {
@@ -1216,15 +2152,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907756574,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907756574,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907756579,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756579
+          }
+        ],
+        "stop" : 1780907756579
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907756579,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
   {
@@ -1244,15 +2204,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907757036,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907757036,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907757037,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757037
+          }
+        ],
+        "stop" : 1780907757037
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907757037,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
   {
@@ -1272,15 +2256,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907757229,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907757229,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907757230,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757230
+          }
+        ],
+        "stop" : 1780907757230
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907757230,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
   {
@@ -1305,33 +2313,8 @@
     "steps" : [
 
     ],
-    "stop" : 2,
-    "uuid" : "00000000-0000-0000-0000-000000000049"
-  },
-  {
-    "attachments" : [
-
-    ],
-    "fullName" : "OuterSuite/outerSuccess()",
-    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
-    "labels" : [
-      {
-        "name" : "suite",
-        "value" : "ExamplesTests"
-      }
-    ],
-    "name" : "outerSuccess()",
-    "parameters" : [
-
-    ],
-    "stage" : "finished",
-    "start" : 3,
-    "status" : "passed",
-    "steps" : [
-
-    ],
     "stop" : 5,
-    "uuid" : "00000000-0000-0000-0000-000000000050"
+    "uuid" : "00000000-0000-0000-0000-000000000049"
   },
   {
     "attachments" : [
@@ -1356,6 +2339,31 @@
 
     ],
     "stop" : 7,
+    "uuid" : "00000000-0000-0000-0000-000000000050"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/outerSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/outerSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "outerSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 8,
+    "status" : "passed",
+    "steps" : [
+
+    ],
+    "stop" : 9,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
   {
@@ -1375,15 +2383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907756875,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907756875,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907756878,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756878
+          }
+        ],
+        "stop" : 1780907756878
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907756878,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
   {
@@ -1403,15 +2435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907757173,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907757173,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907757173,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757173
+          }
+        ],
+        "stop" : 1780907757173
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907757173,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
   {
@@ -1431,15 +2487,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907757246,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907757246,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907757247,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757247
+          }
+        ],
+        "stop" : 1780907757247
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907757247,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
   {
@@ -1464,7 +2544,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
   {
@@ -1484,7 +2564,7 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 4,
     "status" : "passed",
     "steps" : [
 
@@ -1514,7 +2594,7 @@
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
   {
@@ -1534,15 +2614,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907756890,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907756890,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907756890,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756890
+          }
+        ],
+        "stop" : 1780907756890
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907756890,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
   {
@@ -1562,15 +2666,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907757193,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907757193,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907757193,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757193
+          }
+        ],
+        "stop" : 1780907757193
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907757193,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
   {
@@ -1590,15 +2718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907757300,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907757300,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907757301,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757301
+          }
+        ],
+        "stop" : 1780907757301
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907757301,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
   {
@@ -1623,8 +2775,33 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 0,
     "uuid" : "00000000-0000-0000-0000-000000000061"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "deeplyNestedSuccess()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 1,
+    "status" : "passed",
+    "steps" : [
+
+    ],
+    "stop" : 1,
+    "uuid" : "00000000-0000-0000-0000-000000000062"
   },
   {
     "attachments" : [
@@ -1649,31 +2826,6 @@
 
     ],
     "stop" : 3,
-    "uuid" : "00000000-0000-0000-0000-000000000062"
-  },
-  {
-    "attachments" : [
-
-    ],
-    "fullName" : "OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
-    "historyId" : "ExamplesTests/OuterSuite/InnerSuite/DeeplyNestedSuite/deeplyNestedSuccess()",
-    "labels" : [
-      {
-        "name" : "suite",
-        "value" : "ExamplesTests"
-      }
-    ],
-    "name" : "deeplyNestedSuccess()",
-    "parameters" : [
-
-    ],
-    "stage" : "finished",
-    "start" : 4,
-    "status" : "passed",
-    "steps" : [
-
-    ],
-    "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
   {
@@ -1693,12 +2845,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754803,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907754803,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907754803,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754803
+          }
+        ],
+        "stop" : 1780907754803
+      }
     ],
-    "stop" : 0,
+    "stop" : 1780907754803,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
   {
@@ -1718,12 +2894,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 1,
+    "start" : 1780907754813,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907754813,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907754813,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754813
+          }
+        ],
+        "stop" : 1780907754813
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907754813,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
   {
@@ -1743,12 +2943,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907754826,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907754826,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907754826,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754827
+          }
+        ],
+        "stop" : 1780907754827
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907754827,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
   {
@@ -1773,7 +2997,7 @@
     "steps" : [
 
     ],
-    "stop" : 16,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
   {
@@ -1798,7 +3022,7 @@
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
   {
@@ -1818,12 +3042,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907753803,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Compute and record",
+        "stage" : "finished",
+        "start" : 1780907753803,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Activity attachment",
+            "stage" : "finished",
+            "start" : 1780907753804,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907753804
+          }
+        ],
+        "stop" : 1780907753804
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907753804,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
   {
@@ -1843,15 +3091,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907753805,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Failure is expected",
+        "stage" : "finished",
+        "start" : 1780907753805,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907754492,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754492
+          }
+        ],
+        "stop" : 1780907754492
+      }
     ],
-    "stop" : 1298,
+    "stop" : 1780907754492,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
   {
@@ -1871,15 +3143,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754494,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907754494,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907754497,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754497
+          }
+        ],
+        "stop" : 1780907754497
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907754497,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
   {
@@ -1899,15 +3195,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907754495,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907754495,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907754497,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754497
+          }
+        ],
+        "stop" : 1780907754497
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907754497,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
   {
@@ -1927,15 +3247,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907754498,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907754498,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907754499,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754499
+          }
+        ],
+        "stop" : 1780907754499
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907754499,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
   {
@@ -1955,15 +3299,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754500,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907754500,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907754500,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754501
+          }
+        ],
+        "stop" : 1780907754501
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907754501,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907754501,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754501
+          }
+        ],
+        "stop" : 1780907754501
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907754501,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
   {
@@ -1983,15 +3376,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907754502,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907754502,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907754502,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754503
+          }
+        ],
+        "stop" : 1780907754503
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907754503,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907754504,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754504
+          }
+        ],
+        "stop" : 1780907754504
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907754504,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
   {
@@ -2011,15 +3453,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907754505,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907754505,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907754505,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754506
+          }
+        ],
+        "stop" : 1780907754506
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907754506,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907754509,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754509
+          }
+        ],
+        "stop" : 1780907754509
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907754509,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
   {
@@ -2039,15 +3530,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754509,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907754509,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_flacky()",
+            "stage" : "finished",
+            "start" : 1780907754510,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754510
+          }
+        ],
+        "stop" : 1780907754510
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907754510,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
   {
@@ -2067,12 +3582,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907754511,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 1780907754512,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
   {
@@ -2097,7 +3612,7 @@
     "steps" : [
 
     ],
-    "stop" : 257,
+    "stop" : 258,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
   {
@@ -2170,15 +3685,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754775,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907754775,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907754777,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754777
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907754777,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754777
+          }
+        ],
+        "stop" : 1780907754777
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907754777,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
   {
@@ -2198,15 +3750,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907754776,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907754776,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907754777,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754777
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907754777,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754777
+          }
+        ],
+        "stop" : 1780907754777
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907754777,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
   {
@@ -2226,15 +3815,52 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907754777,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Calculator.swift:26: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907754777,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculator.divide(_:_:)",
+            "stage" : "finished",
+            "start" : 1780907754778,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754778
+          },
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907754778,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754778
+          }
+        ],
+        "stop" : 1780907754778
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907754778,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
   {
@@ -2254,12 +3880,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754778,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Calculation Result'",
+        "stage" : "finished",
+        "start" : 1780907754778,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result",
+            "stage" : "finished",
+            "start" : 1780907754778,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754779
+          }
+        ],
+        "stop" : 1780907754779
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907754779,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
   {
@@ -2279,12 +3929,61 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754782,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Sum result'",
+        "stage" : "finished",
+        "start" : 1780907754782,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result",
+            "stage" : "finished",
+            "start" : 1780907754782,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754782
+          }
+        ],
+        "stop" : 1780907754782
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment named 'Product result'",
+        "stage" : "finished",
+        "start" : 1780907754782,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result",
+            "stage" : "finished",
+            "start" : 1780907754782,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754783
+          }
+        ],
+        "stop" : 1780907754783
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907754783,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
   {
@@ -2304,12 +4003,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754783,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Pixel.png'",
+        "stage" : "finished",
+        "start" : 1780907754783,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907754783,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754784
+          }
+        ],
+        "stop" : 1780907754784
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907754784,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
   {
@@ -2434,7 +4157,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
   {
@@ -2454,12 +4177,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 4,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
   {
@@ -2479,12 +4202,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
   {
@@ -2509,7 +4232,7 @@
     "steps" : [
 
     ],
-    "stop" : 0,
+    "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
   {
@@ -2529,12 +4252,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 1,
+    "start" : 7,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
   {
@@ -2554,12 +4277,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
   {
@@ -2584,7 +4307,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
   {
@@ -2604,7 +4327,7 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 4,
     "status" : "passed",
     "steps" : [
 
@@ -2659,7 +4382,7 @@
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
   {
@@ -2679,7 +4402,7 @@
 
     ],
     "stage" : "finished",
-    "start" : 15,
+    "start" : 13,
     "status" : "passed",
     "steps" : [
 
@@ -2729,15 +4452,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907756775,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907756775,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907756781,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756781
+          }
+        ],
+        "stop" : 1780907756781
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907756781,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
   {
@@ -2757,15 +4504,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907756939,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907756939,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907756940,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907756940
+          }
+        ],
+        "stop" : 1780907756940
+      }
     ],
-    "stop" : 5,
+    "stop" : 1780907756940,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
   {
@@ -2785,15 +4556,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 1780907757256,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907757256,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907757258,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907757258
+          }
+        ],
+        "stop" : 1780907757258
+      }
     ],
-    "stop" : 7,
+    "stop" : 1780907757258,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
   {
@@ -2818,7 +4613,7 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
   {
@@ -2838,12 +4633,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 5,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
   {
@@ -2863,12 +4658,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 7,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
   {
@@ -2888,12 +4683,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907754800,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907754800,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907754800,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754806
+          }
+        ],
+        "stop" : 1780907754806
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907754806,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
   {
@@ -2913,12 +4732,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907754812,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907754812,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907754812,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754813
+          }
+        ],
+        "stop" : 1780907754813
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907754813,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
   {
@@ -2938,12 +4781,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 7,
+    "start" : 1780907754826,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907754826,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907754826,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907754827
+          }
+        ],
+        "stop" : 1780907754827
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907754827,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
   {
@@ -2968,7 +4835,7 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
   {
@@ -2988,12 +4855,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 3,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
   {
@@ -3013,7 +4880,7 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 5,
     "status" : "passed",
     "steps" : [
 
@@ -3043,33 +4910,8 @@
     "steps" : [
 
     ],
-    "stop" : 2,
-    "uuid" : "00000000-0000-0000-0000-000000000116"
-  },
-  {
-    "attachments" : [
-
-    ],
-    "fullName" : "`сложение работает`()",
-    "historyId" : "ExamplesTests/`сложение работает`()",
-    "labels" : [
-      {
-        "name" : "suite",
-        "value" : "ExamplesTests"
-      }
-    ],
-    "name" : "`сложение работает`()",
-    "parameters" : [
-
-    ],
-    "stage" : "finished",
-    "start" : 3,
-    "status" : "passed",
-    "steps" : [
-
-    ],
     "stop" : 3,
-    "uuid" : "00000000-0000-0000-0000-000000000117"
+    "uuid" : "00000000-0000-0000-0000-000000000116"
   },
   {
     "attachments" : [
@@ -3094,6 +4936,31 @@
 
     ],
     "stop" : 5,
+    "uuid" : "00000000-0000-0000-0000-000000000117"
+  },
+  {
+    "attachments" : [
+
+    ],
+    "fullName" : "`сложение работает`()",
+    "historyId" : "ExamplesTests/`сложение работает`()",
+    "labels" : [
+      {
+        "name" : "suite",
+        "value" : "ExamplesTests"
+      }
+    ],
+    "name" : "`сложение работает`()",
+    "parameters" : [
+
+    ],
+    "stage" : "finished",
+    "start" : 6,
+    "status" : "passed",
+    "steps" : [
+
+    ],
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }
 ]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.Xcworkspace-iOS_allure_steps.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.Xcworkspace-iOS_allure_steps.txt
@@ -21,7 +21,7 @@
     "steps" : [
 
     ],
-    "stop" : 37,
+    "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
   {
@@ -41,12 +41,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 38,
+    "start" : 15,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 57,
+    "stop" : 28,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
   {
@@ -66,12 +66,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 58,
+    "start" : 29,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 71,
+    "stop" : 113,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
   {
@@ -127,7 +127,7 @@
     "steps" : [
 
     ],
-    "stop" : 1,
+    "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000005"
   },
   {
@@ -147,7 +147,7 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 3,
     "status" : "skipped",
     "statusDetails" : {
       "message" : "Test skipped: Disabled reason"
@@ -155,7 +155,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000006"
   },
   {
@@ -175,15 +175,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850135,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907850135,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907850146,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850146
+          }
+        ],
+        "stop" : 1780907850146
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907850146,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
   {
@@ -203,15 +227,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907850164,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907850164,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907850167,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850167
+          }
+        ],
+        "stop" : 1780907850167
+      }
     ],
-    "stop" : 28,
+    "stop" : 1780907850167,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
   {
@@ -231,15 +279,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 1780907850297,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907850297,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907850372,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850372
+          }
+        ],
+        "stop" : 1780907850372
+      }
     ],
-    "stop" : 38,
+    "stop" : 1780907850372,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
   {
@@ -259,15 +331,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850128,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907850128,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907850137,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850137
+          }
+        ],
+        "stop" : 1780907850137
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907850137,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
   {
@@ -287,15 +383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907850167,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907850167,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907850170,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850170
+          }
+        ],
+        "stop" : 1780907850170
+      }
     ],
-    "stop" : 26,
+    "stop" : 1780907850170,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
   {
@@ -315,15 +435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 1780907850295,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907850295,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907850370,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850370
+          }
+        ],
+        "stop" : 1780907850370
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907850370,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
   {
@@ -343,15 +487,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850121,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907850121,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907850121,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850127
+          }
+        ],
+        "stop" : 1780907850127
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907850127,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907850131,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850131
+          }
+        ],
+        "stop" : 1780907850131
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907850131,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
   {
@@ -371,15 +564,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907850160,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907850160,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907850160,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850162
+          }
+        ],
+        "stop" : 1780907850162
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907850162,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907850162,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850162
+          }
+        ],
+        "stop" : 1780907850162
+      }
     ],
-    "stop" : 51,
+    "stop" : 1780907850162,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
   {
@@ -399,15 +641,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 52,
+    "start" : 1780907850222,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907850222,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907850222,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850228
+          }
+        ],
+        "stop" : 1780907850228
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907850228,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907850297,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850297
+          }
+        ],
+        "stop" : 1780907850297
+      }
     ],
-    "stop" : 86,
+    "stop" : 1780907850297,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
   {
@@ -427,15 +718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850126,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907850126,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flacky()",
+            "stage" : "finished",
+            "start" : 1780907850136,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850136
+          }
+        ],
+        "stop" : 1780907850136
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907850136,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
   {
@@ -455,12 +770,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907850137,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 27,
+    "stop" : 1780907850155,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
   {
@@ -480,12 +795,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 28,
+    "start" : 1780907850156,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 30,
+    "stop" : 1780907850231,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
   {
@@ -516,7 +831,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000019"
   },
   {
@@ -539,15 +854,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907850137,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907850137,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907850138,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850138
+          }
+        ],
+        "stop" : 1780907850138
+      }
     ],
-    "stop" : 11,
+    "stop" : 1780907850138,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
   {
@@ -570,7 +909,7 @@
       }
     ],
     "stage" : "finished",
-    "start" : 12,
+    "start" : 1780907850139,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
@@ -578,7 +917,7 @@
     "steps" : [
 
     ],
-    "stop" : 12,
+    "stop" : 1780907850210,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
   {
@@ -601,12 +940,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 13,
+    "start" : 1780907850166,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907850166,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907850167,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850167
+          }
+        ],
+        "stop" : 1780907850167
+      }
     ],
-    "stop" : 13,
+    "stop" : 1780907850167,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
   {
@@ -629,12 +992,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 14,
+    "start" : 1780907850168,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 1780907850168,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
   {
@@ -657,12 +1020,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 15,
+    "start" : 1780907850296,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907850296,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907850296,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850296
+          }
+        ],
+        "stop" : 1780907850296
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907850296,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
   {
@@ -687,7 +1074,7 @@
     "steps" : [
 
     ],
-    "stop" : 17,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
   {
@@ -707,12 +1094,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 27,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
   {
@@ -732,12 +1119,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 28,
+    "start" : 14,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 30,
+    "stop" : 87,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
   {
@@ -757,15 +1144,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850135,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907850135,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907850146,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850146
+          }
+        ],
+        "stop" : 1780907850146
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907850146,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
   {
@@ -785,15 +1196,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907850162,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907850162,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907850189,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850189
+          }
+        ],
+        "stop" : 1780907850189
+      }
     ],
-    "stop" : 28,
+    "stop" : 1780907850189,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
   {
@@ -813,15 +1248,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 1780907850227,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907850227,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907850302,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850302
+          }
+        ],
+        "stop" : 1780907850302
+      }
     ],
-    "stop" : 38,
+    "stop" : 1780907850302,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
   {
@@ -841,12 +1300,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850121,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907850121,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907850121,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850124
+          }
+        ],
+        "stop" : 1780907850124
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907850124,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
   {
@@ -866,12 +1349,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907850160,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907850160,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907850160,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850162
+          }
+        ],
+        "stop" : 1780907850162
+      }
     ],
-    "stop" : 28,
+    "stop" : 1780907850162,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
   {
@@ -891,12 +1398,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 1780907850222,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907850222,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907850222,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850297
+          }
+        ],
+        "stop" : 1780907850297
+      }
     ],
-    "stop" : 38,
+    "stop" : 1780907850297,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
   {
@@ -916,12 +1447,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850122,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907850122,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907850122,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850122
+          }
+        ],
+        "stop" : 1780907850122
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907850122,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907850122,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850122
+          }
+        ],
+        "stop" : 1780907850122
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907850122,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907850122,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850131
+          }
+        ],
+        "stop" : 1780907850131
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907850131,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
   {
@@ -941,12 +1546,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907850160,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907850160,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907850160,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850161
+          }
+        ],
+        "stop" : 1780907850161
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907850161,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907850161,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850161
+          }
+        ],
+        "stop" : 1780907850161
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907850161,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907850161,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850163
+          }
+        ],
+        "stop" : 1780907850163
+      }
     ],
-    "stop" : 25,
+    "stop" : 1780907850163,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
   {
@@ -966,12 +1645,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 26,
+    "start" : 1780907850222,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907850222,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907850222,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850222
+          }
+        ],
+        "stop" : 1780907850222
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907850222,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907850222,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850222
+          }
+        ],
+        "stop" : 1780907850222
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907850222,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907850222,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850297
+          }
+        ],
+        "stop" : 1780907850297
+      }
     ],
-    "stop" : 34,
+    "stop" : 1780907850297,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
   {
@@ -991,12 +1744,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850122,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907850122,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907850122,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850131
+          }
+        ],
+        "stop" : 1780907850131
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907850131,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
   {
@@ -1016,12 +1793,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907850160,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907850160,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907850160,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850162
+          }
+        ],
+        "stop" : 1780907850162
+      }
     ],
-    "stop" : 26,
+    "stop" : 1780907850162,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
   {
@@ -1041,12 +1842,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 1780907850292,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907850292,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907850292,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850367
+          }
+        ],
+        "stop" : 1780907850367
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907850367,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
   {
@@ -1066,12 +1891,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850121,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907850121,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907850121,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850124
+          }
+        ],
+        "stop" : 1780907850124
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907850124,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
   {
@@ -1091,12 +1940,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907850160,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907850160,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907850160,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850163
+          }
+        ],
+        "stop" : 1780907850163
+      }
     ],
-    "stop" : 26,
+    "stop" : 1780907850163,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
   {
@@ -1116,12 +1989,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 1780907850222,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907850222,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907850222,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850297
+          }
+        ],
+        "stop" : 1780907850297
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907850297,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
   {
@@ -1146,7 +2043,7 @@
     "steps" : [
 
     ],
-    "stop" : 17,
+    "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
   {
@@ -1166,12 +2063,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 5,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 28,
+    "stop" : 32,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
   {
@@ -1191,12 +2088,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 33,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 31,
+    "stop" : 152,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
   {
@@ -1216,15 +2113,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850125,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907850125,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907850135,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850135
+          }
+        ],
+        "stop" : 1780907850135
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907850135,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
   {
@@ -1244,15 +2165,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907850162,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907850162,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907850189,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850189
+          }
+        ],
+        "stop" : 1780907850189
+      }
     ],
-    "stop" : 24,
+    "stop" : 1780907850189,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
   {
@@ -1272,15 +2217,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 25,
+    "start" : 1780907850223,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907850223,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907850342,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850342
+          }
+        ],
+        "stop" : 1780907850342
+      }
     ],
-    "stop" : 27,
+    "stop" : 1780907850342,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
   {
@@ -1305,7 +2274,7 @@
     "steps" : [
 
     ],
-    "stop" : 15,
+    "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000049"
   },
   {
@@ -1325,12 +2294,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 4,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 25,
+    "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000050"
   },
   {
@@ -1350,12 +2319,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 26,
+    "start" : 32,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 34,
+    "stop" : 153,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
   {
@@ -1375,15 +2344,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850130,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907850130,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907850138,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850138
+          }
+        ],
+        "stop" : 1780907850138
+      }
     ],
-    "stop" : 12,
+    "stop" : 1780907850138,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
   {
@@ -1403,15 +2396,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 13,
+    "start" : 1780907850168,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907850168,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907850170,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850170
+          }
+        ],
+        "stop" : 1780907850170
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907850170,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
   {
@@ -1431,15 +2448,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907850293,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907850293,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907850368,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850368
+          }
+        ],
+        "stop" : 1780907850368
+      }
     ],
-    "stop" : 24,
+    "stop" : 1780907850368,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
   {
@@ -1464,7 +2505,7 @@
     "steps" : [
 
     ],
-    "stop" : 12,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
   {
@@ -1484,12 +2525,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 13,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 15,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
   {
@@ -1509,12 +2550,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 24,
+    "stop" : 86,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
   {
@@ -1534,15 +2575,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850139,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907850139,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907850140,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850140
+          }
+        ],
+        "stop" : 1780907850140
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907850140,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
   {
@@ -1562,15 +2627,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907850169,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907850169,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907850170,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850170
+          }
+        ],
+        "stop" : 1780907850170
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907850170,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
   {
@@ -1590,15 +2679,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907850299,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907850299,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907850301,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850301
+          }
+        ],
+        "stop" : 1780907850301
+      }
     ],
-    "stop" : 12,
+    "stop" : 1780907850301,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
   {
@@ -1623,7 +2736,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000061"
   },
   {
@@ -1643,12 +2756,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 2,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000062"
   },
   {
@@ -1668,12 +2781,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 4,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
   {
@@ -1693,12 +2806,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850130,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907850130,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907850130,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850131
+          }
+        ],
+        "stop" : 1780907850131
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907850131,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
   {
@@ -1718,12 +2855,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907850161,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907850161,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907850161,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850162
+          }
+        ],
+        "stop" : 1780907850162
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907850162,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
   {
@@ -1743,12 +2904,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907850294,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907850294,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907850294,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850296
+          }
+        ],
+        "stop" : 1780907850296
+      }
     ],
-    "stop" : 13,
+    "stop" : 1780907850296,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
   {
@@ -1773,7 +2958,7 @@
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
   {
@@ -1798,7 +2983,7 @@
     "steps" : [
 
     ],
-    "stop" : 11,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
   {
@@ -1818,12 +3003,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907847710,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Compute and record",
+        "stage" : "finished",
+        "start" : 1780907847710,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Activity attachment",
+            "stage" : "finished",
+            "start" : 1780907847710,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907847711
+          }
+        ],
+        "stop" : 1780907847711
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907847711,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
   {
@@ -1843,15 +3052,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907847711,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Failure is expected",
+        "stage" : "finished",
+        "start" : 1780907847711,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907847998,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907847998
+          }
+        ],
+        "stop" : 1780907847998
+      }
     ],
-    "stop" : 457,
+    "stop" : 1780907847998,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
   {
@@ -1871,15 +3104,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907847999,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907847999,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907848001,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907848001
+          }
+        ],
+        "stop" : 1780907848001
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907848001,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
   {
@@ -1899,15 +3156,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907848000,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907848000,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907848001,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907848001
+          }
+        ],
+        "stop" : 1780907848001
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907848001,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
   {
@@ -1927,15 +3208,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907849786,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907849786,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907851572,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907851572
+          }
+        ],
+        "stop" : 1780907851572
+      }
     ],
-    "stop" : 1598,
+    "stop" : 1780907851572,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
   {
@@ -1955,15 +3260,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907849788,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907849788,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907849788,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907849788
+          }
+        ],
+        "stop" : 1780907849788
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907849788,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907849789,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907849789
+          }
+        ],
+        "stop" : 1780907849789
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907849789,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
   {
@@ -1983,15 +3337,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907849813,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907849813,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907849813,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907849814
+          }
+        ],
+        "stop" : 1780907849814
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907849814,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907849838,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907849838
+          }
+        ],
+        "stop" : 1780907849838
+      }
     ],
-    "stop" : 32,
+    "stop" : 1780907849838,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
   {
@@ -2011,15 +3414,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 33,
+    "start" : 1780907849815,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907849815,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907849815,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907849815
+          }
+        ],
+        "stop" : 1780907849815
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907849815,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907849816,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907849816
+          }
+        ],
+        "stop" : 1780907849816
+      }
     ],
-    "stop" : 34,
+    "stop" : 1780907849816,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
   {
@@ -2039,15 +3491,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907849816,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907849816,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_flacky()",
+            "stage" : "finished",
+            "start" : 1780907849833,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907849833
+          }
+        ],
+        "stop" : 1780907849833
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907849833,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
   {
@@ -2067,12 +3543,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 30,
+    "start" : 1780907849834,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 31,
+    "stop" : 1780907849834,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
   {
@@ -2125,7 +3601,7 @@
     "steps" : [
 
     ],
-    "stop" : 10,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
   {
@@ -2150,7 +3626,7 @@
     "steps" : [
 
     ],
-    "stop" : 0,
+    "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000081"
   },
   {
@@ -2170,15 +3646,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850097,
     "status" : "failed",
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907850097,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907850100,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850100
+          }
+        ],
+        "stop" : 1780907850100
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907850100,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
   {
@@ -2198,15 +3698,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907850098,
     "status" : "failed",
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907850098,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907850099,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850099
+          }
+        ],
+        "stop" : 1780907850099
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907850099,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
   {
@@ -2226,15 +3750,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 7,
+    "start" : 1780907850099,
     "status" : "failed",
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907850099,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907850100,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850100
+          }
+        ],
+        "stop" : 1780907850100
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907850100,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
   {
@@ -2254,12 +3802,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850100,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Calculation Result'",
+        "stage" : "finished",
+        "start" : 1780907850100,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result",
+            "stage" : "finished",
+            "start" : 1780907850100,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850101
+          }
+        ],
+        "stop" : 1780907850101
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907850101,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
   {
@@ -2279,12 +3851,61 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850101,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Sum result'",
+        "stage" : "finished",
+        "start" : 1780907850101,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result",
+            "stage" : "finished",
+            "start" : 1780907850101,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850102
+          }
+        ],
+        "stop" : 1780907850102
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment named 'Product result'",
+        "stage" : "finished",
+        "start" : 1780907850102,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result",
+            "stage" : "finished",
+            "start" : 1780907850102,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850102
+          }
+        ],
+        "stop" : 1780907850102
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907850102,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
   {
@@ -2304,12 +3925,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850103,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Pixel.png'",
+        "stage" : "finished",
+        "start" : 1780907850103,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907850103,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850104
+          }
+        ],
+        "stop" : 1780907850104
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907850104,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
   {
@@ -2359,7 +4004,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000089"
   },
   {
@@ -2379,12 +4024,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 4,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 30,
     "uuid" : "00000000-0000-0000-0000-000000000090"
   },
   {
@@ -2404,12 +4049,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 14,
+    "start" : 31,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 15,
+    "stop" : 81,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
   {
@@ -2434,7 +4079,7 @@
     "steps" : [
 
     ],
-    "stop" : 19,
+    "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
   {
@@ -2454,12 +4099,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 20,
+    "start" : 5,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 30,
+    "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
   {
@@ -2479,12 +4124,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 31,
+    "start" : 32,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 33,
+    "stop" : 81,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
   {
@@ -2534,7 +4179,7 @@
     "steps" : [
 
     ],
-    "stop" : 15,
+    "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
   {
@@ -2554,12 +4199,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 32,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 18,
+    "stop" : 78,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
   {
@@ -2584,7 +4229,7 @@
     "steps" : [
 
     ],
-    "stop" : 15,
+    "stop" : 3,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
   {
@@ -2604,12 +4249,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 4,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 26,
+    "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
   {
@@ -2629,12 +4274,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 32,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 29,
+    "stop" : 81,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
   {
@@ -2659,7 +4304,7 @@
     "steps" : [
 
     ],
-    "stop" : 39,
+    "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
   {
@@ -2679,12 +4324,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 40,
+    "start" : 16,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 60,
+    "stop" : 52,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
   {
@@ -2704,12 +4349,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 61,
+    "start" : 53,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 113,
+    "stop" : 174,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
   {
@@ -2729,15 +4374,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850126,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907850126,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907850137,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850137
+          }
+        ],
+        "stop" : 1780907850137
+      }
     ],
-    "stop" : 19,
+    "stop" : 1780907850137,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
   {
@@ -2757,15 +4426,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 20,
+    "start" : 1780907850159,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907850159,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907850185,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850185
+          }
+        ],
+        "stop" : 1780907850185
+      }
     ],
-    "stop" : 30,
+    "stop" : 1780907850185,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
   {
@@ -2785,15 +4478,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 31,
+    "start" : 1780907850219,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907850219,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907850269,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850269
+          }
+        ],
+        "stop" : 1780907850269
+      }
     ],
-    "stop" : 40,
+    "stop" : 1780907850269,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
   {
@@ -2818,7 +4535,7 @@
     "steps" : [
 
     ],
-    "stop" : 17,
+    "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
   {
@@ -2838,12 +4555,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 5,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 28,
+    "stop" : 32,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
   {
@@ -2863,12 +4580,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 33,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 30,
+    "stop" : 83,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
   {
@@ -2888,12 +4605,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907850119,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907850119,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907850119,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850122
+          }
+        ],
+        "stop" : 1780907850122
+      }
     ],
-    "stop" : 18,
+    "stop" : 1780907850122,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
   {
@@ -2913,12 +4654,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 19,
+    "start" : 1780907850160,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907850160,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907850160,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850187
+          }
+        ],
+        "stop" : 1780907850187
+      }
     ],
-    "stop" : 21,
+    "stop" : 1780907850187,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
   {
@@ -2938,12 +4703,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 22,
+    "start" : 1780907850218,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907850218,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907850218,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907850268
+          }
+        ],
+        "stop" : 1780907850268
+      }
     ],
-    "stop" : 24,
+    "stop" : 1780907850268,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
   {
@@ -2968,7 +4757,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
   {
@@ -2988,12 +4777,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 5,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
   {
@@ -3013,12 +4802,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 15,
+    "start" : 32,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 17,
+    "stop" : 78,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
   {
@@ -3068,7 +4857,7 @@
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 31,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
   {
@@ -3088,12 +4877,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 7,
+    "start" : 32,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 8,
+    "stop" : 151,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }
 ]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.Xcworkspace-macOS_allure_steps.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.Xcworkspace-macOS_allure_steps.txt
@@ -21,7 +21,7 @@
     "steps" : [
 
     ],
-    "stop" : 37,
+    "stop" : 15,
     "uuid" : "00000000-0000-0000-0000-000000000001"
   },
   {
@@ -41,12 +41,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 38,
+    "start" : 16,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 57,
+    "stop" : 29,
     "uuid" : "00000000-0000-0000-0000-000000000002"
   },
   {
@@ -66,12 +66,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 58,
+    "start" : 30,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 71,
+    "stop" : 43,
     "uuid" : "00000000-0000-0000-0000-000000000003"
   },
   {
@@ -175,15 +175,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806479,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907806479,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907806486,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806486
+          }
+        ],
+        "stop" : 1780907806486
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907806486,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
   {
@@ -203,15 +227,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907806492,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907806492,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907806493,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806493
+          }
+        ],
+        "stop" : 1780907806493
+      }
     ],
-    "stop" : 28,
+    "stop" : 1780907806493,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
   {
@@ -231,15 +279,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 1780907806501,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907806501,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907806503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806503
+          }
+        ],
+        "stop" : 1780907806503
+      }
     ],
-    "stop" : 38,
+    "stop" : 1780907806503,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
   {
@@ -259,15 +331,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806477,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806477,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907806482,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806482
+          }
+        ],
+        "stop" : 1780907806482
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907806482,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
   {
@@ -287,15 +383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907806489,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806489,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907806490,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806490
+          }
+        ],
+        "stop" : 1780907806490
+      }
     ],
-    "stop" : 26,
+    "stop" : 1780907806490,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
   {
@@ -315,15 +435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 1780907806500,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806500,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907806502,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806502
+          }
+        ],
+        "stop" : 1780907806502
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907806502,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
   {
@@ -343,15 +487,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806444,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907806444,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907806444,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806480
+          }
+        ],
+        "stop" : 1780907806480
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806480,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907806480,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806480
+          }
+        ],
+        "stop" : 1780907806480
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907806480,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
   {
@@ -371,15 +564,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907806457,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907806457,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907806457,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806490
+          }
+        ],
+        "stop" : 1780907806490
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806490,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907806490,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806490
+          }
+        ],
+        "stop" : 1780907806490
+      }
     ],
-    "stop" : 51,
+    "stop" : 1780907806490,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
   {
@@ -399,15 +641,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 52,
+    "start" : 1780907806470,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907806470,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907806470,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806500
+          }
+        ],
+        "stop" : 1780907806500
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806500,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907806500,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806500
+          }
+        ],
+        "stop" : 1780907806500
+      }
     ],
-    "stop" : 86,
+    "stop" : 1780907806500,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
   {
@@ -427,15 +718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806478,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907806478,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flacky()",
+            "stage" : "finished",
+            "start" : 1780907806483,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806483
+          }
+        ],
+        "stop" : 1780907806483
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907806483,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
   {
@@ -455,12 +770,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907806484,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 27,
+    "stop" : 1780907806486,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
   {
@@ -480,12 +795,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 28,
+    "start" : 1780907806487,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 30,
+    "stop" : 1780907806489,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
   {
@@ -539,15 +854,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907806483,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907806483,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907806483,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806483
+          }
+        ],
+        "stop" : 1780907806483
+      }
     ],
-    "stop" : 11,
+    "stop" : 1780907806483,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
   {
@@ -570,15 +909,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 12,
+    "start" : 1780907806492,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907806492,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907806492,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806492
+          }
+        ],
+        "stop" : 1780907806492
+      }
     ],
-    "stop" : 12,
+    "stop" : 1780907806492,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
   {
@@ -601,12 +964,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 13,
+    "start" : 1780907806493,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 1780907806493,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
   {
@@ -629,12 +992,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 14,
+    "start" : 1780907806494,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 1780907806494,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
   {
@@ -657,12 +1020,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 15,
+    "start" : 1780907806501,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907806501,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907806501,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806501
+          }
+        ],
+        "stop" : 1780907806501
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907806501,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
   {
@@ -687,7 +1074,7 @@
     "steps" : [
 
     ],
-    "stop" : 17,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000025"
   },
   {
@@ -707,12 +1094,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 27,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000026"
   },
   {
@@ -732,12 +1119,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 28,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 30,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000027"
   },
   {
@@ -757,15 +1144,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806481,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907806481,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907806490,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806490
+          }
+        ],
+        "stop" : 1780907806490
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907806490,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
   {
@@ -785,15 +1196,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907806491,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907806491,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907806492,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806492
+          }
+        ],
+        "stop" : 1780907806492
+      }
     ],
-    "stop" : 28,
+    "stop" : 1780907806492,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
   {
@@ -813,15 +1248,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 1780907806498,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907806498,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907806500,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806500
+          }
+        ],
+        "stop" : 1780907806500
+      }
     ],
-    "stop" : 38,
+    "stop" : 1780907806500,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
   {
@@ -841,12 +1300,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806444,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907806444,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907806444,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806451
+          }
+        ],
+        "stop" : 1780907806451
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907806451,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
   {
@@ -866,12 +1349,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907806457,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907806457,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907806457,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806459
+          }
+        ],
+        "stop" : 1780907806459
+      }
     ],
-    "stop" : 28,
+    "stop" : 1780907806459,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
   {
@@ -891,12 +1398,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 1780907806470,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907806470,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907806470,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806472
+          }
+        ],
+        "stop" : 1780907806472
+      }
     ],
-    "stop" : 38,
+    "stop" : 1780907806472,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
   {
@@ -916,12 +1447,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806444,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907806444,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907806444,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806444
+          }
+        ],
+        "stop" : 1780907806444
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907806444,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907806444,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806444
+          }
+        ],
+        "stop" : 1780907806444
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907806444,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907806444,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806453
+          }
+        ],
+        "stop" : 1780907806453
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907806453,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
   {
@@ -941,12 +1546,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907806457,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907806457,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907806457,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806457
+          }
+        ],
+        "stop" : 1780907806457
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907806457,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907806457,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806457
+          }
+        ],
+        "stop" : 1780907806457
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907806457,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907806457,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806458
+          }
+        ],
+        "stop" : 1780907806458
+      }
     ],
-    "stop" : 25,
+    "stop" : 1780907806458,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
   {
@@ -966,12 +1645,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 26,
+    "start" : 1780907806470,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907806470,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907806470,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806470
+          }
+        ],
+        "stop" : 1780907806470
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907806470,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907806470,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806470
+          }
+        ],
+        "stop" : 1780907806470
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907806470,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907806470,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806472
+          }
+        ],
+        "stop" : 1780907806472
+      }
     ],
-    "stop" : 34,
+    "stop" : 1780907806472,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
   {
@@ -991,12 +1744,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806440,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907806440,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907806440,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806445
+          }
+        ],
+        "stop" : 1780907806445
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907806445,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
   {
@@ -1016,12 +1793,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907806457,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907806457,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907806457,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806459
+          }
+        ],
+        "stop" : 1780907806459
+      }
     ],
-    "stop" : 26,
+    "stop" : 1780907806459,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
   {
@@ -1041,12 +1842,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 1780907806470,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907806470,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907806470,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806472
+          }
+        ],
+        "stop" : 1780907806472
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907806472,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
   {
@@ -1066,12 +1891,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806440,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907806440,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907806440,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806445
+          }
+        ],
+        "stop" : 1780907806445
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907806445,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
   {
@@ -1091,12 +1940,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907806457,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907806457,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907806457,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806458
+          }
+        ],
+        "stop" : 1780907806458
+      }
     ],
-    "stop" : 26,
+    "stop" : 1780907806458,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
   {
@@ -1116,12 +1989,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 1780907806470,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907806470,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907806470,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806472
+          }
+        ],
+        "stop" : 1780907806472
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907806472,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
   {
@@ -1146,7 +2043,7 @@
     "steps" : [
 
     ],
-    "stop" : 17,
+    "stop" : 7,
     "uuid" : "00000000-0000-0000-0000-000000000043"
   },
   {
@@ -1166,12 +2063,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 8,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 28,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000044"
   },
   {
@@ -1191,12 +2088,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 31,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000045"
   },
   {
@@ -1216,15 +2113,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806484,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907806484,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907806491,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806491
+          }
+        ],
+        "stop" : 1780907806491
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907806491,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
   {
@@ -1244,15 +2165,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907806489,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907806489,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907806491,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806491
+          }
+        ],
+        "stop" : 1780907806491
+      }
     ],
-    "stop" : 24,
+    "stop" : 1780907806491,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
   {
@@ -1272,15 +2217,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 25,
+    "start" : 1780907806498,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907806498,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907806500,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806500
+          }
+        ],
+        "stop" : 1780907806500
+      }
     ],
-    "stop" : 27,
+    "stop" : 1780907806500,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
   {
@@ -1305,7 +2274,7 @@
     "steps" : [
 
     ],
-    "stop" : 15,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000049"
   },
   {
@@ -1325,12 +2294,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 25,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000050"
   },
   {
@@ -1350,12 +2319,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 26,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 34,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000051"
   },
   {
@@ -1375,15 +2344,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806484,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907806484,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907806489,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806489
+          }
+        ],
+        "stop" : 1780907806489
+      }
     ],
-    "stop" : 12,
+    "stop" : 1780907806489,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
   {
@@ -1403,15 +2396,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 13,
+    "start" : 1780907806493,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907806493,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907806494,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806494
+          }
+        ],
+        "stop" : 1780907806494
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907806494,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
   {
@@ -1431,15 +2448,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907806501,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907806501,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907806503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806503
+          }
+        ],
+        "stop" : 1780907806503
+      }
     ],
-    "stop" : 24,
+    "stop" : 1780907806503,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
   {
@@ -1464,7 +2505,7 @@
     "steps" : [
 
     ],
-    "stop" : 12,
+    "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000055"
   },
   {
@@ -1484,12 +2525,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 13,
+    "start" : 3,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 15,
+    "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000056"
   },
   {
@@ -1509,12 +2550,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 5,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 24,
+    "stop" : 6,
     "uuid" : "00000000-0000-0000-0000-000000000057"
   },
   {
@@ -1534,15 +2575,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806484,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907806484,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907806486,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806486
+          }
+        ],
+        "stop" : 1780907806486
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907806486,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
   {
@@ -1562,15 +2627,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907806494,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907806494,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907806495,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806495
+          }
+        ],
+        "stop" : 1780907806495
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907806495,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
   {
@@ -1590,15 +2679,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907806502,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907806502,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907806503,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806503
+          }
+        ],
+        "stop" : 1780907806503
+      }
     ],
-    "stop" : 12,
+    "stop" : 1780907806503,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
   {
@@ -1623,7 +2736,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000061"
   },
   {
@@ -1643,12 +2756,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 3,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 5,
+    "stop" : 4,
     "uuid" : "00000000-0000-0000-0000-000000000062"
   },
   {
@@ -1668,12 +2781,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 6,
+    "start" : 5,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000063"
   },
   {
@@ -1693,12 +2806,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806449,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907806449,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907806449,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806452
+          }
+        ],
+        "stop" : 1780907806452
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907806452,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
   {
@@ -1718,12 +2855,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907806458,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907806458,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907806458,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806458
+          }
+        ],
+        "stop" : 1780907806458
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907806458,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
   {
@@ -1743,12 +2904,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907806471,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907806471,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907806471,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806472
+          }
+        ],
+        "stop" : 1780907806472
+      }
     ],
-    "stop" : 13,
+    "stop" : 1780907806472,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
   {
@@ -1773,7 +2958,7 @@
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000067"
   },
   {
@@ -1798,7 +2983,7 @@
     "steps" : [
 
     ],
-    "stop" : 11,
+    "stop" : 12,
     "uuid" : "00000000-0000-0000-0000-000000000068"
   },
   {
@@ -1818,12 +3003,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806125,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Compute and record",
+        "stage" : "finished",
+        "start" : 1780907806125,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Activity attachment",
+            "stage" : "finished",
+            "start" : 1780907806125,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806126
+          }
+        ],
+        "stop" : 1780907806126
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907806126,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
   {
@@ -1843,15 +3052,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806126,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Failure is expected",
+        "stage" : "finished",
+        "start" : 1780907806126,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907806174,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806174
+          }
+        ],
+        "stop" : 1780907806174
+      }
     ],
-    "stop" : 457,
+    "stop" : 1780907806174,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
   {
@@ -1871,15 +3104,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806175,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806175,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907806176,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806176
+          }
+        ],
+        "stop" : 1780907806176
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907806176,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
   {
@@ -1899,15 +3156,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907806176,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806176,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907806177,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806177
+          }
+        ],
+        "stop" : 1780907806177
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907806177,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
   {
@@ -1927,15 +3208,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907806177,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806177,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907806178,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806178
+          }
+        ],
+        "stop" : 1780907806178
+      }
     ],
-    "stop" : 1598,
+    "stop" : 1780907806178,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
   {
@@ -1955,15 +3260,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806178,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907806178,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907806178,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806178
+          }
+        ],
+        "stop" : 1780907806178
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806178,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907806179,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806179
+          }
+        ],
+        "stop" : 1780907806179
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907806179,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
   {
@@ -1983,15 +3337,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907806179,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907806179,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907806179,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806179
+          }
+        ],
+        "stop" : 1780907806179
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806179,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907806183,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806183
+          }
+        ],
+        "stop" : 1780907806183
+      }
     ],
-    "stop" : 32,
+    "stop" : 1780907806183,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
   {
@@ -2011,15 +3414,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 33,
+    "start" : 1780907806183,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907806183,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907806183,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806183
+          }
+        ],
+        "stop" : 1780907806183
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806183,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907806184,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806184
+          }
+        ],
+        "stop" : 1780907806184
+      }
     ],
-    "stop" : 34,
+    "stop" : 1780907806184,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
   {
@@ -2039,15 +3491,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806184,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907806184,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_flacky()",
+            "stage" : "finished",
+            "start" : 1780907806185,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806185
+          }
+        ],
+        "stop" : 1780907806185
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907806185,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
   {
@@ -2067,12 +3543,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 30,
+    "start" : 1780907806186,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 31,
+    "stop" : 1780907806190,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
   {
@@ -2097,7 +3573,7 @@
     "steps" : [
 
     ],
-    "stop" : 254,
+    "stop" : 257,
     "uuid" : "00000000-0000-0000-0000-000000000079"
   },
   {
@@ -2125,7 +3601,7 @@
     "steps" : [
 
     ],
-    "stop" : 10,
+    "stop" : 2,
     "uuid" : "00000000-0000-0000-0000-000000000080"
   },
   {
@@ -2150,7 +3626,7 @@
     "steps" : [
 
     ],
-    "stop" : 0,
+    "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000081"
   },
   {
@@ -2170,15 +3646,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806452,
     "status" : "failed",
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907806452,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907806454,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806454
+          }
+        ],
+        "stop" : 1780907806454
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907806454,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
   {
@@ -2198,15 +3698,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907806455,
     "status" : "failed",
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907806455,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907806457,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806457
+          }
+        ],
+        "stop" : 1780907806457
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907806457,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
   {
@@ -2226,15 +3750,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 7,
+    "start" : 1780907806458,
     "status" : "failed",
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907806458,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907806460,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806460
+          }
+        ],
+        "stop" : 1780907806460
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907806460,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
   {
@@ -2254,12 +3802,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806460,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Calculation Result'",
+        "stage" : "finished",
+        "start" : 1780907806460,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result",
+            "stage" : "finished",
+            "start" : 1780907806460,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806462
+          }
+        ],
+        "stop" : 1780907806462
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907806462,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
   {
@@ -2279,12 +3851,61 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806462,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Sum result'",
+        "stage" : "finished",
+        "start" : 1780907806462,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result",
+            "stage" : "finished",
+            "start" : 1780907806462,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806463
+          }
+        ],
+        "stop" : 1780907806463
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment named 'Product result'",
+        "stage" : "finished",
+        "start" : 1780907806463,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result",
+            "stage" : "finished",
+            "start" : 1780907806463,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806464
+          }
+        ],
+        "stop" : 1780907806464
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907806464,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
   {
@@ -2304,12 +3925,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806465,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Pixel.png'",
+        "stage" : "finished",
+        "start" : 1780907806465,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907806465,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806467
+          }
+        ],
+        "stop" : 1780907806467
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907806467,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
   {
@@ -2334,7 +3979,7 @@
     "steps" : [
 
     ],
-    "stop" : 0,
+    "stop" : 1,
     "uuid" : "00000000-0000-0000-0000-000000000088"
   },
   {
@@ -2359,7 +4004,7 @@
     "steps" : [
 
     ],
-    "stop" : 2,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000089"
   },
   {
@@ -2379,12 +4024,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 13,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000090"
   },
   {
@@ -2404,12 +4049,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 14,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 15,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000091"
   },
   {
@@ -2434,7 +4079,7 @@
     "steps" : [
 
     ],
-    "stop" : 19,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000092"
   },
   {
@@ -2454,12 +4099,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 20,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 30,
+    "stop" : 10,
     "uuid" : "00000000-0000-0000-0000-000000000093"
   },
   {
@@ -2479,12 +4124,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 31,
+    "start" : 11,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 33,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000094"
   },
   {
@@ -2509,7 +4154,7 @@
     "steps" : [
 
     ],
-    "stop" : 4,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000095"
   },
   {
@@ -2529,12 +4174,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 15,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000096"
   },
   {
@@ -2554,12 +4199,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 12,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 18,
+    "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000097"
   },
   {
@@ -2584,7 +4229,7 @@
     "steps" : [
 
     ],
-    "stop" : 15,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000098"
   },
   {
@@ -2604,12 +4249,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 26,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000099"
   },
   {
@@ -2629,12 +4274,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 29,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000100"
   },
   {
@@ -2659,7 +4304,7 @@
     "steps" : [
 
     ],
-    "stop" : 39,
+    "stop" : 16,
     "uuid" : "00000000-0000-0000-0000-000000000101"
   },
   {
@@ -2679,12 +4324,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 40,
+    "start" : 17,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 60,
+    "stop" : 30,
     "uuid" : "00000000-0000-0000-0000-000000000102"
   },
   {
@@ -2704,12 +4349,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 61,
+    "start" : 31,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 113,
+    "stop" : 43,
     "uuid" : "00000000-0000-0000-0000-000000000103"
   },
   {
@@ -2729,15 +4374,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806443,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806443,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907806448,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806448
+          }
+        ],
+        "stop" : 1780907806448
+      }
     ],
-    "stop" : 19,
+    "stop" : 1780907806448,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
   {
@@ -2757,15 +4426,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 20,
+    "start" : 1780907806488,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806488,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907806490,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806490
+          }
+        ],
+        "stop" : 1780907806490
+      }
     ],
-    "stop" : 30,
+    "stop" : 1780907806490,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
   {
@@ -2785,15 +4478,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 31,
+    "start" : 1780907806496,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907806496,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907806497,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806497
+          }
+        ],
+        "stop" : 1780907806497
+      }
     ],
-    "stop" : 40,
+    "stop" : 1780907806497,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
   {
@@ -2818,7 +4535,7 @@
     "steps" : [
 
     ],
-    "stop" : 17,
+    "stop" : 5,
     "uuid" : "00000000-0000-0000-0000-000000000107"
   },
   {
@@ -2838,12 +4555,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 6,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 28,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000108"
   },
   {
@@ -2863,12 +4580,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 30,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000109"
   },
   {
@@ -2888,12 +4605,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907806444,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907806444,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907806444,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806454
+          }
+        ],
+        "stop" : 1780907806454
+      }
     ],
-    "stop" : 18,
+    "stop" : 1780907806454,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
   {
@@ -2913,12 +4654,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 19,
+    "start" : 1780907806456,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907806456,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907806456,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806458
+          }
+        ],
+        "stop" : 1780907806458
+      }
     ],
-    "stop" : 21,
+    "stop" : 1780907806458,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
   {
@@ -2938,12 +4703,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 22,
+    "start" : 1780907806468,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907806468,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907806468,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907806470
+          }
+        ],
+        "stop" : 1780907806470
+      }
     ],
-    "stop" : 24,
+    "stop" : 1780907806470,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
   {
@@ -2968,7 +4757,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000113"
   },
   {
@@ -2988,12 +4777,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000114"
   },
   {
@@ -3013,12 +4802,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 15,
+    "start" : 12,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 17,
+    "stop" : 13,
     "uuid" : "00000000-0000-0000-0000-000000000115"
   },
   {
@@ -3043,7 +4832,7 @@
     "steps" : [
 
     ],
-    "stop" : 3,
+    "stop" : 8,
     "uuid" : "00000000-0000-0000-0000-000000000116"
   },
   {
@@ -3063,12 +4852,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 9,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 6,
+    "stop" : 11,
     "uuid" : "00000000-0000-0000-0000-000000000117"
   },
   {
@@ -3088,12 +4877,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 7,
+    "start" : 12,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 8,
+    "stop" : 14,
     "uuid" : "00000000-0000-0000-0000-000000000118"
   }
 ]

--- a/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.Xcworkspace-visionOS_allure_steps.txt
+++ b/Tests/PeekieTests/__Snapshots__/AllureFormatterSnapshotTests/results_withSteps-_.Xcworkspace-visionOS_allure_steps.txt
@@ -175,15 +175,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897784,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907897784,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907897801,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897801
+          }
+        ],
+        "stop" : 1780907897801
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907897801,
     "uuid" : "00000000-0000-0000-0000-000000000007"
   },
   {
@@ -203,15 +227,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907897834,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907897834,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907897844,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897844
+          }
+        ],
+        "stop" : 1780907897844
+      }
     ],
-    "stop" : 28,
+    "stop" : 1780907897844,
     "uuid" : "00000000-0000-0000-0000-000000000008"
   },
   {
@@ -231,15 +279,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 1780907897850,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expected failure",
+        "stage" : "finished",
+        "start" : 1780907897850,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907897859,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897859
+          }
+        ],
+        "stop" : 1780907897859
+      }
     ],
-    "stop" : 38,
+    "stop" : 1780907897859,
     "uuid" : "00000000-0000-0000-0000-000000000009"
   },
   {
@@ -259,15 +331,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897766,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897766,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907897782,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897782
+          }
+        ],
+        "stop" : 1780907897782
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907897782,
     "uuid" : "00000000-0000-0000-0000-000000000010"
   },
   {
@@ -287,15 +383,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907897831,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897831,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907897840,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897840
+          }
+        ],
+        "stop" : 1780907897840
+      }
     ],
-    "stop" : 26,
+    "stop" : 1780907897840,
     "uuid" : "00000000-0000-0000-0000-000000000011"
   },
   {
@@ -315,15 +435,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 1780907897844,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897844,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failure()",
+            "stage" : "finished",
+            "start" : 1780907897846,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897846
+          }
+        ],
+        "stop" : 1780907897846
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907897846,
     "uuid" : "00000000-0000-0000-0000-000000000012"
   },
   {
@@ -343,15 +487,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897757,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907897757,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907897757,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897772
+          }
+        ],
+        "stop" : 1780907897772
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897772,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907897773,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897773
+          }
+        ],
+        "stop" : 1780907897773
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907897773,
     "uuid" : "00000000-0000-0000-0000-000000000013"
   },
   {
@@ -371,15 +564,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907897803,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907897803,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907897803,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897837
+          }
+        ],
+        "stop" : 1780907897837
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897837,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907897837,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897837
+          }
+        ],
+        "stop" : 1780907897837
+      }
     ],
-    "stop" : 51,
+    "stop" : 1780907897837,
     "uuid" : "00000000-0000-0000-0000-000000000014"
   },
   {
@@ -399,15 +641,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 52,
+    "start" : 1780907897814,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Failure context.txt",
+        "stage" : "finished",
+        "start" : 1780907897814,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context.txt",
+            "stage" : "finished",
+            "start" : 1780907897814,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897848
+          }
+        ],
+        "stop" : 1780907897848
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897848,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907897848,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897848
+          }
+        ],
+        "stop" : 1780907897848
+      }
     ],
-    "stop" : 86,
+    "stop" : 1780907897848,
     "uuid" : "00000000-0000-0000-0000-000000000015"
   },
   {
@@ -427,15 +718,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897785,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907897785,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flacky()",
+            "stage" : "finished",
+            "start" : 1780907897802,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897802
+          }
+        ],
+        "stop" : 1780907897802
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907897802,
     "uuid" : "00000000-0000-0000-0000-000000000016"
   },
   {
@@ -455,12 +770,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907897803,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 27,
+    "stop" : 1780907897812,
     "uuid" : "00000000-0000-0000-0000-000000000017"
   },
   {
@@ -480,12 +795,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 28,
+    "start" : 1780907897813,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 30,
+    "stop" : 1780907897815,
     "uuid" : "00000000-0000-0000-0000-000000000018"
   },
   {
@@ -539,15 +854,39 @@
       }
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907897821,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907897821,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907897828,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897828
+          }
+        ],
+        "stop" : 1780907897828
+      }
     ],
-    "stop" : 11,
+    "stop" : 1780907897828,
     "uuid" : "00000000-0000-0000-0000-000000000020"
   },
   {
@@ -570,7 +909,7 @@
       }
     ],
     "stage" : "finished",
-    "start" : 12,
+    "start" : 1780907897829,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:66: Expectation failed: (result → 4.0) == 5.0"
@@ -578,7 +917,7 @@
     "steps" : [
 
     ],
-    "stop" : 12,
+    "stop" : 1780907897829,
     "uuid" : "00000000-0000-0000-0000-000000000021"
   },
   {
@@ -601,12 +940,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 13,
+    "start" : 1780907897832,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907897832,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907897832,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897832
+          }
+        ],
+        "stop" : 1780907897832
+      }
     ],
-    "stop" : 13,
+    "stop" : 1780907897832,
     "uuid" : "00000000-0000-0000-0000-000000000022"
   },
   {
@@ -629,12 +992,12 @@
       }
     ],
     "stage" : "finished",
-    "start" : 14,
+    "start" : 1780907897833,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 14,
+    "stop" : 1780907897833,
     "uuid" : "00000000-0000-0000-0000-000000000023"
   },
   {
@@ -657,12 +1020,36 @@
       }
     ],
     "stage" : "finished",
-    "start" : 15,
+    "start" : 1780907897848,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Expectation failed: (result → 4.0) == 5.0",
+        "stage" : "finished",
+        "start" : 1780907897848,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.flackyParameterized(value:)",
+            "stage" : "finished",
+            "start" : 1780907897848,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897848
+          }
+        ],
+        "stop" : 1780907897848
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907897848,
     "uuid" : "00000000-0000-0000-0000-000000000024"
   },
   {
@@ -757,15 +1144,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897822,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907897822,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907897839,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897839
+          }
+        ],
+        "stop" : 1780907897839
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907897839,
     "uuid" : "00000000-0000-0000-0000-000000000028"
   },
   {
@@ -785,15 +1196,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907897838,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907897838,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907897848,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897848
+          }
+        ],
+        "stop" : 1780907897848
+      }
     ],
-    "stop" : 28,
+    "stop" : 1780907897848,
     "uuid" : "00000000-0000-0000-0000-000000000029"
   },
   {
@@ -813,15 +1248,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 1780907897849,
     "status" : "failed",
     "statusDetails" : {
       "message" : "SwiftTestingTests.swift:85: Caught error: .divisionByZero"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Caught error: .divisionByZero",
+        "stage" : "finished",
+        "start" : 1780907897849,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "ExampleSUITests.throwing()",
+            "stage" : "finished",
+            "start" : 1780907897858,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897858
+          }
+        ],
+        "stop" : 1780907897858
+      }
     ],
-    "stop" : 38,
+    "stop" : 1780907897858,
     "uuid" : "00000000-0000-0000-0000-000000000030"
   },
   {
@@ -841,12 +1300,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897771,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907897771,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907897771,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897788
+          }
+        ],
+        "stop" : 1780907897788
+      }
     ],
-    "stop" : 17,
+    "stop" : 1780907897788,
     "uuid" : "00000000-0000-0000-0000-000000000031"
   },
   {
@@ -866,12 +1349,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 18,
+    "start" : 1780907897802,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907897802,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907897802,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897812
+          }
+        ],
+        "stop" : 1780907897812
+      }
     ],
-    "stop" : 28,
+    "stop" : 1780907897812,
     "uuid" : "00000000-0000-0000-0000-000000000032"
   },
   {
@@ -891,12 +1398,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 29,
+    "start" : 1780907897814,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Calculation Result.txt",
+        "stage" : "finished",
+        "start" : 1780907897814,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result.txt",
+            "stage" : "finished",
+            "start" : 1780907897814,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897823
+          }
+        ],
+        "stop" : 1780907897823
+      }
     ],
-    "stop" : 38,
+    "stop" : 1780907897823,
     "uuid" : "00000000-0000-0000-0000-000000000033"
   },
   {
@@ -916,12 +1447,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897757,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907897757,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907897757,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897761
+          }
+        ],
+        "stop" : 1780907897761
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907897761,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907897761,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897761
+          }
+        ],
+        "stop" : 1780907897761
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907897761,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907897761,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897772
+          }
+        ],
+        "stop" : 1780907897772
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907897772,
     "uuid" : "00000000-0000-0000-0000-000000000034"
   },
   {
@@ -941,12 +1546,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907897795,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907897795,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907897795,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897795
+          }
+        ],
+        "stop" : 1780907897795
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907897795,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907897795,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897795
+          }
+        ],
+        "stop" : 1780907897795
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907897795,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907897795,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897804
+          }
+        ],
+        "stop" : 1780907897804
+      }
     ],
-    "stop" : 25,
+    "stop" : 1780907897804,
     "uuid" : "00000000-0000-0000-0000-000000000035"
   },
   {
@@ -966,12 +1645,86 @@
 
     ],
     "stage" : "finished",
-    "start" : 26,
+    "start" : 1780907897814,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Sum result.txt",
+        "stage" : "finished",
+        "start" : 1780907897814,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result.txt",
+            "stage" : "finished",
+            "start" : 1780907897814,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897814
+          }
+        ],
+        "stop" : 1780907897814
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Product result.txt",
+        "stage" : "finished",
+        "start" : 1780907897814,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result.txt",
+            "stage" : "finished",
+            "start" : 1780907897814,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897814
+          }
+        ],
+        "stop" : 1780907897814
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment name Operands.txt",
+        "stage" : "finished",
+        "start" : 1780907897814,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Operands.txt",
+            "stage" : "finished",
+            "start" : 1780907897814,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897822
+          }
+        ],
+        "stop" : 1780907897822
+      }
     ],
-    "stop" : 34,
+    "stop" : 1780907897822,
     "uuid" : "00000000-0000-0000-0000-000000000036"
   },
   {
@@ -991,12 +1744,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897770,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907897770,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907897770,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897786
+          }
+        ],
+        "stop" : 1780907897786
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907897786,
     "uuid" : "00000000-0000-0000-0000-000000000037"
   },
   {
@@ -1016,12 +1793,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907897795,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907897795,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907897795,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897804
+          }
+        ],
+        "stop" : 1780907897804
+      }
     ],
-    "stop" : 26,
+    "stop" : 1780907897804,
     "uuid" : "00000000-0000-0000-0000-000000000038"
   },
   {
@@ -1041,12 +1842,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 1780907897814,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Pixel.png",
+        "stage" : "finished",
+        "start" : 1780907897814,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907897814,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897816
+          }
+        ],
+        "stop" : 1780907897816
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907897816,
     "uuid" : "00000000-0000-0000-0000-000000000039"
   },
   {
@@ -1066,12 +1891,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897771,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907897771,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907897771,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897787
+          }
+        ],
+        "stop" : 1780907897787
+      }
     ],
-    "stop" : 16,
+    "stop" : 1780907897787,
     "uuid" : "00000000-0000-0000-0000-000000000040"
   },
   {
@@ -1091,12 +1940,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 17,
+    "start" : 1780907897802,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907897802,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907897802,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897811
+          }
+        ],
+        "stop" : 1780907897811
+      }
     ],
-    "stop" : 26,
+    "stop" : 1780907897811,
     "uuid" : "00000000-0000-0000-0000-000000000041"
   },
   {
@@ -1116,12 +1989,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 27,
+    "start" : 1780907897814,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Raw binary blob",
+        "stage" : "finished",
+        "start" : 1780907897814,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Raw binary blob",
+            "stage" : "finished",
+            "start" : 1780907897814,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897816
+          }
+        ],
+        "stop" : 1780907897816
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907897816,
     "uuid" : "00000000-0000-0000-0000-000000000042"
   },
   {
@@ -1216,15 +2113,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897767,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907897767,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907897782,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897782
+          }
+        ],
+        "stop" : 1780907897782
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907897782,
     "uuid" : "00000000-0000-0000-0000-000000000046"
   },
   {
@@ -1244,15 +2165,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907897829,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907897829,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907897837,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897837
+          }
+        ],
+        "stop" : 1780907897837
+      }
     ],
-    "stop" : 24,
+    "stop" : 1780907897837,
     "uuid" : "00000000-0000-0000-0000-000000000047"
   },
   {
@@ -1272,15 +2217,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 25,
+    "start" : 1780907897844,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Outer suite failure: result was 200.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Outer suite failure: result was 200.0",
+        "stage" : "finished",
+        "start" : 1780907897844,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.outerFailure()",
+            "stage" : "finished",
+            "start" : 1780907897846,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897846
+          }
+        ],
+        "stop" : 1780907897846
+      }
     ],
-    "stop" : 27,
+    "stop" : 1780907897846,
     "uuid" : "00000000-0000-0000-0000-000000000048"
   },
   {
@@ -1375,15 +2344,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897815,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907897815,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907897827,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897827
+          }
+        ],
+        "stop" : 1780907897827
+      }
     ],
-    "stop" : 12,
+    "stop" : 1780907897827,
     "uuid" : "00000000-0000-0000-0000-000000000052"
   },
   {
@@ -1403,15 +2396,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 13,
+    "start" : 1780907897837,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907897837,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907897839,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897839
+          }
+        ],
+        "stop" : 1780907897839
+      }
     ],
-    "stop" : 15,
+    "stop" : 1780907897839,
     "uuid" : "00000000-0000-0000-0000-000000000053"
   },
   {
@@ -1431,15 +2448,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 16,
+    "start" : 1780907897849,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Inner suite failure: result was 12.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Inner suite failure: result was 12.0",
+        "stage" : "finished",
+        "start" : 1780907897849,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.innerFailure()",
+            "stage" : "finished",
+            "start" : 1780907897857,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897857
+          }
+        ],
+        "stop" : 1780907897857
+      }
     ],
-    "stop" : 24,
+    "stop" : 1780907897857,
     "uuid" : "00000000-0000-0000-0000-000000000054"
   },
   {
@@ -1534,15 +2575,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897817,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907897817,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907897820,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897820
+          }
+        ],
+        "stop" : 1780907897820
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907897820,
     "uuid" : "00000000-0000-0000-0000-000000000058"
   },
   {
@@ -1562,15 +2627,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907897839,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907897839,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907897839,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897839
+          }
+        ],
+        "stop" : 1780907897839
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907897839,
     "uuid" : "00000000-0000-0000-0000-000000000059"
   },
   {
@@ -1590,15 +2679,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907897852,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Deeply nested failure: result was 0.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Deeply nested failure: result was 0.0",
+        "stage" : "finished",
+        "start" : 1780907897852,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "OuterSuite.InnerSuite.DeeplyNestedSuite.deeplyNestedFailure()",
+            "stage" : "finished",
+            "start" : 1780907897859,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897859
+          }
+        ],
+        "stop" : 1780907897859
+      }
     ],
-    "stop" : 12,
+    "stop" : 1780907897859,
     "uuid" : "00000000-0000-0000-0000-000000000060"
   },
   {
@@ -1693,12 +2806,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897773,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907897773,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907897773,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897776
+          }
+        ],
+        "stop" : 1780907897776
+      }
     ],
-    "stop" : 3,
+    "stop" : 1780907897776,
     "uuid" : "00000000-0000-0000-0000-000000000064"
   },
   {
@@ -1718,12 +2855,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 4,
+    "start" : 1780907897804,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907897804,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907897804,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897804
+          }
+        ],
+        "stop" : 1780907897804
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907897804,
     "uuid" : "00000000-0000-0000-0000-000000000065"
   },
   {
@@ -1743,12 +2904,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907897822,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Deeply nested attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907897822,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Deeply nested attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907897822,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897830
+          }
+        ],
+        "stop" : 1780907897830
+      }
     ],
-    "stop" : 13,
+    "stop" : 1780907897830,
     "uuid" : "00000000-0000-0000-0000-000000000066"
   },
   {
@@ -1818,12 +3003,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907895333,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Compute and record",
+        "stage" : "finished",
+        "start" : 1780907895333,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Activity attachment",
+            "stage" : "finished",
+            "start" : 1780907895333,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907895334
+          }
+        ],
+        "stop" : 1780907895334
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907895334,
     "uuid" : "00000000-0000-0000-0000-000000000069"
   },
   {
@@ -1843,15 +3052,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907895335,
     "status" : "passed",
     "statusDetails" : {
       "message" : "Failure is expected"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Failure is expected",
+        "stage" : "finished",
+        "start" : 1780907895335,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_expectedFailure()",
+            "stage" : "finished",
+            "start" : 1780907895792,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907895792
+          }
+        ],
+        "stop" : 1780907895792
+      }
     ],
-    "stop" : 457,
+    "stop" : 1780907895792,
     "uuid" : "00000000-0000-0000-0000-000000000070"
   },
   {
@@ -1871,15 +3104,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907895791,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907895791,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907895793,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907895793
+          }
+        ],
+        "stop" : 1780907895793
+      }
     ],
-    "stop" : 2,
+    "stop" : 1780907895793,
     "uuid" : "00000000-0000-0000-0000-000000000071"
   },
   {
@@ -1899,15 +3156,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 3,
+    "start" : 1780907895793,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907895793,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907895794,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907895794
+          }
+        ],
+        "stop" : 1780907895794
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907895794,
     "uuid" : "00000000-0000-0000-0000-000000000072"
   },
   {
@@ -1927,15 +3208,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907897385,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897385,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failure()",
+            "stage" : "finished",
+            "start" : 1780907898978,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907898978
+          }
+        ],
+        "stop" : 1780907898978
+      }
     ],
-    "stop" : 1598,
+    "stop" : 1780907898978,
     "uuid" : "00000000-0000-0000-0000-000000000073"
   },
   {
@@ -1955,15 +3260,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897387,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907897387,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907897387,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897387
+          }
+        ],
+        "stop" : 1780907897387
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897387,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907897388,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897388
+          }
+        ],
+        "stop" : 1780907897388
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907897388,
     "uuid" : "00000000-0000-0000-0000-000000000074"
   },
   {
@@ -1983,15 +3337,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 2,
+    "start" : 1780907897417,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907897417,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907897417,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897418
+          }
+        ],
+        "stop" : 1780907897418
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897418,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907897447,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897447
+          }
+        ],
+        "stop" : 1780907897447
+      }
     ],
-    "stop" : 32,
+    "stop" : 1780907897447,
     "uuid" : "00000000-0000-0000-0000-000000000075"
   },
   {
@@ -2011,15 +3414,64 @@
 
     ],
     "stage" : "finished",
-    "start" : 33,
+    "start" : 1780907897419,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Failure context'",
+        "stage" : "finished",
+        "start" : 1780907897419,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Failure context",
+            "stage" : "finished",
+            "start" : 1780907897419,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897419
+          }
+        ],
+        "stop" : 1780907897419
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "failed - Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897419,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_failureWithAttachment()",
+            "stage" : "finished",
+            "start" : 1780907897420,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897420
+          }
+        ],
+        "stop" : 1780907897420
+      }
     ],
-    "stop" : 34,
+    "stop" : 1780907897420,
     "uuid" : "00000000-0000-0000-0000-000000000076"
   },
   {
@@ -2039,15 +3491,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897420,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Flacky failure message: result was 2.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed - Flacky failure message: result was 2.0",
+        "stage" : "finished",
+        "start" : 1780907897420,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_flacky()",
+            "stage" : "finished",
+            "start" : 1780907897449,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897449
+          }
+        ],
+        "stop" : 1780907897449
+      }
     ],
-    "stop" : 29,
+    "stop" : 1780907897449,
     "uuid" : "00000000-0000-0000-0000-000000000077"
   },
   {
@@ -2067,12 +3543,12 @@
 
     ],
     "stage" : "finished",
-    "start" : 30,
+    "start" : 1780907897450,
     "status" : "passed",
     "steps" : [
 
     ],
-    "stop" : 31,
+    "stop" : 1780907897451,
     "uuid" : "00000000-0000-0000-0000-000000000078"
   },
   {
@@ -2170,15 +3646,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897718,
     "status" : "failed",
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907897718,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907897722,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897722
+          }
+        ],
+        "stop" : 1780907897722
+      }
     ],
-    "stop" : 4,
+    "stop" : 1780907897722,
     "uuid" : "00000000-0000-0000-0000-000000000082"
   },
   {
@@ -2198,15 +3698,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 5,
+    "start" : 1780907897720,
     "status" : "failed",
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907897720,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907897721,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897721
+          }
+        ],
+        "stop" : 1780907897721
+      }
     ],
-    "stop" : 6,
+    "stop" : 1780907897721,
     "uuid" : "00000000-0000-0000-0000-000000000083"
   },
   {
@@ -2226,15 +3750,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 7,
+    "start" : 1780907897721,
     "status" : "failed",
     "statusDetails" : {
       "message" : "XCTestTests.swift:77: failed: caught error: \"divisionByZero\""
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "failed: caught error: \"divisionByZero\"",
+        "stage" : "finished",
+        "start" : 1780907897721,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "XCTestTests.test_throwing()",
+            "stage" : "finished",
+            "start" : 1780907897722,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897722
+          }
+        ],
+        "stop" : 1780907897722
+      }
     ],
-    "stop" : 8,
+    "stop" : 1780907897722,
     "uuid" : "00000000-0000-0000-0000-000000000084"
   },
   {
@@ -2254,12 +3802,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897722,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Calculation Result'",
+        "stage" : "finished",
+        "start" : 1780907897722,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Calculation Result",
+            "stage" : "finished",
+            "start" : 1780907897722,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897723
+          }
+        ],
+        "stop" : 1780907897723
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907897723,
     "uuid" : "00000000-0000-0000-0000-000000000085"
   },
   {
@@ -2279,12 +3851,61 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897723,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Sum result'",
+        "stage" : "finished",
+        "start" : 1780907897723,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Sum result",
+            "stage" : "finished",
+            "start" : 1780907897723,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897723
+          }
+        ],
+        "stop" : 1780907897723
+      },
+      {
+        "attachments" : [
+
+        ],
+        "name" : "Added attachment named 'Product result'",
+        "stage" : "finished",
+        "start" : 1780907897723,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Product result",
+            "stage" : "finished",
+            "start" : 1780907897723,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897724
+          }
+        ],
+        "stop" : 1780907897724
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907897724,
     "uuid" : "00000000-0000-0000-0000-000000000086"
   },
   {
@@ -2304,12 +3925,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897724,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment named 'Pixel.png'",
+        "stage" : "finished",
+        "start" : 1780907897724,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Pixel.png",
+            "stage" : "finished",
+            "start" : 1780907897724,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897725
+          }
+        ],
+        "stop" : 1780907897725
+      }
     ],
-    "stop" : 1,
+    "stop" : 1780907897725,
     "uuid" : "00000000-0000-0000-0000-000000000087"
   },
   {
@@ -2729,15 +4374,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897785,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897785,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907897804,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897804
+          }
+        ],
+        "stop" : 1780907897804
+      }
     ],
-    "stop" : 19,
+    "stop" : 1780907897804,
     "uuid" : "00000000-0000-0000-0000-000000000104"
   },
   {
@@ -2757,15 +4426,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 20,
+    "start" : 1780907897830,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897830,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907897840,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897840
+          }
+        ],
+        "stop" : 1780907897840
+      }
     ],
-    "stop" : 30,
+    "stop" : 1780907897840,
     "uuid" : "00000000-0000-0000-0000-000000000105"
   },
   {
@@ -2785,15 +4478,39 @@
 
     ],
     "stage" : "finished",
-    "start" : 31,
+    "start" : 1780907897847,
     "status" : "failed",
     "statusDetails" : {
       "message" : "Expected 5.0 but got 6.0"
     },
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Issue recorded: Expected 5.0 but got 6.0",
+        "stage" : "finished",
+        "start" : 1780907897847,
+        "status" : "failed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "rootLevelFailure()",
+            "stage" : "finished",
+            "start" : 1780907897856,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897856
+          }
+        ],
+        "stop" : 1780907897856
+      }
     ],
-    "stop" : 40,
+    "stop" : 1780907897856,
     "uuid" : "00000000-0000-0000-0000-000000000106"
   },
   {
@@ -2888,12 +4605,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 0,
+    "start" : 1780907897761,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907897761,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907897761,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897779
+          }
+        ],
+        "stop" : 1780907897779
+      }
     ],
-    "stop" : 18,
+    "stop" : 1780907897779,
     "uuid" : "00000000-0000-0000-0000-000000000110"
   },
   {
@@ -2913,12 +4654,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 19,
+    "start" : 1780907897794,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907897794,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907897794,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897796
+          }
+        ],
+        "stop" : 1780907897796
+      }
     ],
-    "stop" : 21,
+    "stop" : 1780907897796,
     "uuid" : "00000000-0000-0000-0000-000000000111"
   },
   {
@@ -2938,12 +4703,36 @@
 
     ],
     "stage" : "finished",
-    "start" : 22,
+    "start" : 1780907897814,
     "status" : "passed",
     "steps" : [
+      {
+        "attachments" : [
 
+        ],
+        "name" : "Added attachment name Root attachment.txt",
+        "stage" : "finished",
+        "start" : 1780907897814,
+        "status" : "passed",
+        "steps" : [
+          {
+            "attachments" : [
+
+            ],
+            "name" : "Root attachment.txt",
+            "stage" : "finished",
+            "start" : 1780907897814,
+            "status" : "passed",
+            "steps" : [
+
+            ],
+            "stop" : 1780907897816
+          }
+        ],
+        "stop" : 1780907897816
+      }
     ],
-    "stop" : 24,
+    "stop" : 1780907897816,
     "uuid" : "00000000-0000-0000-0000-000000000112"
   },
   {


### PR DESCRIPTION
## Summary

Adds `--steps` to `peekie tests --format allure`: per-test activity trees are read from the bundle (`xcresulttool get test-results activities`, one cheap call per test — ~30 ms) and mapped to Allure steps and metadata. This makes the Allure export complete for UI test bundles, where the step log is the report's main content.

Validated on a production UI-test bundle (91 tests, retries, screen recordings): 93 results, every one with steps and an `ALLURE_ID` label, screen recordings bound to the correct attempts, and the downstream jq-based post-processing pipeline of the consuming repo runs unchanged.

## Key Changes

- `TestActivitiesDTO`: decodes `get test-results activities` output — activity titles, start times, failure association, nested activities, attachment references.
- `AllureFormatter`: new async `results(report:startedAt:stepsFrom:)` / `write(report:to:stepsFrom:)` overloads. Activities map to the Allure step tree with real timestamps; metadata activities follow the eroshenkoam/xcresults convention — `allure.id:` → `AS_ID` label, `allure.label.<name>:<value>` → label, `allure.name:` / `allure.description:` → overrides. Attachments join their steps exactly: the activity attachment `uuid` is the exported file name stem. Attachments referenced by no activity stay on the result, so nothing exported is lost.
- Real per-attempt timestamps replace the synthetic retry chaining whenever activities are present, so retry resolution keeps picking the final attempt — now with true times.
- CLI: `peekie tests <xcresult> --format allure --output-dir <dir> --steps`.

## Additional Changes

- `AllureTestResult` extracted to its own file; steps machinery lives in `AllureFormatter+Steps.swift` (`StepsBuilder`, `ActivityMetadata`).
- Snapshot coverage: `results_withSteps` over all resource bundles (deterministic UUIDs), unit tests for metadata title parsing; existing no-steps snapshots re-recorded for the new `steps`/`description` fields.
- README: `--steps` documented in the `peekie tests` section.