### PR TITLE
Fix failure message extraction for merged xcresult bundles

### DIFF
--- a/Sources/PeekieSDK/Models/DTO/TestResultsDTO.swift
+++ b/Sources/PeekieSDK/Models/DTO/TestResultsDTO.swift
@@ -197,14 +197,32 @@ extension TestResultsDTO.TestNode {
         case expectedFailure = "Expected Failure"
     }
 
+    /// Children visible for metadata lookup, descending through structural wrapper
+    /// nodes (Device/Arguments) that `xcresulttool merge` inserts between a test
+    /// case and its metadata: in a merged bundle the tree is
+    /// `Test Case → Device → Failure Message`, while an unmerged one has the
+    /// message as a direct child. Repetition nodes are not entered — each
+    /// repetition owns its messages.
+    var metadataSearchSpace: [Self] {
+        var queue = children ?? []
+        var result = [Self]()
+        while queue.isEmpty == false {
+            let node = queue.removeFirst()
+            result.append(node)
+            if node.nodeType == .device || node.nodeType == .arguments {
+                queue.append(contentsOf: node.children ?? [])
+            }
+        }
+        return result
+    }
+
     /// Extracts failure message from children nodes
     /// Extracts message after "failed -" separator (e.g., "File.swift:51: failed - Failure message"
     /// -> "Failure message")
     /// For Swift Testing format, extracts message after "Issue recorded: " (e.g., "File.swift:56:
     /// Issue recorded: Failure message" -> "Failure message")
     var failureMessage: String? {
-        guard let children,
-              let messageNode = children.first(where: { $0.nodeType == .failureMessage })
+        guard let messageNode = metadataSearchSpace.first(where: { $0.nodeType == .failureMessage })
         else {
             return nil
         }
@@ -225,11 +243,7 @@ extension TestResultsDTO.TestNode {
     /// Extracts message after "skipped -" separator (e.g., "Test skipped - Skip message" -> "Skip
     /// message")
     var skipMessage: String? {
-        guard let children else {
-            return nil
-        }
-
-        let messageNode = children.first {
+        let messageNode = metadataSearchSpace.first {
             $0.nodeType == .failureMessage && $0.name.lowercased().contains("skip")
         }
         guard let message = messageNode?.name else {

--- a/Sources/PeekieSDK/Models/DTO/TestResultsDTO.swift
+++ b/Sources/PeekieSDK/Models/DTO/TestResultsDTO.swift
@@ -197,13 +197,18 @@ extension TestResultsDTO.TestNode {
         case expectedFailure = "Expected Failure"
     }
 
-    /// Children visible for metadata lookup, descending through structural wrapper
-    /// nodes (Device/Arguments) that `xcresulttool merge` inserts between a test
-    /// case and its metadata: in a merged bundle the tree is
-    /// `Test Case → Device → Failure Message`, while an unmerged one has the
-    /// message as a direct child. Repetition nodes are not entered — each
-    /// repetition owns its messages.
+    /// Children visible for metadata lookup. For test cases the search descends
+    /// through structural wrapper nodes (Device/Arguments) that `xcresulttool
+    /// merge` inserts between a test case and its metadata: in a merged bundle
+    /// the tree is `Test Case → Device → Failure Message`, while an unmerged one
+    /// has the message as a direct child. Dimension nodes (Device, Arguments,
+    /// Repetition) stay scoped to their direct children — each owns its own
+    /// messages, mirroring how `extractPaths`/`mergedTests` treat them.
     var metadataSearchSpace: [Self] {
+        guard nodeType == .testCase else {
+            return children ?? []
+        }
+
         var queue = children ?? []
         var result = [Self]()
         while queue.isEmpty == false {

--- a/Sources/PeekieSDK/Models/Report+Test.swift
+++ b/Sources/PeekieSDK/Models/Report+Test.swift
@@ -186,9 +186,10 @@ extension Report.Module.Suite.RepeatableTest.Test {
 
         self.path = path
 
-        // Extract messages from testCase metadata
-        failureMessage = testCase.failureMessage
-        skipMessage = testCase.skipMessage
+        // Prefer the arguments node's own messages so each argument set keeps its
+        // message; fall back to testCase metadata
+        failureMessage = node.failureMessage ?? testCase.failureMessage
+        skipMessage = node.skipMessage ?? testCase.skipMessage
         attachments = []
     }
 

--- a/Tests/PeekieTests/TestResultsDTOFailureMessageTests.swift
+++ b/Tests/PeekieTests/TestResultsDTOFailureMessageTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Testing
+@testable import PeekieSDK
+
+/// `xcresulttool merge` inserts structural wrapper nodes (Device/Arguments)
+/// between a test case and its Failure Message, so message extraction must
+/// descend through them: an unmerged bundle has `Test Case → Failure Message`,
+/// a merged one `Test Case → Device → Failure Message`.
+struct TestResultsDTOFailureMessageTests {
+    // MARK: Internal
+
+    @Test
+    func failureMessageFromDirectChild() {
+        let testCase = makeNode(
+            name: "test_example()",
+            nodeType: .testCase,
+            result: .failed,
+            children: [
+                makeNode(
+                    name: "File.swift:51: failed - Направление не выбрано",
+                    nodeType: .failureMessage
+                ),
+            ]
+        )
+
+        #expect(testCase.failureMessage == "Направление не выбрано")
+    }
+
+    @Test
+    func failureMessageThroughDeviceWrapper() {
+        // Merged bundle: Test Case -> Device -> Failure Message
+        let testCase = makeNode(
+            name: "test_example()",
+            nodeType: .testCase,
+            result: .failed,
+            children: [
+                makeNode(
+                    name: "iPhone 13",
+                    nodeType: .device,
+                    result: .failed,
+                    children: [
+                        makeNode(
+                            name: "File.swift:84: failed - Не удалось выбрать тип заказа",
+                            nodeType: .failureMessage
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        #expect(testCase.failureMessage == "Не удалось выбрать тип заказа")
+    }
+
+    @Test
+    func failureMessageThroughDeviceAndArguments() {
+        // Merged parameterized test: Test Case -> Device -> Arguments -> Failure Message
+        let testCase = makeNode(
+            name: "test_example(value:)",
+            nodeType: .testCase,
+            result: .failed,
+            children: [
+                makeNode(
+                    name: "iPhone 13",
+                    nodeType: .device,
+                    result: .failed,
+                    children: [
+                        makeNode(
+                            name: "value: 42",
+                            nodeType: .arguments,
+                            result: .failed,
+                            children: [
+                                makeNode(
+                                    name: "File.swift:12: Issue recorded: Wrong answer",
+                                    nodeType: .failureMessage
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        #expect(testCase.failureMessage == "Wrong answer")
+    }
+
+    @Test
+    func failureMessageDoesNotEnterRepetitions() {
+        // Each repetition owns its message: the test case level must not leak it
+        let testCase = makeNode(
+            name: "test_example()",
+            nodeType: .testCase,
+            result: .failed,
+            children: [
+                makeNode(
+                    name: "iPhone 13",
+                    nodeType: .device,
+                    result: .failed,
+                    children: [
+                        makeNode(
+                            name: "Repetition 1 of 3",
+                            nodeType: .repetition,
+                            result: .failed,
+                            children: [
+                                makeNode(
+                                    name: "File.swift:1: failed - Only mine",
+                                    nodeType: .failureMessage
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        #expect(testCase.failureMessage == nil)
+    }
+
+    @Test
+    func skipMessageThroughDeviceWrapper() {
+        let testCase = makeNode(
+            name: "test_example()",
+            nodeType: .testCase,
+            result: .skipped,
+            children: [
+                makeNode(
+                    name: "iPhone 13",
+                    nodeType: .device,
+                    result: .skipped,
+                    children: [
+                        makeNode(
+                            name: "Test skipped - Not supported on CI",
+                            nodeType: .failureMessage
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        #expect(testCase.skipMessage == "Not supported on CI")
+    }
+
+    @Test
+    func argumentsInitPrefersOwnMessageOverTestCase() {
+        let failedArguments = makeNode(
+            name: "value: 42",
+            nodeType: .arguments,
+            result: .failed,
+            children: [
+                makeNode(
+                    name: "File.swift:12: failed - Argument-specific message",
+                    nodeType: .failureMessage
+                ),
+            ]
+        )
+
+        let testCase = makeNode(
+            name: "test_example(value:)",
+            nodeType: .testCase,
+            result: .failed,
+            children: [
+                makeNode(
+                    name: "File.swift:12: failed - Case-level message",
+                    nodeType: .failureMessage
+                ),
+                failedArguments,
+            ]
+        )
+
+        let test = Report.Module.Suite.RepeatableTest.Test(
+            from: failedArguments,
+            path: [],
+            testCase: testCase
+        )
+
+        #expect(test.failureMessage == "Argument-specific message")
+    }
+
+    // MARK: Private
+
+    private func makeNode(
+        name: String,
+        nodeType: TestResultsDTO.TestNode.NodeType,
+        result: TestResultsDTO.TestNode.Result? = nil,
+        children: [TestResultsDTO.TestNode]? = nil
+    )
+        -> TestResultsDTO.TestNode
+    {
+        TestResultsDTO.TestNode(
+            children: children,
+            durationInSeconds: nil,
+            name: name,
+            nodeIdentifierURL: nil,
+            nodeType: nodeType,
+            result: result
+        )
+    }
+}

--- a/Tests/PeekieTests/TestResultsDTOFailureMessageTests.swift
+++ b/Tests/PeekieTests/TestResultsDTOFailureMessageTests.swift
@@ -116,6 +116,32 @@ struct TestResultsDTOFailureMessageTests {
     }
 
     @Test
+    func dimensionNodesStayScopedToDirectChildren() {
+        // A device node must not surface a message owned by an arguments node
+        // beneath it — only test cases search through wrappers
+        let device = makeNode(
+            name: "iPhone 13",
+            nodeType: .device,
+            result: .failed,
+            children: [
+                makeNode(
+                    name: "value: 42",
+                    nodeType: .arguments,
+                    result: .failed,
+                    children: [
+                        makeNode(
+                            name: "File.swift:12: failed - Argument message",
+                            nodeType: .failureMessage
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        #expect(device.failureMessage == nil)
+    }
+
+    @Test
     func skipMessageThroughDeviceWrapper() {
         let testCase = makeNode(
             name: "test_example()",


### PR DESCRIPTION
## Summary

`xcresulttool merge` inserts a `Device` wrapper node (and an `Arguments` one for parameterized tests) between a test case and its `Failure Message` node:

```
unmerged:  Test Case → Failure Message
merged:    Test Case → Device → Failure Message
```

Message extraction only looked at direct children, so every Allure result exported from a **merged** bundle came out with `statusDetails: null`. Consumers that merge per-chunk bundles before converting (the common CI layout) lost the failure text: Allure TestOps shows such failed tests with no error banner on the Overview tab — the failure is only discoverable by digging into step attachments. Sonar's failure messages suffered the same way.

## Key Changes

- `TestResultsDTO.TestNode`: message lookup walks a `metadataSearchSpace`. For **test case** nodes it descends through structural wrapper nodes (`Device`/`Arguments`); dimension nodes (`Device`/`Arguments`/`Repetition`) stay scoped to their direct children — each owns its own messages, mirroring how `extractPaths`/`mergedTests(filterDevice:)` treat the device dimension.
- `Report.….Test` (Arguments initializer): prefers the argument node's own message over the test-case fallback, so each argument set keeps its specific message.

## Validation

- Reproduced on a production regress bundle: single-chunk conversion had `statusDetails.message`, the `xcresulttool merge`d equivalent lost it; with the fix the merged bundle yields the same message as the single chunk.
- New unit suite `TestResultsDTOFailureMessageTests` (7 tests): direct child (regression guard), through `Device`, through `Device → Arguments`, repetition non-leak, dimension-node scoping, skip message, argument-specific preference.
- Full test run green; existing snapshots unchanged.